### PR TITLE
Fix code deck terminal focus

### DIFF
--- a/src/renderer/features/Console/ConsoleRunning.tsx
+++ b/src/renderer/features/Console/ConsoleRunning.tsx
@@ -179,13 +179,14 @@ TerminalTabButton.displayName = 'TerminalTabButton';
 type XtermPaneProps = {
   terminal: TerminalState;
   hidden: boolean;
+  isActive: boolean;
   className: string;
   hiddenClassName: string;
 };
 
-const XtermPane = memo(({ terminal, hidden, className, hiddenClassName }: XtermPaneProps) => (
+const XtermPane = memo(({ terminal, hidden, isActive, className, hiddenClassName }: XtermPaneProps) => (
   <div className={mergeClasses(className, hidden && hiddenClassName)}>
-    <ConsoleXterm terminal={terminal} />
+    <ConsoleXterm terminal={terminal} isActive={isActive} />
   </div>
 ));
 XtermPane.displayName = 'XtermPane';
@@ -261,6 +262,7 @@ export const ConsoleStarted = memo(({ tabId }: ConsoleStartedProps) => {
               key={t.id}
               terminal={t}
               hidden={t.id !== activeId}
+              isActive={t.id === activeId}
               className={styles.xtermPane}
               hiddenClassName={styles.xtermPaneHidden}
             />

--- a/src/renderer/features/Console/ConsoleXterm.tsx
+++ b/src/renderer/features/Console/ConsoleXterm.tsx
@@ -1,6 +1,6 @@
 import { makeStyles } from '@fluentui/react-components';
 import { debounce } from 'es-toolkit/compat';
-import { memo, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { assert } from 'tsafe';
 
 import type { TerminalState } from '@/renderer/features/Console/state';
@@ -11,7 +11,7 @@ const useStyles = makeStyles({
   root: { width: '100%', height: '100%' },
 });
 
-export const ConsoleXterm = memo(({ terminal }: { terminal: TerminalState }) => {
+export const ConsoleXterm = memo(({ terminal, isActive }: { terminal: TerminalState; isActive: boolean }) => {
   const theme = useXTermTheme();
   const ref = useRef<HTMLDivElement | null>(null);
 
@@ -50,7 +50,6 @@ export const ConsoleXterm = memo(({ terminal }: { terminal: TerminalState }) => 
     const raf = requestAnimationFrame(() => {
       fit();
       terminal.xterm.refresh(0, terminal.xterm.rows - 1);
-      terminal.xterm.focus();
     });
 
     return () => {
@@ -60,7 +59,19 @@ export const ConsoleXterm = memo(({ terminal }: { terminal: TerminalState }) => 
     };
   }, [terminal.fitAddon, terminal.id, terminal.xterm, theme]);
 
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+    const raf = requestAnimationFrame(() => terminal.xterm.focus());
+    return () => cancelAnimationFrame(raf);
+  }, [isActive, terminal.xterm]);
+
+  const handlePointerDownCapture = useCallback(() => {
+    terminal.xterm.focus();
+  }, [terminal.xterm]);
+
   const styles = useStyles();
-  return <div ref={ref} className={styles.root} />;
+  return <div ref={ref} className={styles.root} onPointerDownCapture={handlePointerDownCapture} />;
 });
 ConsoleXterm.displayName = 'ConsoleXterm';


### PR DESCRIPTION
## Summary
- Refocus the active xterm pane when code-deck terminal tabs become active.
- Focus xterm on pointer-down inside the terminal wrapper so clicks restore terminal input ownership.
- Avoid stealing focus during generic xterm mount/refresh unless the pane is active.

## Validation
- `npx eslint src/renderer/features/Console/ConsoleXterm.tsx src/renderer/features/Console/ConsoleRunning.tsx`

## Notes
- `npx tsc --noEmit --pretty false` currently fails on unrelated existing repo-wide TypeScript errors.
