### PR TITLE
Add sandbox choice to Agent Session setup

### DIFF
--- a/src/renderer/features/Code/CodeEmptyState.tsx
+++ b/src/renderer/features/Code/CodeEmptyState.tsx
@@ -1,15 +1,19 @@
-import { makeStyles, shorthands,tokens } from '@fluentui/react-components';
-import { Add20Regular,FolderOpen20Regular } from '@fluentui/react-icons';
+import { Badge, makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { Add20Regular, Cube20Regular, FolderOpen20Regular } from '@fluentui/react-icons';
 import { useStore } from '@nanostores/react';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button, Heading } from '@/renderer/ds';
 import { ProjectForm } from '@/renderer/features/Projects/ProjectForm';
+import { getAvailableProfileNames, getProfileMenuLabel } from '@/renderer/features/SandboxProfile/profile-list';
+import { SandboxPicker } from '@/renderer/features/SandboxProfile/SandboxPicker';
+import { emitter } from '@/renderer/services/ipc';
+import { $machines } from '@/renderer/services/machines';
 import { persistedStoreApi } from '@/renderer/services/store';
-import type { CodeTabId, Project } from '@/shared/types';
+import type { CodeTab, CodeTabId, Project } from '@/shared/types';
 import { firstSource } from '@/shared/types';
 
-import { codeApi } from './state';
+import { codeApi, resolveCodeTabProfileName } from './state';
 
 const useStyles = makeStyles({
   projectCard: {
@@ -30,7 +34,7 @@ const useStyles = makeStyles({
     },
   },
   projectIcon: { color: tokens.colorNeutralForeground2, flexShrink: 0 },
-  projectContent: { minWidth: 0 },
+  projectContent: { minWidth: 0, flex: '1 1 auto' },
   projectLabel: {
     fontSize: tokens.fontSizeBase300,
     fontWeight: tokens.fontWeightMedium,
@@ -79,8 +83,59 @@ const useStyles = makeStyles({
     overflowY: 'auto',
     '@media (min-width: 640px)': { gridTemplateColumns: '1fr 1fr' },
   },
+  sandboxPanel: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: tokens.spacingHorizontalM,
+    width: '100%',
+    maxWidth: '512px',
+    borderRadius: tokens.borderRadiusXLarge,
+    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
+    backgroundColor: tokens.colorNeutralBackground1,
+    padding: tokens.spacingHorizontalL,
+    '@media (max-width: 520px)': { alignItems: 'flex-start', flexDirection: 'column' },
+  },
+  sandboxTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalS,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  sandboxHint: { color: tokens.colorNeutralForeground2, fontSize: tokens.fontSizeBase200, marginTop: '2px' },
+  projectMeta: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXS,
+    marginTop: tokens.spacingVerticalXS,
+    flexWrap: 'wrap',
+  },
+  unavailable: { color: tokens.colorPaletteRedForeground1 },
   newProjectIcon: { marginRight: '6px' },
 });
+
+type SandboxResolution = {
+  profileName: string;
+  source: 'oneOff' | 'project' | 'default' | 'fallback';
+  available: boolean;
+};
+
+const resolveSandboxForProject = (
+  project: Project,
+  explicitProfileName: string | null,
+  availableProfiles: string[],
+  defaultProfileName: string
+): SandboxResolution => {
+  const requested = explicitProfileName ?? project.sandboxProfile ?? defaultProfileName;
+  const source = explicitProfileName ? 'oneOff' : project.sandboxProfile ? 'project' : 'default';
+  if (availableProfiles.length === 0) {
+    return { profileName: requested, source, available: true };
+  }
+  if (availableProfiles.includes(requested)) {
+    return { profileName: requested, source, available: true };
+  }
+  return { profileName: availableProfiles[0] ?? 'host', source: 'fallback', available: false };
+};
 
 type CodeEmptyStateProps = {
   tabId: CodeTabId;
@@ -88,21 +143,52 @@ type CodeEmptyStateProps = {
 };
 
 const ProjectCard = memo(
-  ({ project, onSelect }: { project: Project; onSelect: (project: Project) => void }) => {
+  ({
+    project,
+    resolution,
+    onSelect,
+  }: {
+    project: Project;
+    resolution: SandboxResolution;
+    onSelect: (project: Project) => void;
+  }) => {
     const styles = useStyles();
+    const machines = useStore($machines);
     const handleClick = useCallback(() => {
       onSelect(project);
     }, [project, onSelect]);
 
+    const sourceLabel =
+      resolution.source === 'oneOff'
+        ? 'One-off'
+        : resolution.source === 'project'
+          ? 'Project'
+          : resolution.source === 'fallback'
+            ? 'Fallback'
+            : 'Default';
+
     return (
-      <button
-        onClick={handleClick}
-        className={styles.projectCard}
-      >
+      <button onClick={handleClick} className={styles.projectCard}>
         <FolderOpen20Regular className={styles.projectIcon} />
         <div className={styles.projectContent}>
           <div className={styles.projectLabel}>{project.label}</div>
-          <div className={styles.projectDir}>{(() => { const s = firstSource(project); if (s?.kind === 'local') return s.workspaceDir; if (s?.kind === 'git-remote') return s.repoUrl; return ''; })()}</div>
+          <div className={styles.projectDir}>
+            {(() => {
+              const s = firstSource(project);
+              if (s?.kind === 'local') {
+                return s.workspaceDir;
+              }
+              if (s?.kind === 'git-remote') {
+                return s.repoUrl;
+              }
+              return '';
+            })()}
+          </div>
+          <div className={styles.projectMeta}>
+            <Badge size="small" appearance="outline" color={resolution.available ? 'informative' : 'danger'}>
+              {sourceLabel} · {getProfileMenuLabel(resolution.profileName, machines)}
+            </Badge>
+          </div>
         </div>
       </button>
     );
@@ -113,13 +199,42 @@ ProjectCard.displayName = 'ProjectCard';
 export const CodeEmptyState = memo(({ tabId, embedded = false }: CodeEmptyStateProps) => {
   const styles = useStyles();
   const store = useStore(persistedStoreApi.$atom);
+  const tab = store.codeTabs.find((t) => t.id === tabId) as CodeTab | undefined;
   const [showNewProject, setShowNewProject] = useState(false);
+  const [isEnterprise, setIsEnterprise] = useState(false);
+  const machines = useStore($machines);
+
+  useEffect(() => {
+    emitter.invoke('platform:is-enterprise').then(setIsEnterprise);
+  }, []);
 
   const projects = store.projects;
+  const availableProfiles = useMemo(
+    () => getAvailableProfileNames({ isEnterprise, available: store.availableSandboxProfiles, machines }),
+    [isEnterprise, store.availableSandboxProfiles, machines]
+  );
+  const defaultProfileName = store.defaultProfileName ?? 'host';
+  const selectedProfileName = tab?.profileName ?? resolveCodeTabProfileName(null);
+  const explicitProfileName = tab?.profileNameExplicit ? selectedProfileName : null;
+  const selectedProfileAvailable = availableProfiles.length === 0 || availableProfiles.includes(selectedProfileName);
 
   const handleSelectProject = useCallback(
     (project: Project) => {
       codeApi.setTabProject(tabId, project.id);
+    },
+    [tabId]
+  );
+
+  const handleSandboxChange = useCallback(
+    (profileName: string) => {
+      void codeApi.setTabProfile(tabId, profileName);
+    },
+    [tabId]
+  );
+
+  const handleCreatedProject = useCallback(
+    (project: Project) => {
+      void codeApi.setTabProject(tabId, project.id);
     },
     [tabId]
   );
@@ -136,14 +251,44 @@ export const CodeEmptyState = memo(({ tabId, embedded = false }: CodeEmptyStateP
     <div className={embedded ? styles.rootEmbedded : styles.rootFull}>
       {!embedded && <Heading size="md">Select a Project</Heading>}
       {!embedded && (
-        <p className={styles.description}>
-          Choose an existing project to open in this tab, or create a new one.
-        </p>
+        <p className={styles.description}>Choose an existing project to open in this tab, or create a new one.</p>
       )}
+
+      <div className={styles.sandboxPanel}>
+        <div>
+          <div className={styles.sandboxTitle}>
+            <Cube20Regular /> Sandbox for this session
+          </div>
+          <div
+            className={selectedProfileAvailable ? styles.sandboxHint : `${styles.sandboxHint} ${styles.unavailable}`}
+          >
+            {tab?.profileNameExplicit
+              ? 'One-off override for this Agent Session.'
+              : 'Defaults update when you choose a project.'}
+            {!selectedProfileAvailable
+              ? ' Selected profile is unavailable; project launch will use a safe fallback.'
+              : ''}
+          </div>
+        </div>
+        {availableProfiles.length > 0 ? (
+          <SandboxPicker
+            value={selectedProfileAvailable ? selectedProfileName : (availableProfiles[0] ?? 'host')}
+            onChange={handleSandboxChange}
+            context={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
+          />
+        ) : (
+          <Badge appearance="outline">No sandbox profiles</Badge>
+        )}
+      </div>
 
       <div className={styles.grid}>
         {projects.map((project) => (
-          <ProjectCard key={project.id} project={project} onSelect={handleSelectProject} />
+          <ProjectCard
+            key={project.id}
+            project={project}
+            resolution={resolveSandboxForProject(project, explicitProfileName, availableProfiles, defaultProfileName)}
+            onSelect={handleSelectProject}
+          />
         ))}
       </div>
 
@@ -152,7 +297,13 @@ export const CodeEmptyState = memo(({ tabId, embedded = false }: CodeEmptyStateP
         Create new project
       </Button>
 
-      <ProjectForm open={showNewProject} onClose={handleCloseNewProject} />
+      <ProjectForm
+        open={showNewProject}
+        onClose={handleCloseNewProject}
+        showSandboxForCreate
+        submitLabel="Create and launch"
+        onCreated={handleCreatedProject}
+      />
     </div>
   );
 });

--- a/src/renderer/features/Code/state.test.ts
+++ b/src/renderer/features/Code/state.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CodeTab, Project, StoreData } from '@/shared/types';
+
+const invoke = vi.fn(() => Promise.resolve());
+const setKey = vi.fn((key: keyof StoreData, value: StoreData[keyof StoreData]) => {
+  store = { ...store, [key]: value } as StoreData;
+  return Promise.resolve();
+});
+const getKey = vi.fn((key: keyof StoreData) => store[key]);
+
+vi.mock('@/renderer/services/ipc', () => ({
+  emitter: { invoke },
+}));
+
+vi.mock('@/renderer/services/store', () => ({
+  persistedStoreApi: { getKey, setKey },
+}));
+
+vi.mock('@/renderer/services/agent-process', () => ({
+  $agentStatuses: { get: () => ({}), set: vi.fn() },
+  $agentXTerms: { get: () => ({}), set: vi.fn() },
+  agentProcessApi: { start: vi.fn(), stop: vi.fn(), rebuild: vi.fn() },
+  clearStatus: vi.fn(),
+  pollProcessStatus: vi.fn(),
+  teardownTerminal: vi.fn(),
+}));
+
+vi.mock('@/renderer/features/Console/state', () => ({
+  destroyAllTerminalsForTab: vi.fn(),
+}));
+
+vi.mock('@/renderer/constants', () => ({
+  STATUS_POLL_INTERVAL_MS: 999999,
+}));
+
+let store: StoreData;
+
+const project = (id: string, sandboxProfile?: string | null): Project => ({
+  id,
+  label: id,
+  slug: id,
+  sources: [],
+  ...(sandboxProfile !== undefined ? { sandboxProfile } : {}),
+  createdAt: 1,
+});
+
+const tab = (patch: Partial<CodeTab> = {}): CodeTab => ({
+  id: 'tab-1',
+  projectId: null,
+  sessionId: 'session-1',
+  profileName: 'host',
+  profileNameExplicit: false,
+  createdAt: 1,
+  ...patch,
+});
+
+const resetStore = (patch: Partial<StoreData> = {}) => {
+  store = {
+    defaultProfileName: 'host',
+    projects: [],
+    codeTabs: [],
+    activeCodeTabId: null,
+    availableSandboxProfiles: undefined,
+    ...patch,
+  } as StoreData;
+  invoke.mockClear();
+  setKey.mockClear();
+  getKey.mockClear();
+};
+
+describe('code tab sandbox profile resolution', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    resetStore();
+  });
+
+  it('uses project sandbox over global default when no one-off override exists', async () => {
+    resetStore({
+      defaultProfileName: 'host',
+      projects: [project('project-1', 'devbox')],
+      codeTabs: [tab()],
+    });
+    const { codeApi } = await import('./state');
+
+    await codeApi.setTabProject('tab-1', 'project-1');
+
+    expect(store.codeTabs[0]).toMatchObject({
+      projectId: 'project-1',
+      profileName: 'devbox',
+      profileNameExplicit: false,
+    });
+  });
+
+  it('preserves an explicit one-off override when selecting a project', async () => {
+    resetStore({
+      defaultProfileName: 'host',
+      availableSandboxProfiles: ['host', 'devbox', 'platform'],
+      projects: [project('project-1', 'devbox')],
+      codeTabs: [tab({ profileName: 'platform', profileNameExplicit: true })],
+    });
+    const { codeApi } = await import('./state');
+
+    await codeApi.setTabProject('tab-1', 'project-1');
+
+    expect(store.codeTabs[0]).toMatchObject({
+      projectId: 'project-1',
+      profileName: 'platform',
+      profileNameExplicit: true,
+    });
+  });
+
+  it('falls back to a safe available profile when inherited choice is unavailable', async () => {
+    resetStore({
+      defaultProfileName: 'platform',
+      availableSandboxProfiles: ['aci'],
+      projects: [project('project-1', 'devbox')],
+      codeTabs: [tab()],
+    });
+    const { codeApi } = await import('./state');
+
+    await codeApi.setTabProject('tab-1', 'project-1');
+
+    expect(store.codeTabs[0]).toMatchObject({ projectId: 'project-1', profileName: 'aci' });
+  });
+
+  it('falls back to a safe available profile when one-off choice is unavailable', async () => {
+    resetStore({
+      defaultProfileName: 'host',
+      availableSandboxProfiles: ['aci'],
+      projects: [project('project-1', 'devbox')],
+      codeTabs: [tab({ profileName: 'platform', profileNameExplicit: true })],
+    });
+    const { codeApi } = await import('./state');
+
+    await codeApi.setTabProject('tab-1', 'project-1');
+
+    expect(store.codeTabs[0]).toMatchObject({ projectId: 'project-1', profileName: 'aci', profileNameExplicit: true });
+  });
+
+  it('clears stale container id when selecting a project changes the profile', async () => {
+    resetStore({
+      defaultProfileName: 'host',
+      projects: [project('project-1', 'devbox')],
+      codeTabs: [tab({ containerId: 'old-container' })],
+    });
+    const { codeApi } = await import('./state');
+
+    await codeApi.setTabProject('tab-1', 'project-1');
+
+    expect(store.codeTabs[0]?.containerId).toBeUndefined();
+  });
+
+  it('sets created projects on the setup tab without replacing a one-off sandbox', async () => {
+    resetStore({
+      defaultProfileName: 'host',
+      availableSandboxProfiles: ['host', 'devbox', 'platform'],
+      projects: [project('created-project', 'devbox')],
+      codeTabs: [tab({ profileName: 'platform', profileNameExplicit: true })],
+    });
+    const { codeApi } = await import('./state');
+
+    await codeApi.setTabProject('tab-1', 'created-project');
+
+    expect(store.codeTabs[0]).toMatchObject({
+      projectId: 'created-project',
+      profileName: 'platform',
+      profileNameExplicit: true,
+    });
+  });
+});

--- a/src/renderer/features/Code/state.ts
+++ b/src/renderer/features/Code/state.ts
@@ -15,13 +15,7 @@ import {
 } from '@/renderer/services/agent-process';
 import { emitter } from '@/renderer/services/ipc';
 import { persistedStoreApi } from '@/renderer/services/store';
-import type {
-  CodeLayoutMode,
-  CodeTab,
-  CodeTabId,
-  ProjectId,
-  TicketId,
-} from '@/shared/types';
+import type { CodeLayoutMode, CodeTab, CodeTabId, ProjectId, TicketId } from '@/shared/types';
 
 /**
  * Resolve the profile a fresh tab should be bound to. Mirrors the chain in
@@ -38,6 +32,17 @@ const seedProfileName = (projectId: ProjectId | null | undefined): string => {
   }
   return persistedStoreApi.getKey('defaultProfileName') ?? 'host';
 };
+
+const resolveAvailableProfileName = (name: string): string => {
+  const available = persistedStoreApi.getKey('availableSandboxProfiles');
+  if (!available || available.length === 0 || available.includes(name)) {
+    return name;
+  }
+  return available[0] ?? 'host';
+};
+
+export const resolveCodeTabProfileName = (projectId: ProjectId | null | undefined): string =>
+  resolveAvailableProfileName(seedProfileName(projectId));
 
 // Re-export agent status/xterm maps so existing imports from Code/state still work.
 // Components can read per-tab status via $agentStatuses.get()[tabId].
@@ -67,7 +72,8 @@ export const codeApi = {
       id: nanoid(),
       projectId: null,
       sessionId: uuidv4(),
-      profileName: seedProfileName(null),
+      profileName: resolveCodeTabProfileName(null),
+      profileNameExplicit: false,
       createdAt: Date.now(),
     };
     const tabs = [...(persistedStoreApi.getKey('codeTabs') ?? []), tab];
@@ -120,7 +126,20 @@ export const codeApi = {
   },
 
   setTabProject: async (tabId: CodeTabId, projectId: ProjectId) => {
-    const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) => (t.id === tabId ? { ...t, projectId } : t));
+    const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) => {
+      if (t.id !== tabId) {
+        return t;
+      }
+      const profileName = t.profileNameExplicit
+        ? resolveAvailableProfileName(t.profileName ?? seedProfileName(projectId))
+        : resolveCodeTabProfileName(projectId);
+      if (profileName === t.profileName) {
+        return { ...t, projectId, profileName };
+      }
+      const { containerId: _drop, ...rest } = t;
+      void _drop;
+      return { ...rest, projectId, profileName };
+    });
     await persistedStoreApi.setKey('codeTabs', tabs);
   },
 
@@ -154,7 +173,8 @@ export const codeApi = {
       sessionId: uuidv4(),
       ticketTitle: opts?.ticketTitle,
       workspaceDir: opts?.workspaceDir,
-      profileName: opts?.profileName ?? seedProfileName(projectId),
+      profileName: opts?.profileName ?? resolveCodeTabProfileName(projectId),
+      profileNameExplicit: Boolean(opts?.profileName),
       createdAt: Date.now(),
     };
     const tabs = [...existingTabs, tab];
@@ -169,7 +189,8 @@ export const codeApi = {
       projectId: null,
       sessionId: uuidv4(),
       customAppId,
-      profileName: seedProfileName(null),
+      profileName: resolveCodeTabProfileName(null),
+      profileNameExplicit: false,
       createdAt: Date.now(),
     };
     const tabs = [...(persistedStoreApi.getKey('codeTabs') ?? []), tab];
@@ -178,16 +199,12 @@ export const codeApi = {
   },
 
   setTabAppId: async (tabId: CodeTabId, customAppId: string) => {
-    const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) =>
-      t.id === tabId ? { ...t, customAppId } : t
-    );
+    const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) => (t.id === tabId ? { ...t, customAppId } : t));
     await persistedStoreApi.setKey('codeTabs', tabs);
   },
 
   setTabSessionId: async (tabId: CodeTabId, sessionId: string | undefined) => {
-    const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) =>
-      t.id === tabId ? { ...t, sessionId } : t
-    );
+    const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) => (t.id === tabId ? { ...t, sessionId } : t));
     await persistedStoreApi.setKey('codeTabs', tabs);
   },
 
@@ -196,17 +213,21 @@ export const codeApi = {
     // profile-specific so we drop it here — the SDK would silently fall back
     // anyway, but not sending a definitely-stale id is cleaner.
     const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) => {
-      if (t.id !== tabId) return t;
+      if (t.id !== tabId) {
+        return t;
+      }
       const { containerId: _drop, ...rest } = t;
       void _drop;
-      return { ...rest, profileName };
+      return { ...rest, profileName, profileNameExplicit: true };
     });
     await persistedStoreApi.setKey('codeTabs', tabs);
   },
 
   setTabContainerId: async (tabId: CodeTabId, containerId: string | undefined) => {
     const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) => {
-      if (t.id !== tabId) return t;
+      if (t.id !== tabId) {
+        return t;
+      }
       if (containerId === undefined) {
         const { containerId: _drop, ...rest } = t;
         void _drop;

--- a/src/renderer/features/Projects/ProjectForm.tsx
+++ b/src/renderer/features/Projects/ProjectForm.tsx
@@ -60,135 +60,140 @@ type ProjectFormProps = {
   open: boolean;
   onClose: () => void;
   editProject?: Project;
+  showSandboxForCreate?: boolean;
+  submitLabel?: string;
+  onCreated?: (project: Project) => void;
 };
 
-export const ProjectForm = memo(({ open, onClose, editProject }: ProjectFormProps) => {
-  const styles = useStyles();
-  const isEdit = Boolean(editProject);
+export const ProjectForm = memo(
+  ({ open, onClose, editProject, showSandboxForCreate = false, submitLabel, onCreated }: ProjectFormProps) => {
+    const styles = useStyles();
+    const isEdit = Boolean(editProject);
 
-  const [label, setLabel] = useState(editProject?.label ?? '');
-  const [isSubmitting, setIsSubmitting] = useState(false);
+    const [label, setLabel] = useState(editProject?.label ?? '');
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const [dueDate, setDueDate] = useState(editProject?.dueDate !== undefined ? toInputDate(editProject.dueDate) : '');
+    const [dueDate, setDueDate] = useState(editProject?.dueDate !== undefined ? toInputDate(editProject.dueDate) : '');
 
-  // Per-project sandbox profile. ``null``/missing means "inherit user-default".
-  const [sandboxProfile, setSandboxProfile] = useState<string | null>(editProject?.sandboxProfile ?? null);
-  const [isEnterprise, setIsEnterprise] = useState(false);
-  useEffect(() => {
-    emitter.invoke('platform:is-enterprise').then(setIsEnterprise);
-  }, []);
-  const storeData = useStore(persistedStoreApi.$atom);
-  const availableProfiles = useMemo(
-    () => getAvailableProfileNames({ isEnterprise, available: storeData.availableSandboxProfiles }),
-    [isEnterprise, storeData.availableSandboxProfiles]
-  );
-  const handleSandboxProfileChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    setSandboxProfile(e.target.value === INHERIT_PROFILE ? null : e.target.value);
-  }, []);
+    // Per-project sandbox profile. ``null``/missing means "inherit user-default".
+    const [sandboxProfile, setSandboxProfile] = useState<string | null>(editProject?.sandboxProfile ?? null);
+    const [isEnterprise, setIsEnterprise] = useState(false);
+    useEffect(() => {
+      emitter.invoke('platform:is-enterprise').then(setIsEnterprise);
+    }, []);
+    const storeData = useStore(persistedStoreApi.$atom);
+    const availableProfiles = useMemo(
+      () => getAvailableProfileNames({ isEnterprise, available: storeData.availableSandboxProfiles }),
+      [isEnterprise, storeData.availableSandboxProfiles]
+    );
+    const handleSandboxProfileChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+      setSandboxProfile(e.target.value === INHERIT_PROFILE ? null : e.target.value);
+    }, []);
 
-  const isValid = label.trim().length > 0;
+    const isValid = label.trim().length > 0;
 
-  const handleLabelChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setLabel(e.target.value);
-  }, []);
+    const handleLabelChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+      setLabel(e.target.value);
+    }, []);
 
-  const handleSubmit = useCallback(async () => {
-    if (!isValid || isSubmitting) {
-      return;
-    }
-    setIsSubmitting(true);
-
-    const slug =
-      label
-        .trim()
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '')
-        .slice(0, 60) || 'project';
-    const dueDateMs = fromInputDate(dueDate);
-
-    try {
-      if (isEdit && editProject) {
-        // Sources are managed from the sidebar / ⋯ menu — omit them here so the
-        // edit form never overwrites them.
-        await projectsApi.updateProject(editProject.id, {
-          label: label.trim(),
-          sandboxProfile,
-          dueDate: dueDateMs,
-        });
-      } else {
-        // New projects start empty; sources are added afterward via the
-        // sidebar's Sources branch or the project page's ⋯ menu.
-        await projectsApi.addProject({
-          label: label.trim(),
-          slug,
-          sources: [],
-          ...(sandboxProfile ? { sandboxProfile } : {}),
-          ...(dueDateMs !== undefined ? { dueDate: dueDateMs } : {}),
-        });
+    const handleSubmit = useCallback(async () => {
+      if (!isValid || isSubmitting) {
+        return;
       }
-      onClose();
-    } finally {
-      setIsSubmitting(false);
-    }
-  }, [isValid, isSubmitting, isEdit, editProject, label, sandboxProfile, dueDate, onClose]);
+      setIsSubmitting(true);
 
-  const handleDueDateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setDueDate(e.target.value);
-  }, []);
+      const slug =
+        label
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-|-$/g, '')
+          .slice(0, 60) || 'project';
+      const dueDateMs = fromInputDate(dueDate);
 
-  return (
-    <AnimatedDialog open={open} onClose={onClose}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>{isEdit ? 'Edit Project' : 'New Project'}</DialogHeader>
-        <DialogBody className={styles.body}>
-          <div className={styles.field}>
-            <label className={styles.label}>Name</label>
-            <Input
-              type="text"
-              value={label}
-              onChange={handleLabelChange}
-              placeholder="my-project"
-              className={styles.fullWidth}
-            />
-          </div>
+      try {
+        if (isEdit && editProject) {
+          // Sources are managed from the sidebar / ⋯ menu — omit them here so the
+          // edit form never overwrites them.
+          await projectsApi.updateProject(editProject.id, {
+            label: label.trim(),
+            sandboxProfile,
+            dueDate: dueDateMs,
+          });
+        } else {
+          // New projects start empty; sources are added afterward via the
+          // sidebar's Sources branch or the project page's ⋯ menu.
+          const project = await projectsApi.addProject({
+            label: label.trim(),
+            slug,
+            sources: [],
+            ...(sandboxProfile ? { sandboxProfile } : {}),
+            ...(dueDateMs !== undefined ? { dueDate: dueDateMs } : {}),
+          });
+          onCreated?.(project);
+        }
+        onClose();
+      } finally {
+        setIsSubmitting(false);
+      }
+    }, [isValid, isSubmitting, isEdit, editProject, label, sandboxProfile, dueDate, onClose, onCreated]);
 
-          {/* Sandbox — only in edit mode. New projects inherit the default. */}
-          {isEdit && (
+    const handleDueDateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+      setDueDate(e.target.value);
+    }, []);
+
+    return (
+      <AnimatedDialog open={open} onClose={onClose}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>{isEdit ? 'Edit Project' : 'New Project'}</DialogHeader>
+          <DialogBody className={styles.body}>
             <div className={styles.field}>
-              <label className={styles.label}>Sandbox</label>
-              <Select
-                value={sandboxProfile ?? INHERIT_PROFILE}
-                onChange={handleSandboxProfileChange}
+              <label className={styles.label}>Name</label>
+              <Input
+                type="text"
+                value={label}
+                onChange={handleLabelChange}
+                placeholder="my-project"
                 className={styles.fullWidth}
-              >
-                <option value={INHERIT_PROFILE}>Inherit default</option>
-                {availableProfiles.map((name) => (
-                  <option key={name} value={name}>
-                    {getProfileMenuLabel(name)}
-                  </option>
-                ))}
-              </Select>
+              />
             </div>
-          )}
 
-          <div className={styles.field}>
-            <label className={styles.label}>Due date</label>
-            <Input type="date" value={dueDate} onChange={handleDueDateChange} className={styles.fullWidth} />
-          </div>
-        </DialogBody>
-        <DialogFooter className={styles.footer}>
-          <Button variant="ghost" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button onClick={handleSubmit} isDisabled={!isValid || isSubmitting}>
-            {isEdit ? 'Save' : 'Create'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </AnimatedDialog>
-  );
-});
+            {(isEdit || showSandboxForCreate) && (
+              <div className={styles.field}>
+                <label className={styles.label}>Sandbox</label>
+                <Select
+                  value={sandboxProfile ?? INHERIT_PROFILE}
+                  onChange={handleSandboxProfileChange}
+                  className={styles.fullWidth}
+                >
+                  <option value={INHERIT_PROFILE}>Inherit default</option>
+                  {availableProfiles.map((name) => (
+                    <option key={name} value={name}>
+                      {getProfileMenuLabel(name)}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+            )}
+
+            <div className={styles.field}>
+              <label className={styles.label}>Due date</label>
+              <Input type="date" value={dueDate} onChange={handleDueDateChange} className={styles.fullWidth} />
+            </div>
+          </DialogBody>
+          <DialogFooter className={styles.footer}>
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} isDisabled={!isValid || isSubmitting}>
+              {submitLabel ?? (isEdit ? 'Save' : 'Create')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </AnimatedDialog>
+    );
+  }
+);
 ProjectForm.displayName = 'ProjectForm';
 
 /** Format an epoch-ms timestamp as a local YYYY-MM-DD string for <input type="date">. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1145,6 +1145,7 @@ export type CodeTab = {
    * workspace into another sandbox.
    */
   profileName?: string;
+  profileNameExplicit?: boolean;
   /**
    * Docker container id captured from the last successful launch of this tab.
    * Sent back on the next start so omni-code can ``client.resume(state)`` for


### PR DESCRIPTION
## Summary
- Adds a pre-launch sandbox selector to blank Agent Session tabs.
- Shows sandbox source chips on project cards for one-off, project, inherited default, and unavailable fallback resolution.
- Persists one-off tab sandbox overrides separately from seeded defaults so project selection re-resolves only when appropriate.
- Allows creating a project from Agent Session setup, choosing sandbox behavior, and launching into it.

## Test plan
- [x] `npx vitest run src/renderer/features/Code/state.test.ts`
- [x] `npx eslint src/renderer/features/Code/state.ts src/renderer/features/Code/CodeEmptyState.tsx src/renderer/features/Code/state.test.ts src/renderer/features/Projects/ProjectForm.tsx`
- [x] `npx tsc --noEmit --pretty false 2>&1 | rg 'src/renderer/features/Code/(state|CodeEmptyState|state.test)|src/renderer/features/Projects/ProjectForm|src/shared/types' || true`

## Notes
- Full `npx tsc --noEmit --pretty false` still reports pre-existing repo-wide errors unrelated to this change.
