### PR TITLE
Fix project page hydration and sidebar visibility

### DIFF
--- a/src/renderer/features/Pages/state.test.ts
+++ b/src/renderer/features/Pages/state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { atom } from 'nanostores';
+
+import type { Page, StoreData } from '@/shared/types';
+
+vi.mock('@/renderer/services/ipc', () => ({
+  emitter: { invoke: vi.fn() },
+  ipc: { on: vi.fn() },
+}));
+
+vi.mock('@/renderer/services/store', () => ({
+  persistedStoreApi: { $atom: atom({ pages: [] } as unknown as StoreData) },
+}));
+
+import { pagesRecordFromStorePages } from './state';
+
+const makePage = (id: string, projectId: string, parentId: string | null, title: string): Page => ({
+  id,
+  projectId,
+  parentId,
+  title,
+  icon: undefined,
+  sortOrder: 0,
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+describe('pages state', () => {
+  it('maps store snapshot pages by id', () => {
+    const page = makePage('pg_1', 'proj_1', null, 'Documentation Index');
+
+    expect(pagesRecordFromStorePages([page])).toEqual({ pg_1: page });
+  });
+
+  it('preserves updated titles, icons, and parent relationships from snapshots', () => {
+    const original = makePage('pg_1', 'proj_1', null, 'Documentation Index');
+    const updated = { ...original, title: 'GA User Stories', icon: '🧩', updatedAt: 2 };
+
+    expect(pagesRecordFromStorePages([updated])).toEqual({ pg_1: updated });
+  });
+});

--- a/src/renderer/features/Pages/state.ts
+++ b/src/renderer/features/Pages/state.ts
@@ -1,13 +1,30 @@
+import { objectEquals } from '@observ33r/object-equals';
 import { map } from 'nanostores';
 
 import type { TemplateKey } from '@/lib/page-templates';
 import { emitter, ipc } from '@/renderer/services/ipc';
+import { persistedStoreApi } from '@/renderer/services/store';
 import type { Page, PageId, ProjectId } from '@/shared/types';
 
 /**
  * All pages for the currently viewed project, keyed by page ID.
  */
 export const $pages = map<Record<PageId, Page>>({});
+
+export const pagesRecordFromStorePages = (pages: readonly Page[] | undefined): Record<PageId, Page> => {
+  const next: Record<PageId, Page> = {};
+  for (const page of pages ?? []) {
+    next[page.id] = page;
+  }
+  return next;
+};
+
+persistedStoreApi.$atom.subscribe((store) => {
+  const next = pagesRecordFromStorePages(store.pages);
+  if (!objectEquals($pages.get(), next)) {
+    $pages.set(next);
+  }
+});
 
 export const pageApi = {
   fetchPages: async (projectId: ProjectId): Promise<void> => {
@@ -19,8 +36,8 @@ export const pageApi = {
     const next: Record<PageId, Page> = {};
     for (const [id, page] of Object.entries(current)) {
       if (page.projectId !== projectId) {
-next[id] = page;
-}
+        next[id] = page;
+      }
     }
     for (const item of items) {
       next[item.id] = item;
@@ -104,16 +121,16 @@ next[id] = page;
   onExternalChange: (pageId: PageId, handler: (content: string) => void): (() => void) => {
     return ipc.on('page:content-changed', (id, content) => {
       if (id === pageId) {
-handler(content);
-}
+        handler(content);
+      }
     });
   },
 
   onExternalDelete: (pageId: PageId, handler: () => void): (() => void) => {
     return ipc.on('page:content-deleted', (id) => {
       if (id === pageId) {
-handler();
-}
+        handler();
+      }
     });
   },
 };

--- a/src/renderer/features/Tickets/SidebarTree.test.ts
+++ b/src/renderer/features/Tickets/SidebarTree.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Page } from '@/shared/types';
+
+import { getProjectRootLevelPages } from './sidebar-tree-model';
+
+const makePage = (input: Partial<Page> & Pick<Page, 'id' | 'projectId' | 'parentId' | 'title'>): Page => ({
+  icon: undefined,
+  sortOrder: 0,
+  createdAt: 1,
+  updatedAt: 1,
+  ...input,
+});
+
+describe('getProjectRootLevelPages', () => {
+  it('includes tool-created root-level pages and UI-created root children', () => {
+    const root = makePage({ id: 'pg_root', projectId: 'proj_1', parentId: null, title: 'Project Brief', isRoot: true });
+    const toolPage = makePage({ id: 'pg_tool', projectId: 'proj_1', parentId: null, title: 'GA Release Brief' });
+    const uiPage = makePage({ id: 'pg_ui', projectId: 'proj_1', parentId: root.id, title: 'Documentation Index' });
+    const child = makePage({ id: 'pg_child', projectId: 'proj_1', parentId: toolPage.id, title: 'GA User Stories' });
+    const other = makePage({ id: 'pg_other', projectId: 'proj_2', parentId: null, title: 'Other Project' });
+
+    expect(
+      getProjectRootLevelPages(
+        { pg_root: root, pg_tool: toolPage, pg_ui: uiPage, pg_child: child, pg_other: other },
+        'proj_1'
+      )
+    ).toEqual([toolPage, uiPage]);
+  });
+});

--- a/src/renderer/features/Tickets/SidebarTree.tsx
+++ b/src/renderer/features/Tickets/SidebarTree.tsx
@@ -47,6 +47,7 @@ import { openTicketInCode } from '@/renderer/services/navigation';
 import { isActivePhase } from '@/shared/ticket-phase';
 import type { Milestone, Page, PageId, Project, ProjectId, Ticket } from '@/shared/types';
 
+import { getProjectRootLevelPages } from './sidebar-tree-model';
 import { ticketApi } from './state';
 
 const useStyles = makeStyles({
@@ -742,8 +743,7 @@ export const SidebarTree = memo(
           }
         }
 
-        const rootPage = Object.values(pages).find((p) => p.projectId === project.id && p.isRoot);
-        const rootPages = rootPage ? getChildPages(pages, rootPage.id) : [];
+        const rootPages = getProjectRootLevelPages(pages, project.id);
 
         result[project.id] = {
           milestones: projectMilestones,

--- a/src/renderer/features/Tickets/sidebar-tree-model.ts
+++ b/src/renderer/features/Tickets/sidebar-tree-model.ts
@@ -1,0 +1,12 @@
+import type { Page, ProjectId } from '@/shared/types';
+
+export function getProjectRootLevelPages(pages: Record<string, Page>, projectId: ProjectId): Page[] {
+  const rootPage = Object.values(pages).find((page) => page.projectId === projectId && page.isRoot);
+  const rootParentId = rootPage?.id;
+  return Object.values(pages)
+    .filter(
+      (page) =>
+        page.projectId === projectId && !page.isRoot && (page.parentId === null || page.parentId === rootParentId)
+    )
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+}

--- a/src/server/managers.ts
+++ b/src/server/managers.ts
@@ -716,10 +716,10 @@ export const wireGlobalHandlers = async (arg: {
    * tenant-scoped PgProjectsRepo (RLS isolates it). SQLite: the single shared
    * repo (one tenant only). Writes flow through this repo, so the LISTEN/NOTIFY
    * (Postgres) and change-watcher (SQLite) layers keep ProjectManager caches
-   * coherent automatically — the same path used by the launcher's own writes.
+   * coherent automatically.
    */
   const getTenantRepo = (tenantId: string): IProjectsRepo =>
-    pgPool ? new PgProjectsRepo(pgPool, tenantId, replicaId) : asyncRepo;
+    pgPool ? new PgProjectsRepo(pgPool, tenantId) : asyncRepo;
 
   /** Profile claims pulled from EasyAuth headers for the users table. */
   type PrincipalClaims = { email?: string | null; displayName?: string | null; idp?: string | null };


### PR DESCRIPTION
## Summary
- Hydrates the renderer page store from every `store:changed` snapshot so project pages created or updated outside the current view appear after create/update, refresh, and restart.
- Renders both tool-created root-level pages (`parentId: null`) and UI-created pages under the project root page in the sidebar Pages branch.
- Ensures Postgres-backed HTTP MCP page writes are treated as external writes by the server listener, so the ProjectManager cache re-hydrates and broadcasts fresh page rows.
- Adds targeted tests for page snapshot mapping and root-level page navigation filtering.

## Test plan
- `npx vitest run src/renderer/features/Pages/state.test.ts src/renderer/features/Tickets/SidebarTree.test.ts`
- Electron/CDP proof captured at `/workspace/.omni-artifacts/tkt_S8_MeMTUbIrt/screenshots/electron-cdp-final-pages-and-child-proof.png`
- `npx tsc --noEmit --pretty false` (currently fails on pre-existing unrelated repository type errors; targeted Vitest reports no touched-file type errors)
