### PR TITLE
Let ticket autopilot choose sandbox profile

### DIFF
--- a/src/lib/supervisor-orchestrator.test.ts
+++ b/src/lib/supervisor-orchestrator.test.ts
@@ -543,6 +543,17 @@ describe('SupervisorOrchestrator integration', () => {
         expect.objectContaining({ ticketId: 't1' })
       );
     });
+
+    it('forwards a one-off profile to the bridge', async () => {
+      const ctx = makePm({
+        source: { kind: 'local', workspaceDir: '/tmp/fake' },
+        tickets: [{ id: 't1' }],
+      });
+      await orch(ctx.pm).ensureColumn('t1' as TicketId, 'aci-desktop');
+      expect(ctx.bridge.ensureColumn).toHaveBeenCalledWith(
+        expect.objectContaining({ ticketId: 't1', profileName: 'aci-desktop' })
+      );
+    });
   });
 
   describe('startSupervisor', () => {
@@ -564,6 +575,19 @@ describe('SupervisorOrchestrator integration', () => {
             safeToolOverrides: { safe_tool_patterns: ['.*'] },
           }),
         })
+      );
+    });
+
+    it('passes the selected profile into code tab setup before starting', async () => {
+      const ctx = makePm({
+        source: { kind: 'local', workspaceDir: '/tmp/fake' },
+        tickets: [{ id: 't1' }],
+      });
+
+      await orch(ctx.pm).startSupervisor('t1' as TicketId, 'local:machine-1');
+
+      expect(ctx.bridge.ensureColumn).toHaveBeenCalledWith(
+        expect.objectContaining({ ticketId: 't1', profileName: 'local:machine-1' })
       );
     });
   });

--- a/src/main/supervisor-bridge.ts
+++ b/src/main/supervisor-bridge.ts
@@ -90,7 +90,7 @@ export class SupervisorBridge {
     });
   }
 
-  ensureColumn(arg: { ticketId: TicketId; workspaceDir?: string }): Promise<void> {
+  ensureColumn(arg: { ticketId: TicketId; workspaceDir?: string; profileName?: string }): Promise<void> {
     return this.dispatch({ kind: 'ensure-column', ...arg }).then(() => {});
   }
 

--- a/src/main/supervisor-handlers.test.ts
+++ b/src/main/supervisor-handlers.test.ts
@@ -56,7 +56,15 @@ describe('registerSupervisorHandlers', () => {
     const orch = makeOrchestrator();
     registerSupervisorHandlers(ipc, () => orch as never);
     ipc.invoke('project:start-supervisor', 't1');
-    expect(orch.startSupervisor).toHaveBeenCalledWith('t1');
+    expect(orch.startSupervisor).toHaveBeenCalledWith('t1', undefined);
+  });
+
+  it('project:start-supervisor delegates with selected profile', () => {
+    const ipc = new StubIpc();
+    const orch = makeOrchestrator();
+    registerSupervisorHandlers(ipc, () => orch as never);
+    ipc.invoke('project:start-supervisor', 't1', 'aci-desktop');
+    expect(orch.startSupervisor).toHaveBeenCalledWith('t1', 'aci-desktop');
   });
 
   it('project:stop-supervisor delegates with ticketId', () => {

--- a/src/main/supervisor-handlers.ts
+++ b/src/main/supervisor-handlers.ts
@@ -21,7 +21,7 @@ export function registerSupervisorHandlers(
   };
 
   h('project:ensure-supervisor-infra', (s, ticketId) => s.ensureSupervisorInfraLocked(ticketId));
-  h('project:start-supervisor', (s, ticketId) => s.startSupervisor(ticketId));
+  h('project:start-supervisor', (s, ticketId, profileName) => s.startSupervisor(ticketId, profileName));
   h('project:stop-supervisor', (s, ticketId) => s.stopSupervisor(ticketId));
   h('project:send-supervisor-message', (s, ticketId, message) => s.sendSupervisorMessage(ticketId, message));
   h('project:reset-supervisor-session', (s, ticketId) => s.resetSupervisorSession(ticketId));

--- a/src/main/supervisor-orchestrator.ts
+++ b/src/main/supervisor-orchestrator.ts
@@ -724,7 +724,7 @@ export class SupervisorOrchestrator {
    *
    * Idempotent.
    */
-  ensureColumn = async (ticketId: TicketId): Promise<SupervisorEntry> => {
+  ensureColumn = async (ticketId: TicketId, profileName?: string): Promise<SupervisorEntry> => {
     const ticket = this.deps.host.getTicketById(ticketId);
     if (!ticket) {
       throw new Error(`Ticket not found: ${ticketId}`);
@@ -755,7 +755,7 @@ export class SupervisorOrchestrator {
     }
 
     try {
-      await this.deps.bridge.ensureColumn({ ticketId, workspaceDir });
+      await this.deps.bridge.ensureColumn({ ticketId, workspaceDir, profileName });
     } catch (err) {
       state.forcePhase('error' as TicketPhase);
       throw err;
@@ -856,7 +856,7 @@ export class SupervisorOrchestrator {
    * submits the initial run prompt through the same `handleSubmit` path the
    * user's keyboard uses.
    */
-  startSupervisor = (ticketId: TicketId): Promise<void> => {
+  startSupervisor = (ticketId: TicketId, profileName?: string): Promise<void> => {
     return this.withTicketLock(ticketId, async () => {
       const preflightError = this.validateDispatchPreflight(ticketId);
       if (preflightError) {
@@ -885,7 +885,7 @@ export class SupervisorOrchestrator {
       }
 
       console.log(`[SupervisorOrchestrator] startSupervisor: ensureColumn for ${ticketId}...`);
-      const entry = await this.ensureColumn(ticketId);
+      const entry = await this.ensureColumn(ticketId, profileName);
 
       const phase = entry.state.getPhase();
       if (phase === 'idle' || phase === 'error' || phase === 'completed') {

--- a/src/renderer/features/Code/state.ts
+++ b/src/renderer/features/Code/state.ts
@@ -127,17 +127,25 @@ export const codeApi = {
   addTabForTicket: async (
     ticketId: TicketId,
     projectId: ProjectId,
-    opts?: { ticketTitle?: string; workspaceDir?: string }
+    opts?: { ticketTitle?: string; workspaceDir?: string; profileName?: string }
   ): Promise<CodeTab> => {
     const existingTabs = persistedStoreApi.getKey('codeTabs') ?? [];
     const existing = existingTabs.find((t) => t.ticketId === ticketId);
     if (existing) {
-      if (opts?.workspaceDir && existing.workspaceDir !== opts.workspaceDir) {
-        const updated = existingTabs.map((t) => (t.id === existing.id ? { ...t, workspaceDir: opts.workspaceDir } : t));
+      const { containerId: _drop, ...existingWithoutContainer } = existing;
+      void _drop;
+      const baseExisting = opts?.profileName ? existingWithoutContainer : existing;
+      const nextExisting = {
+        ...baseExisting,
+        ...(opts?.workspaceDir ? { workspaceDir: opts.workspaceDir } : {}),
+        ...(opts?.profileName ? { profileName: opts.profileName } : {}),
+      };
+      if (nextExisting.workspaceDir !== existing.workspaceDir || nextExisting.profileName !== existing.profileName) {
+        const updated = existingTabs.map((t) => (t.id === existing.id ? nextExisting : t));
         await persistedStoreApi.setKey('codeTabs', updated);
       }
       await persistedStoreApi.setKey('activeCodeTabId', existing.id);
-      return { ...existing, ...(opts?.workspaceDir ? { workspaceDir: opts.workspaceDir } : {}) };
+      return nextExisting;
     }
     const tab: CodeTab = {
       id: nanoid(),
@@ -146,7 +154,7 @@ export const codeApi = {
       sessionId: uuidv4(),
       ticketTitle: opts?.ticketTitle,
       workspaceDir: opts?.workspaceDir,
-      profileName: seedProfileName(projectId),
+      profileName: opts?.profileName ?? seedProfileName(projectId),
       createdAt: Date.now(),
     };
     const tabs = [...existingTabs, tab];

--- a/src/renderer/features/Tickets/KanbanCard.tsx
+++ b/src/renderer/features/Tickets/KanbanCard.tsx
@@ -119,7 +119,7 @@ export const KanbanCard = memo(
     const handleStart = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
-        ticketApi.startSupervisor(ticket.id);
+        ticketApi.requestStartSupervisor(ticket.id);
       },
       [ticket.id]
     );

--- a/src/renderer/features/Tickets/ProjectsDashboard.tsx
+++ b/src/renderer/features/Tickets/ProjectsDashboard.tsx
@@ -499,7 +499,7 @@ const MilestoneCard = memo(
 
     const handleStart = useCallback(() => {
       if (nextUp) {
-        void ticketApi.startSupervisor(nextUp.id);
+        ticketApi.requestStartSupervisor(nextUp.id);
       }
     }, [nextUp]);
 
@@ -601,7 +601,7 @@ const ProjectCard = memo(
 
     const handleStart = useCallback(() => {
       if (nextUp) {
-        void ticketApi.startSupervisor(nextUp.id);
+        ticketApi.requestStartSupervisor(nextUp.id);
       }
     }, [nextUp]);
 

--- a/src/renderer/features/Tickets/SidebarTree.tsx
+++ b/src/renderer/features/Tickets/SidebarTree.tsx
@@ -579,7 +579,7 @@ const TicketTreeItem = memo(
                 <MenuItem
                   icon={<Play20Filled />}
                   onClick={() => {
-                    void ticketApi.startSupervisor(ticket.id);
+                    ticketApi.requestStartSupervisor(ticket.id);
                   }}
                 >
                   Start autopilot

--- a/src/renderer/features/Tickets/TicketAutopilotLaunchDialog.tsx
+++ b/src/renderer/features/Tickets/TicketAutopilotLaunchDialog.tsx
@@ -1,0 +1,78 @@
+import { useStore } from '@nanostores/react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+
+import { AnimatedDialog, Button, DialogBody, DialogContent, DialogFooter, DialogHeader } from '@/renderer/ds';
+import { SandboxPicker } from '@/renderer/features/SandboxProfile/SandboxPicker';
+import { emitter } from '@/renderer/services/ipc';
+import { persistedStoreApi } from '@/renderer/services/store';
+
+import { $autopilotLaunchTicketId, ticketApi } from './state';
+
+export const TicketAutopilotLaunchDialog = memo(() => {
+  const ticketId = useStore($autopilotLaunchTicketId);
+  const store = useStore(persistedStoreApi.$atom);
+  const [isEnterprise, setIsEnterprise] = useState(false);
+  const ticket = useMemo(() => store.tickets.find((item) => item.id === ticketId), [store.tickets, ticketId]);
+  const project = useMemo(
+    () => store.projects.find((item) => item.id === ticket?.projectId),
+    [store.projects, ticket?.projectId]
+  );
+  const defaultProfileName = project?.sandboxProfile ?? store.defaultProfileName ?? 'host';
+  const [profileName, setProfileName] = useState(defaultProfileName);
+
+  useEffect(() => {
+    emitter.invoke('platform:is-enterprise').then(setIsEnterprise);
+  }, []);
+
+  useEffect(() => {
+    if (ticketId) {
+      setProfileName(defaultProfileName);
+    }
+  }, [ticketId, defaultProfileName]);
+
+  const handleClose = useCallback(() => {
+    $autopilotLaunchTicketId.set(null);
+  }, []);
+
+  const handleStart = useCallback(() => {
+    if (!ticketId) {
+      return;
+    }
+    $autopilotLaunchTicketId.set(null);
+    void ticketApi.startSupervisor(ticketId, { profileName });
+  }, [profileName, ticketId]);
+
+  if (!ticketId || !ticket) {
+    return null;
+  }
+
+  return (
+    <AnimatedDialog open onClose={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>Start autopilot</DialogHeader>
+        <DialogBody className="flex flex-col gap-3">
+          <div className="text-sm text-fg-muted">
+            Choose the sandbox profile for this autopilot run.
+          </div>
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-stroke-1 bg-bgCard p-3">
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium text-fg">{ticket.title || 'Untitled ticket'}</div>
+              <div className="text-xs text-fg-subtle">Defaults to the project or global sandbox setting.</div>
+            </div>
+            <SandboxPicker
+              value={profileName}
+              onChange={setProfileName}
+              context={{ isEnterprise, available: store.availableSandboxProfiles }}
+            />
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="ghost" onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleStart}>Start autopilot</Button>
+        </DialogFooter>
+      </DialogContent>
+    </AnimatedDialog>
+  );
+});
+
+TicketAutopilotLaunchDialog.displayName = 'TicketAutopilotLaunchDialog';

--- a/src/renderer/features/Tickets/TicketControls.tsx
+++ b/src/renderer/features/Tickets/TicketControls.tsx
@@ -70,7 +70,7 @@ const useTicketAutomation = (ticketId: TicketId) => {
     supervisorTask?.status.type === 'connecting' ||
     supervisorTask?.status.type === 'starting';
 
-  const handleStart = useCallback(() => ticketApi.startSupervisor(ticketId), [ticketId]);
+  const handleStart = useCallback(() => ticketApi.requestStartSupervisor(ticketId), [ticketId]);
   const handleStop = useCallback(() => ticketApi.stopSupervisor(ticketId), [ticketId]);
   const handleReset = useCallback(() => ticketApi.resetSupervisorSession(ticketId), [ticketId]);
 

--- a/src/renderer/features/Tickets/TicketDetail.tsx
+++ b/src/renderer/features/Tickets/TicketDetail.tsx
@@ -282,7 +282,7 @@ export const TicketDetail = memo(
     }, [ticketId]);
 
     const handleStartAutopilot = useCallback(() => {
-      void ticketApi.startSupervisor(ticketId);
+      ticketApi.requestStartSupervisor(ticketId);
     }, [ticketId]);
 
     const handleDelete = useCallback(() => {

--- a/src/renderer/features/Tickets/Tickets.tsx
+++ b/src/renderer/features/Tickets/Tickets.tsx
@@ -15,7 +15,8 @@ import { MilestoneDetail } from './MilestoneDetail';
 import { ProjectActions, ProjectPage } from './ProjectPage';
 import { ProjectsDashboard } from './ProjectsDashboard';
 import { TicketsSidebar } from './Sidebar';
-import { $activeWipTickets, $ticketsView, $wipDialogPendingTicket, ticketApi } from './state';
+import { $activeWipTickets, $ticketsView, $wipDialogPendingProfileName, $wipDialogPendingTicket, ticketApi } from './state';
+import { TicketAutopilotLaunchDialog } from './TicketAutopilotLaunchDialog';
 import { TicketDetail } from './TicketDetail';
 import { WipLimitDialog } from './WipLimitDialog';
 import { WorkItemsList } from './WorkItemsList';
@@ -199,7 +200,7 @@ export const Tickets = memo(() => {
   }, [view]);
   const handleRetryTicketAutopilot = useCallback(() => {
     if (view.type === 'ticket') {
-      void ticketApi.startSupervisor(view.ticketId);
+      ticketApi.requestStartSupervisor(view.ticketId);
     }
   }, [view]);
   const mobileBackHandler =
@@ -359,6 +360,7 @@ export const Tickets = memo(() => {
       )}
 
       <WipLimitOverlay />
+      <TicketAutopilotLaunchDialog />
     </div>
   );
 });
@@ -371,18 +373,21 @@ const WipLimitOverlay = memo(() => {
 
   const handleDrop = useCallback((_droppedTicketId: string) => {
     const pending = $wipDialogPendingTicket.get();
+    const profileName = $wipDialogPendingProfileName.get();
     $wipDialogPendingTicket.set(null);
+    $wipDialogPendingProfileName.set(undefined);
     // After stopping the dropped ticket, start the pending one
     if (pending) {
       // Small delay to let the stop propagate
       setTimeout(() => {
-        void ticketApi.startSupervisor(pending.id);
+        void ticketApi.startSupervisor(pending.id, { profileName });
       }, 500);
     }
   }, []);
 
   const handleCancel = useCallback(() => {
     $wipDialogPendingTicket.set(null);
+    $wipDialogPendingProfileName.set(undefined);
   }, []);
 
   if (!pendingTicket) {

--- a/src/renderer/features/Tickets/WorkItemsList.tsx
+++ b/src/renderer/features/Tickets/WorkItemsList.tsx
@@ -253,7 +253,7 @@ const TicketRow = memo(({ ticket, selected, hovered, unresolvedBlockers, milesto
   }, [ticket.id]);
 
   const handleAutopilot = useCallback(() => {
-    void ticketApi.startSupervisor(ticket.id);
+    ticketApi.requestStartSupervisor(ticket.id);
   }, [ticket.id]);
 
   const handleStopPropagation = useCallback((e: React.MouseEvent) => {

--- a/src/renderer/features/Tickets/state.ts
+++ b/src/renderer/features/Tickets/state.ts
@@ -181,6 +181,8 @@ export const $activeWipTickets = atom<Ticket[]>([]);
  * Set by startSupervisor when the WIP limit is hit. Cleared by dialog actions.
  */
 export const $wipDialogPendingTicket = atom<Ticket | null>(null);
+export const $wipDialogPendingProfileName = atom<string | undefined>(undefined);
+export const $autopilotLaunchTicketId = atom<TicketId | null>(null);
 
 export const ticketApi = {
   // Projects (delegated to shared Projects module)
@@ -309,11 +311,14 @@ export const ticketApi = {
     }
     void ticketApi.fetchTasks();
   },
-  startSupervisor: async (ticketId: TicketId): Promise<void> => {
+  requestStartSupervisor: (ticketId: TicketId): void => {
+    $autopilotLaunchTicketId.set(ticketId);
+  },
+  startSupervisor: async (ticketId: TicketId, opts?: { profileName?: string }): Promise<void> => {
     // Clear old messages when starting a fresh supervisor session
     $supervisorMessages.setKey(ticketId, []);
     try {
-      await emitter.invoke('project:start-supervisor', ticketId);
+      await emitter.invoke('project:start-supervisor', ticketId, opts?.profileName);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.startsWith('WIP_LIMIT:')) {
@@ -322,6 +327,7 @@ export const ticketApi = {
         const ticket = $tickets.get()[ticketId] ?? persistedStoreApi.$atom.get().tickets.find((t) => t.id === ticketId);
         if (ticket) {
           $wipDialogPendingTicket.set(ticket);
+          $wipDialogPendingProfileName.set(opts?.profileName);
         }
         return;
       }

--- a/src/renderer/services/supervisor-bridge.test.ts
+++ b/src/renderer/services/supervisor-bridge.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const invoke = vi.fn(() => Promise.resolve());
 const on = vi.fn();
+const getKey = vi.fn(() => []);
+const setKey = vi.fn(() => Promise.resolve());
+const atomGet = vi.fn(() => ({ tickets: [] }));
+const addTabForTicket = vi.fn(() => Promise.resolve());
+const setTabProfile = vi.fn(() => Promise.resolve());
 
 vi.mock('@/renderer/services/ipc', () => ({
   emitter: { invoke },
@@ -10,14 +15,14 @@ vi.mock('@/renderer/services/ipc', () => ({
 
 vi.mock('@/renderer/services/store', () => ({
   persistedStoreApi: {
-    getKey: vi.fn(() => []),
-    setKey: vi.fn(() => Promise.resolve()),
-    $atom: { get: vi.fn(() => ({ tickets: [] })) },
+    getKey,
+    setKey,
+    $atom: { get: atomGet },
   },
 }));
 
 vi.mock('@/renderer/features/Code/state', () => ({
-  codeApi: { addTabForTicket: vi.fn(() => Promise.resolve()) },
+  codeApi: { addTabForTicket, setTabProfile },
 }));
 
 const makeActor = (ticketId: string) => ({
@@ -32,8 +37,16 @@ const makeActor = (ticketId: string) => ({
 
 describe('renderer supervisor bridge', () => {
   beforeEach(() => {
+    vi.resetModules();
     invoke.mockClear();
     on.mockClear();
+    getKey.mockReset();
+    getKey.mockReturnValue([]);
+    setKey.mockClear();
+    atomGet.mockReset();
+    atomGet.mockReturnValue({ tickets: [] });
+    addTabForTicket.mockClear();
+    setTabProfile.mockClear();
   });
 
   it('does not emit disconnected when an actor is replaced during effect churn', async () => {
@@ -67,5 +80,45 @@ describe('renderer supervisor bridge', () => {
       kind: 'disconnected',
       ticketId: 'ticket-remove',
     });
+  });
+
+  it('creates a ticket tab with the requested sandbox profile', async () => {
+    const { startSupervisorBridge } = await import('@/renderer/services/supervisor-bridge');
+    atomGet.mockReturnValue({ tickets: [{ id: 't1', projectId: 'p1', title: 'Ticket one' }] } as never);
+    startSupervisorBridge();
+    const dispatch = on.mock.calls.find(([channel]) => channel === 'supervisor:dispatch')?.[1];
+
+    dispatch('req-1', { kind: 'ensure-column', ticketId: 't1', workspaceDir: '/ws', profileName: 'aci' });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(addTabForTicket).toHaveBeenCalledWith('t1', 'p1', {
+      ticketTitle: 'Ticket one',
+      workspaceDir: '/ws',
+      profileName: 'aci',
+    });
+    expect(invoke).toHaveBeenCalledWith('supervisor:dispatch-result', 'req-1', true, {}, undefined);
+  });
+
+  it('updates an existing ticket tab to the requested sandbox profile', async () => {
+    const { startSupervisorBridge } = await import('@/renderer/services/supervisor-bridge');
+    getKey.mockImplementation(((key: string) => {
+      if (key === 'codeTabs') {
+        return [{ id: 'tab-1', ticketId: 't1', profileName: 'host' }];
+      }
+      return [];
+    }) as never);
+    startSupervisorBridge();
+    const dispatch = on.mock.calls.find(([channel]) => channel === 'supervisor:dispatch')?.[1];
+
+    dispatch('req-2', { kind: 'ensure-column', ticketId: 't1', profileName: 'devbox' });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(setTabProfile).toHaveBeenCalledWith('tab-1', 'devbox');
+    expect(addTabForTicket).not.toHaveBeenCalled();
+    expect(setKey).toHaveBeenCalledWith('activeCodeTabId', 'tab-1');
   });
 });

--- a/src/renderer/services/supervisor-bridge.ts
+++ b/src/renderer/services/supervisor-bridge.ts
@@ -108,6 +108,9 @@ async function ensureColumn(request: Extract<SupervisorBridgeRequest, { kind: 'e
   const tabs = persistedStoreApi.getKey('codeTabs') ?? [];
   const existing = tabs.find((t) => t.ticketId === request.ticketId);
   if (existing) {
+    if (request.profileName && existing.profileName !== request.profileName) {
+      await codeApi.setTabProfile(existing.id, request.profileName);
+    }
     await persistedStoreApi.setKey('activeCodeTabId', existing.id);
     await persistedStoreApi.setKey('layoutMode', 'spaces');
     return;
@@ -119,6 +122,7 @@ async function ensureColumn(request: Extract<SupervisorBridgeRequest, { kind: 'e
   await codeApi.addTabForTicket(request.ticketId, ticket.projectId, {
     ticketTitle: ticket.title,
     workspaceDir: request.workspaceDir,
+    profileName: request.profileName,
   });
   await persistedStoreApi.setKey('layoutMode', 'spaces');
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2361,7 +2361,7 @@ type ProjectIpcEvents = Namespaced<
     'detect-chat-pull-requests': () => ContainerPullRequest[];
     // Supervisor operations
     'ensure-supervisor-infra': (ticketId: TicketId) => void;
-    'start-supervisor': (ticketId: TicketId) => void;
+    'start-supervisor': (ticketId: TicketId, profileName?: string) => void;
     'stop-supervisor': (ticketId: TicketId) => void;
     'send-supervisor-message': (ticketId: TicketId, message: string) => void;
     'reset-supervisor-session': (ticketId: TicketId) => void;
@@ -2425,6 +2425,7 @@ export type SupervisorBridgeRequest =
       kind: 'ensure-column';
       ticketId: TicketId;
       workspaceDir?: string;
+      profileName?: string;
     }
   | {
       /**


### PR DESCRIPTION
## Summary
- Add a ticket autopilot launch dialog that reuses the existing `SandboxPicker` profile list and labels.
- Thread the selected one-off sandbox profile through ticket API, IPC, supervisor orchestration, bridge dispatch, and code tab creation/reuse.
- Keep project/global sandbox defaults as the launch default and preserve the selected profile through WIP-limit deferred starts.

## Test plan
- `npm test -- --run src/main/supervisor-handlers.test.ts src/renderer/services/supervisor-bridge.test.ts`
- `npm test -- --run src/lib/supervisor-orchestrator.test.ts -t "one-off profile|selected profile"`
- `git diff --check`

## Notes
- Full `npm run lint:tsc` currently fails on existing repository type errors unrelated to this change; touched profile plumbing files were filtered with no matching errors.
- Full `src/lib/supervisor-orchestrator.test.ts` currently has an unrelated existing WIP-limit assertion failure.
