### PR TITLE
Add session-scoped source changes

### DIFF
--- a/sandbox-image/Dockerfile
+++ b/sandbox-image/Dockerfile
@@ -98,7 +98,7 @@ RUN usermod -l user -d /home/user -m ubuntu 2>/dev/null \
 RUN git lfs install --system
 
 ENV NVM_DIR=/opt/nvm
-ENV NODE_VERSION=20.18.1
+ENV NODE_VERSION=22.13.1
 
 RUN mkdir -p "${NVM_DIR}" \
     && curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \

--- a/sandbox-image/Dockerfile.min
+++ b/sandbox-image/Dockerfile.min
@@ -22,7 +22,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 
-ARG NODE_MAJOR=20
+ARG NODE_MAJOR=22
 
 # A lean, wheels-friendly base: VCS, a system Python + venv/pip, fast search,
 # JSON, and the privilege-drop tools the entrypoint uses. No build toolchain —

--- a/src/main/process-manager.ts
+++ b/src/main/process-manager.ts
@@ -689,6 +689,18 @@ export class ProcessManager {
     return null;
   }
 
+  getProcessContainerId(processId: string): string | null {
+    const proc = this.processes.get(processId);
+    if (!proc) {
+      return null;
+    }
+    const status = proc.getStatus();
+    if ((status.type === 'running' || status.type === 'connecting') && status.data.containerId) {
+      return status.data.containerId;
+    }
+    return null;
+  }
+
   cleanup = async (): Promise<void> => {
     const exits = Array.from(this.processes.values()).map((p) => p.exit());
     await Promise.allSettled(exits);

--- a/src/main/project-handlers.test.ts
+++ b/src/main/project-handlers.test.ts
@@ -30,6 +30,8 @@ const EXPECTED_CHANNELS = [
   'project:read-artifact',
   'project:open-artifact-external',
   'project:get-files-changed',
+  'project:get-code-tab-files-changed',
+  'project:apply-code-tab-source-changes',
   'project:set-pr-review',
   'project:check-merge',
   'project:merge-ticket',
@@ -58,6 +60,8 @@ const makeManager = () => ({
   readArtifact: vi.fn(() => ({ relativePath: '', mimeType: '', textContent: null, size: 0 })),
   openArtifactExternal: vi.fn(),
   getFilesChanged: vi.fn(() => ({ totalFiles: 0, totalAdditions: 0, totalDeletions: 0, hasChanges: false, files: [] })),
+  getCodeTabFilesChanged: vi.fn(() => ({ totalFiles: 0, totalAdditions: 0, totalDeletions: 0, hasChanges: false, files: [] })),
+  applyCodeTabSourceChanges: vi.fn(async () => ({ ok: true, mergeCommitSha: 'apply' })),
   readContext: vi.fn(() => ''),
   writeContext: vi.fn(),
   listProjectFiles: vi.fn(() => []),
@@ -173,6 +177,22 @@ describe('registerProjectHandlers', () => {
     registerProjectHandlers(ipc, () => mgr as never);
     ipc.invoke('project:get-files-changed', 't1', 'src1');
     expect(mgr.getFilesChanged).toHaveBeenCalledWith('t1', 'src1');
+  });
+
+  it('project:get-code-tab-files-changed delegates with tabId + sourceId', () => {
+    const ipc = new StubIpc();
+    const mgr = makeManager();
+    registerProjectHandlers(ipc, () => mgr as never);
+    ipc.invoke('project:get-code-tab-files-changed', 'tab1', 'src1');
+    expect(mgr.getCodeTabFilesChanged).toHaveBeenCalledWith('tab1', 'src1');
+  });
+
+  it('project:apply-code-tab-source-changes delegates with tabId + sourceId', () => {
+    const ipc = new StubIpc();
+    const mgr = makeManager();
+    registerProjectHandlers(ipc, () => mgr as never);
+    ipc.invoke('project:apply-code-tab-source-changes', 'tab1', 'src1');
+    expect(mgr.applyCodeTabSourceChanges).toHaveBeenCalledWith('tab1', 'src1');
   });
 
   it('project:set-pr-review delegates with ticketId + sourceId + review status', () => {

--- a/src/main/project-handlers.ts
+++ b/src/main/project-handlers.ts
@@ -47,6 +47,8 @@ export function registerProjectHandlers(ipc: IIpcListener, resolve: (event: unkn
   h('project:read-artifact', (pm, ticketId, relativePath) => pm.readArtifact(ticketId, relativePath));
   h('project:open-artifact-external', (pm, ticketId, relativePath) => pm.openArtifactExternal(ticketId, relativePath));
   h('project:get-files-changed', (pm, ticketId, sourceId) => pm.getFilesChanged(ticketId, sourceId));
+  h('project:get-code-tab-files-changed', (pm, tabId, sourceId) => pm.getCodeTabFilesChanged(tabId, sourceId));
+  h('project:apply-code-tab-source-changes', (pm, tabId, sourceId) => pm.applyCodeTabSourceChanges(tabId, sourceId));
 
   // Local PR flow (per-source — sourceId is one of the project's ProjectSource ids)
   h('project:set-pr-review', (pm, ticketId, sourceId, review) => pm.setPrReview(ticketId, sourceId, review));

--- a/src/main/project-manager.ts
+++ b/src/main/project-manager.ts
@@ -58,6 +58,7 @@ import { DEFAULT_PIPELINE, SIMPLE_PIPELINE } from '@/shared/pipeline-defaults';
 import type {
   ArtifactFileContent,
   ArtifactFileEntry,
+  CodeTabId,
   ColumnId,
   DiffResponse,
   InboxItem,
@@ -1411,6 +1412,70 @@ export class ProjectManager {
 
     const mergeBase = await resolveTicketDiffBase(gitDir, preferredBase);
     return getGitFilesChanged({ gitDir, mergeBase });
+  };
+
+  getCodeTabFilesChanged = async (tabId: CodeTabId, sourceId: string): Promise<DiffResponse> => {
+    const empty: DiffResponse = { totalFiles: 0, totalAdditions: 0, totalDeletions: 0, hasChanges: false, files: [] };
+    const tab = ((this.store.get('codeTabs') ?? []) as Array<{
+      id: string;
+      projectId: ProjectId | null;
+      workspaceDir?: string;
+    }>).find((t) => t.id === tabId);
+    if (!tab) {
+      return empty;
+    }
+
+    const project = tab.projectId ? this.getProjects().find((p) => p.id === tab.projectId) : undefined;
+    const source = project?.sources.find((s) => s.id === sourceId);
+    if (source) {
+      const containerId = this.processManager?.getProcessContainerId(tabId) ?? null;
+      if (containerId) {
+        return getContainerFilesChanged({ containerId, mountName: source.mountName });
+      }
+      if (source.kind === 'local') {
+        return getGitFilesChanged({ gitDir: source.workspaceDir, mergeBase: 'HEAD' }).catch(() => empty);
+      }
+    }
+
+    if (!project && tab.workspaceDir && sourceId === tab.workspaceDir) {
+      return getGitFilesChanged({ gitDir: tab.workspaceDir, mergeBase: 'HEAD' }).catch(() => empty);
+    }
+
+    return empty;
+  };
+
+  applyCodeTabSourceChanges = async (tabId: CodeTabId, sourceId: string): Promise<PrMergeResult> => {
+    const tab = ((this.store.get('codeTabs') ?? []) as Array<{
+      id: string;
+      projectId: ProjectId | null;
+    }>).find((t) => t.id === tabId);
+    if (!tab?.projectId) {
+      return { ok: false, error: 'Code tab is not attached to a project' };
+    }
+    const project = this.getProjects().find((p) => p.id === tab.projectId);
+    if (!project) {
+      return { ok: false, error: 'Project not found' };
+    }
+    const source = project.sources.find((s) => s.id === sourceId);
+    if (!source) {
+      return { ok: false, error: `Source not found: ${sourceId}` };
+    }
+    if (source.kind !== 'local') {
+      return { ok: false, error: 'Applying changes to host is only supported for local sources' };
+    }
+    const containerId = this.processManager?.getProcessContainerId(tabId) ?? null;
+    if (!containerId) {
+      return { ok: false, error: 'No running sandbox for this code tab' };
+    }
+    const patch = await buildContainerSeedPatch(containerId, source.mountName);
+    if (!patch.trim()) {
+      return { ok: false, error: 'No changes to apply' };
+    }
+    const applied = await gitApplyStdin(source.workspaceDir, ['--whitespace=nowarn'], patch);
+    if (!applied.ok) {
+      return { ok: false, error: `git apply failed: ${applied.stderr}` };
+    }
+    return { ok: true, mergeCommitSha: 'apply' };
   };
 
   // #endregion

--- a/src/renderer/features/Code/CodeDeck.tsx
+++ b/src/renderer/features/Code/CodeDeck.tsx
@@ -824,11 +824,11 @@ const CodeSessionHeader = memo(
                 </MenuTrigger>
                 <MenuPopover>
                   <MenuList>
-                    {ticketId && onOpenPanel && (
+                    {onOpenPanel && (
                       <>
-                        <MenuItem onClick={() => onOpenPanel('overview')}>Overview</MenuItem>
-                        <MenuItem onClick={() => onOpenPanel('pr')}>PR</MenuItem>
-                        <MenuItem onClick={() => onOpenPanel('artifacts')}>Artifacts</MenuItem>
+                        {ticketId && <MenuItem onClick={() => onOpenPanel('overview')}>Overview</MenuItem>}
+                        <MenuItem onClick={() => onOpenPanel('pr')}>Changes</MenuItem>
+                        {ticketId && <MenuItem onClick={() => onOpenPanel('artifacts')}>Artifacts</MenuItem>}
                         <MenuDivider />
                       </>
                     )}
@@ -952,7 +952,7 @@ const DeckColumn = memo(
             }
             onClose={() => onClose(tab.id)}
             ticketId={tab.ticketId as TicketId | undefined}
-            onOpenPanel={tab.ticketId ? setActivePanel : undefined}
+            onOpenPanel={tab.ticketId || tab.projectId ? setActivePanel : undefined}
             dragSurfaceProps={listeners}
             dragHandle={
               <button
@@ -968,8 +968,8 @@ const DeckColumn = memo(
           />
           <div className={styles.flex1MinH0Relative}>
             {children}
-            {tab.ticketId && (
-              <TicketPanelOverlay panel={activePanel} ticketId={tab.ticketId as TicketId} onClose={handleClosePanel} />
+            {(tab.ticketId || tab.projectId) && (
+              <TicketPanelOverlay panel={activePanel} ticketId={tab.ticketId as TicketId | undefined} tabId={tab.id} onClose={handleClosePanel} />
             )}
           </div>
         </div>
@@ -1614,7 +1614,7 @@ const CodeSessionPane = memo(
           actions={actions}
           onClose={() => onClose(tab.id)}
           ticketId={tab.ticketId as TicketId | undefined}
-          onOpenPanel={tab.ticketId ? setActivePanel : undefined}
+          onOpenPanel={tab.ticketId || tab.projectId ? setActivePanel : undefined}
           isGlass={isGlass}
         />
         <div className={styles.flex1MinH0Relative}>
@@ -1630,8 +1630,8 @@ const CodeSessionPane = memo(
             onPreviewUrlChange={onPreviewUrlChange}
             isGlass={isGlass}
           />
-          {tab.ticketId && (
-            <TicketPanelOverlay panel={activePanel} ticketId={tab.ticketId as TicketId} onClose={handleClosePanel} />
+          {(tab.ticketId || tab.projectId) && (
+            <TicketPanelOverlay panel={activePanel} ticketId={tab.ticketId as TicketId | undefined} tabId={tab.id} onClose={handleClosePanel} />
           )}
         </div>
       </div>

--- a/src/renderer/features/Tickets/TicketPRTab.tsx
+++ b/src/renderer/features/Tickets/TicketPRTab.tsx
@@ -4,9 +4,9 @@ import { useStore } from '@nanostores/react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { SelectTabData } from '@/renderer/ds';
-import { IconButton, ListSkeleton, Tab, TabList } from '@/renderer/ds';
+import { Button, IconButton, ListSkeleton, Tab, TabList } from '@/renderer/ds';
 import { persistedStoreApi } from '@/renderer/services/store';
-import type { DiffGroup,DiffResponse, FileDiff, TicketId } from '@/shared/types';
+import type { CodeTabId, DiffGroup,DiffResponse, FileDiff, ProjectSource, TicketId } from '@/shared/types';
 
 import { $tickets, ticketApi } from './state';
 import { TicketPROverview } from './TicketPROverview';
@@ -457,7 +457,7 @@ FileListItem.displayName = 'FileListItem';
  * (FilesChangedPane) picks which source is active.
  */
 const FilesChangedContent = memo(
-  ({ ticketId, sourceId }: { ticketId: TicketId; sourceId: string }) => {
+  ({ scope, sourceId }: { scope: ChangesScope; sourceId: string }) => {
   const styles = useStyles();
   const [data, setData] = useState<DiffResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -466,6 +466,8 @@ const FilesChangedContent = memo(
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [listWidthPercent, setListWidthPercent] = useState(DEFAULT_LIST_PERCENT);
   const [isDragging, setIsDragging] = useState(false);
+  const [applyBusy, setApplyBusy] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
   const splitRef = useRef<HTMLDivElement>(null);
 
   // Reset file selection when the active source switches.
@@ -477,7 +479,9 @@ const FilesChangedContent = memo(
 
   const fetchData = useCallback(async () => {
     try {
-      const resp = await ticketApi.getFilesChanged(ticketId, sourceId);
+      const resp = scope.kind === 'ticket'
+        ? await ticketApi.getFilesChanged(scope.ticketId, sourceId)
+        : await ticketApi.getCodeTabFilesChanged(scope.tabId, sourceId);
       setData(resp);
       if (resp.files.length > 0 && !selectedKey) {
         setSelectedKey(fileKey(resp.files[0]!));
@@ -487,7 +491,7 @@ const FilesChangedContent = memo(
     } finally {
       setLoading(false);
     }
-  }, [ticketId, sourceId, selectedKey]);
+  }, [scope, sourceId, selectedKey]);
 
   // Fetch on mount + poll
   useEffect(() => {
@@ -499,6 +503,22 @@ const FilesChangedContent = memo(
   const handleRefresh = useCallback(() => {
     void fetchData();
   }, [fetchData]);
+
+  const handleApply = useCallback(async () => {
+    if (scope.kind !== 'code-tab') return;
+    setApplyBusy(true);
+    setApplyError(null);
+    try {
+      const result = await ticketApi.applyCodeTabSourceChanges(scope.tabId, sourceId);
+      if (!result.ok) {
+        setApplyError(result.error);
+        return;
+      }
+      await fetchData();
+    } finally {
+      setApplyBusy(false);
+    }
+  }, [fetchData, scope, sourceId]);
 
   const handleSelectFile = useCallback((key: string) => {
     setSelectedKey(key);
@@ -556,6 +576,12 @@ const FilesChangedContent = memo(
         {data.totalAdditions > 0 && <span className={styles.greenText}>+{data.totalAdditions}</span>}
         {data.totalDeletions > 0 && <span className={styles.redText}>-{data.totalDeletions}</span>}
         <div className={styles.flex1} />
+        {applyError && <span className={styles.emptySubText}>{applyError}</span>}
+        {scope.kind === 'code-tab' && (
+          <Button size="sm" onClick={handleApply} isDisabled={applyBusy}>
+            {applyBusy ? 'Applying…' : 'Apply to host'}
+          </Button>
+        )}
         <IconButton aria-label="Refresh" icon={<ArrowSync20Regular />} size="sm" onClick={handleRefresh} />
       </div>
 
@@ -627,21 +653,32 @@ const FilesChangedContent = memo(
 });
 FilesChangedContent.displayName = 'FilesChangedContent';
 
+type ChangesScope = { kind: 'ticket'; ticketId: TicketId } | { kind: 'code-tab'; tabId: CodeTabId };
+
+const useSourcesForChanges = (scope: ChangesScope): ProjectSource[] => {
+  const tickets = useStore($tickets);
+  const store = useStore(persistedStoreApi.$atom);
+  return useMemo(() => {
+    if (scope.kind === 'ticket') {
+      const ticket = tickets[scope.ticketId];
+      if (!ticket) return [];
+      const project = store.projects.find((p) => p.id === ticket.projectId);
+      return project?.sources ?? [];
+    }
+    const tab = store.codeTabs.find((t) => t.id === scope.tabId);
+    const project = tab?.projectId ? store.projects.find((p) => p.id === tab.projectId) : undefined;
+    return project?.sources ?? [];
+  }, [scope, store.codeTabs, store.projects, tickets]);
+};
+
 /**
  * Source-picker shell for the Files Changed sub-tab. Renders one
  * TabList row across project.sources and shows the active source's
  * file-diff pane below. Single-source projects skip the picker.
  */
-const FilesChangedPane = memo(({ ticketId }: { ticketId: TicketId }) => {
+const FilesChangedPane = memo(({ scope }: { scope: ChangesScope }) => {
   const styles = useStyles();
-  const tickets = useStore($tickets);
-  const store = useStore(persistedStoreApi.$atom);
-  const sources = useMemo(() => {
-    const ticket = tickets[ticketId];
-    if (!ticket) return [];
-    const project = store.projects.find((p) => p.id === ticket.projectId);
-    return project?.sources ?? [];
-  }, [tickets, store.projects, ticketId]);
+  const sources = useSourcesForChanges(scope);
 
   const [activeSourceId, setActiveSourceId] = useState<string | null>(null);
   // Track the previous sources signature so we can reset the active id
@@ -684,7 +721,7 @@ const FilesChangedPane = memo(({ ticketId }: { ticketId: TicketId }) => {
         </div>
       )}
       <div className={styles.tabContent}>
-        <FilesChangedContent ticketId={ticketId} sourceId={activeSourceId} />
+        <FilesChangedContent scope={scope} sourceId={activeSourceId} />
       </div>
     </div>
   );
@@ -716,9 +753,14 @@ export const TicketPRTab = memo(({ ticketId }: { ticketId: TicketId }) => {
       {/* Sub-tab content */}
       <div className={styles.tabContent}>
         {activeSubTab === 'Overview' && <TicketPROverview ticketId={ticketId} />}
-        {activeSubTab === 'Files Changed' && <FilesChangedPane ticketId={ticketId} />}
+        {activeSubTab === 'Files Changed' && <FilesChangedPane scope={{ kind: 'ticket', ticketId }} />}
       </div>
     </div>
   );
 });
 TicketPRTab.displayName = 'TicketPRTab';
+
+export const ChangesTab = memo(({ tabId }: { tabId: CodeTabId }) => (
+  <FilesChangedPane scope={{ kind: 'code-tab', tabId }} />
+));
+ChangesTab.displayName = 'ChangesTab';

--- a/src/renderer/features/Tickets/TicketPanelOverlay.tsx
+++ b/src/renderer/features/Tickets/TicketPanelOverlay.tsx
@@ -4,18 +4,18 @@ import { useStore } from '@nanostores/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { memo } from 'react';
 
-import type { TicketId } from '@/shared/types';
+import type { CodeTabId, TicketId } from '@/shared/types';
 
 import { $tickets } from './state';
 import { TicketArtifactsTab } from './TicketArtifactsTab';
 import { TicketOverviewTab } from './TicketOverviewTab';
-import { TicketPRTab } from './TicketPRTab';
+import { ChangesTab, TicketPRTab } from './TicketPRTab';
 
 export type TicketPanel = 'overview' | 'pr' | 'artifacts';
 
 const PANEL_META: Record<TicketPanel, { label: string; icon: typeof Info20Regular }> = {
   overview: { label: 'Overview', icon: Info20Regular },
-  pr: { label: 'PR', icon: BranchRequest20Regular },
+  pr: { label: 'Changes', icon: BranchRequest20Regular },
   artifacts: { label: 'Artifacts', icon: DocumentMultiple20Regular },
 };
 
@@ -90,10 +90,10 @@ const useStyles = makeStyles({
   },
 });
 
-const PanelContent = memo(({ panel, ticketId }: { panel: TicketPanel; ticketId: TicketId }) => {
+const PanelContent = memo(({ panel, ticketId, tabId }: { panel: TicketPanel; ticketId?: TicketId; tabId: CodeTabId }) => {
   const styles = useStyles();
   const tickets = useStore($tickets);
-  const ticket = tickets[ticketId];
+  const ticket = ticketId ? tickets[ticketId] : undefined;
 
   if (panel === 'overview') {
     if (!ticket) {
@@ -106,14 +106,14 @@ return null;
     );
   }
   if (panel === 'pr') {
-    return <TicketPRTab ticketId={ticketId} />;
+    return ticketId ? <TicketPRTab ticketId={ticketId} /> : <ChangesTab tabId={tabId} />;
   }
-  return <TicketArtifactsTab ticketId={ticketId} />;
+  return ticketId ? <TicketArtifactsTab ticketId={ticketId} /> : null;
 });
 PanelContent.displayName = 'PanelContent';
 
 export const TicketPanelOverlay = memo(
-  ({ panel, ticketId, onClose }: { panel: TicketPanel | null; ticketId: TicketId; onClose: () => void }) => {
+  ({ panel, ticketId, tabId, onClose }: { panel: TicketPanel | null; ticketId?: TicketId; tabId: CodeTabId; onClose: () => void }) => {
     const styles = useStyles();
     return (
       <AnimatePresence>
@@ -155,7 +155,7 @@ export const TicketPanelOverlay = memo(
                   </button>
                 </div>
                 <div className={styles.panelBody}>
-                  <PanelContent panel={panel} ticketId={ticketId} />
+                  <PanelContent panel={panel} ticketId={ticketId} tabId={tabId} />
                 </div>
               </div>
             </motion.div>

--- a/src/renderer/features/Tickets/state.ts
+++ b/src/renderer/features/Tickets/state.ts
@@ -396,6 +396,12 @@ export const ticketApi = {
   getFilesChanged: (ticketId: TicketId, sourceId: string): Promise<DiffResponse> => {
     return emitter.invoke('project:get-files-changed', ticketId, sourceId);
   },
+  getCodeTabFilesChanged: (tabId: string, sourceId: string): Promise<DiffResponse> => {
+    return emitter.invoke('project:get-code-tab-files-changed', tabId, sourceId);
+  },
+  applyCodeTabSourceChanges: (tabId: string, sourceId: string): Promise<import('@/shared/types').PrMergeResult> => {
+    return emitter.invoke('project:apply-code-tab-source-changes', tabId, sourceId);
+  },
 
   // Context files (replaces project.brief)
   readContext: (projectId: ProjectId): Promise<string> => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2349,6 +2349,8 @@ type ProjectIpcEvents = Namespaced<
      * iterates ``project.sources`` and calls this per source.
      */
     'get-files-changed': (ticketId: TicketId, sourceId: string) => DiffResponse;
+    'get-code-tab-files-changed': (tabId: CodeTabId, sourceId: string) => DiffResponse;
+    'apply-code-tab-source-changes': (tabId: CodeTabId, sourceId: string) => PrMergeResult;
     // Supervisor operations
     'ensure-supervisor-infra': (ticketId: TicketId) => void;
     'start-supervisor': (ticketId: TicketId) => void;


### PR DESCRIPTION
## Summary
- Adds code-tab scoped Changes APIs so project-backed sessions can review diffs without requiring a ticket.
- Reuses the existing file-diff UI for ticket PRs and standalone session Changes.
- Adds an explicit Apply to host action for local source changes from running sandboxes.
- Updates sandbox images to Node 22 to match the launcher engine requirement.

## Validation
- `git diff --check`
- `npx tsc --noEmit` attempted; repo currently has unrelated pre-existing TypeScript errors outside this change.
- `npx vitest run src/main/project-handlers.test.ts` attempted; blocked by current Vite/Vitest ESM config startup error.
