### PR TITLE
Prevent duplicate project sources by identity

### DIFF
--- a/src/lib/project-manager-test-helpers.ts
+++ b/src/lib/project-manager-test-helpers.ts
@@ -306,6 +306,7 @@ export type SeedArgs = {
   autoDispatch?: boolean;
   /** When set, the seeded project gets a local or git-remote source. */
   source?: { kind: 'local'; workspaceDir: string } | { kind: 'git-remote'; repoUrl: string; defaultBranch?: string };
+  sources?: Project['sources'];
   /** When set, overrides wipLimit (defaults to 100 so WIP doesn't block tests). */
   wipLimit?: number;
   tickets?: Array<Partial<Ticket> & { id: string; columnId?: string }>;
@@ -314,10 +315,7 @@ export type SeedArgs = {
 export const seedStore = (args: SeedArgs = {}): IStore => {
   const projectId = args.projectId ?? 'proj-1';
   const pipeline = args.pipeline ?? TEST_PIPELINE;
-  const sourcesArg = (args as { sources?: unknown[]; source?: unknown }).sources
-    ?? ((args as { source?: unknown }).source != null
-      ? [{ id: 's1', mountName: 'work', ...((args as { source: object }).source) }]
-      : []);
+  const sourcesArg = args.sources ?? (args.source !== undefined ? [{ id: 's1', mountName: 'work', ...args.source }] : []);
   const project: Project = {
     id: projectId,
     label: 'Test Project',

--- a/src/lib/project-manager.test.ts
+++ b/src/lib/project-manager.test.ts
@@ -89,6 +89,49 @@ describe('ProjectManager', () => {
     });
   });
 
+  describe('updateProject source validation', () => {
+    it('rejects duplicate mount names before persisting sources', () => {
+      const { pm, store } = makePm();
+
+      expect(() =>
+        pm.updateProject('proj-1', {
+          sources: [
+            { id: 's1', mountName: 'repo', kind: 'local', workspaceDir: '/tmp/repo-a' },
+            { id: 's2', mountName: 'repo', kind: 'local', workspaceDir: '/tmp/repo-b' },
+          ],
+        })
+      ).toThrow('Duplicate mount name');
+      expect(store.get('projects', [])[0]?.sources).toEqual([]);
+    });
+
+    it('rejects duplicate source identities before persisting sources', () => {
+      const { pm, store } = makePm();
+
+      expect(() =>
+        pm.updateProject('proj-1', {
+          sources: [
+            { id: 's1', mountName: 'repo', kind: 'git-remote', repoUrl: 'https://github.com/owner/repo.git' },
+            { id: 's2', mountName: 'repo-copy', kind: 'git-remote', repoUrl: 'git@github.com:owner/repo.git' },
+          ],
+        })
+      ).toThrow('already includes that repository');
+      expect(store.get('projects', [])[0]?.sources).toEqual([]);
+    });
+
+    it('persists different sources with unique mount names and identities', () => {
+      const { pm, store } = makePm();
+
+      pm.updateProject('proj-1', {
+        sources: [
+          { id: 's1', mountName: 'repo', kind: 'git-remote', repoUrl: 'https://github.com/owner/repo.git' },
+          { id: 's2', mountName: 'repo-2', kind: 'git-remote', repoUrl: 'https://github.com/owner/repo-2.git' },
+        ],
+      });
+
+      expect(store.get('projects', [])[0]?.sources).toHaveLength(2);
+    });
+  });
+
   // -------------------------------------------------------------------------
   // T9 — Milestone CRUD (in-memory only, no fs)
   // -------------------------------------------------------------------------

--- a/src/main/project-manager.ts
+++ b/src/main/project-manager.ts
@@ -55,6 +55,7 @@ import { WorkflowLoader } from '@/main/workflow-loader';
 import type { IIpcListener } from '@/shared/ipc-listener';
 import type { ProjectConfig } from '@/shared/manifest';
 import { DEFAULT_PIPELINE, SIMPLE_PIPELINE } from '@/shared/pipeline-defaults';
+import { validateProjectSources } from '@/shared/project-source';
 import type {
   ArtifactFileContent,
   ArtifactFileEntry,
@@ -734,6 +735,9 @@ export class ProjectManager {
     const index = projects.findIndex((p) => p.id === id);
     if (index === -1) {
       return;
+    }
+    if (patch.sources) {
+      validateProjectSources(patch.sources);
     }
     projects[index] = { ...projects[index]!, ...patch };
     this.setProjects(projects);

--- a/src/renderer/features/Projects/AddSourceDialog.tsx
+++ b/src/renderer/features/Projects/AddSourceDialog.tsx
@@ -30,6 +30,7 @@ import { GitCredentialDialog } from '@/renderer/features/SettingsModal/GitCreden
 import { DirectoryBrowserDialog } from '@/renderer/features/Tickets/DirectoryBrowserDialog';
 import { emitter } from '@/renderer/services/ipc';
 import { persistedStoreApi } from '@/renderer/services/store';
+import { duplicateSourceIdentityMessage, sourceIdentityKey } from '@/shared/project-source';
 import type { Project, ProjectSource, RemoteRepo } from '@/shared/types';
 
 import { CredentialStatus } from './CredentialStatus';
@@ -130,6 +131,11 @@ export const AddSourceDialog = memo(({ open, onClose, project }: AddSourceDialog
         return;
       }
       const taken = new Set(project.sources.map((s) => s.mountName));
+      const existingIdentities = new Set(project.sources.map(sourceIdentityKey));
+      if (existingIdentities.has(sourceIdentityKey(built))) {
+        setError(duplicateSourceIdentityMessage(built));
+        return;
+      }
       let next: ProjectSource = built;
       if (taken.has(built.mountName)) {
         if (!autoSuffix) {

--- a/src/renderer/features/Projects/EditSourceDialog.tsx
+++ b/src/renderer/features/Projects/EditSourceDialog.tsx
@@ -27,6 +27,7 @@ import {
 import { GitCredentialDialog } from '@/renderer/features/SettingsModal/GitCredentialDialog';
 import { DirectoryBrowserDialog } from '@/renderer/features/Tickets/DirectoryBrowserDialog';
 import { persistedStoreApi } from '@/renderer/services/store';
+import { duplicateSourceIdentityMessage, sourceIdentityKey } from '@/shared/project-source';
 import type { Project, ProjectSource } from '@/shared/types';
 
 import { CredentialStatus } from './CredentialStatus';
@@ -125,6 +126,12 @@ export const EditSourceDialog = memo(({ open, onClose, project, source }: EditSo
       source.kind === 'local'
         ? { id: source.id, mountName, kind: 'local', workspaceDir: path }
         : { id: source.id, mountName, kind: 'git-remote', repoUrl: path, ...(trimmedBranch ? { defaultBranch: trimmedBranch } : {}) };
+
+    const existingIdentities = new Set(project.sources.filter((s) => s.id !== source.id).map(sourceIdentityKey));
+    if (existingIdentities.has(sourceIdentityKey(next))) {
+      setError(duplicateSourceIdentityMessage(next));
+      return;
+    }
 
     setSaving(true);
     setError(null);

--- a/src/renderer/features/Projects/source-draft.ts
+++ b/src/renderer/features/Projects/source-draft.ts
@@ -5,6 +5,7 @@
  * Drafts carry the original `ProjectSource.id` when editing (so per-source
  * ticket PR state stays attached); fresh drafts get a new id at convert time.
  */
+import { validateProjectSources } from '@/shared/project-source';
 import type { ProjectSource } from '@/shared/types';
 
 export type SourceDraft = {
@@ -71,6 +72,11 @@ export function draftsToSources(
       const branch = d.defaultBranch.trim();
       sources.push({ ...baseFields, kind: 'git-remote', repoUrl: path, ...(branch ? { defaultBranch: branch } : {}) });
     }
+  }
+  try {
+    validateProjectSources(sources);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'Invalid project sources.' };
   }
   return { ok: true, sources };
 }

--- a/src/shared/project-source.test.ts
+++ b/src/shared/project-source.test.ts
@@ -3,11 +3,21 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { getLocalWorkspaceDir, hasRepo, isLocalSource, requireLocalWorkspaceDir } from '@/shared/project-source';
+import {
+  findDuplicateSourceIdentity,
+  getLocalWorkspaceDir,
+  hasRepo,
+  isLocalSource,
+  normalizeGitRemoteUrl,
+  normalizeLocalSourcePath,
+  requireLocalWorkspaceDir,
+  sourceIdentityKey,
+  validateProjectSources,
+} from '@/shared/project-source';
 import type { Project, ProjectSource } from '@/shared/types';
 
-const localSource: ProjectSource = { kind: 'local', workspaceDir: '/home/user/projects/my-app' };
-const gitSource: ProjectSource = { kind: 'git-remote', repoUrl: 'https://github.com/org/repo.git' };
+const localSource: ProjectSource = { id: 'local', mountName: 'my-app', kind: 'local', workspaceDir: '/home/user/projects/my-app' };
+const gitSource: ProjectSource = { id: 'git', mountName: 'repo', kind: 'git-remote', repoUrl: 'https://github.com/org/repo.git' };
 
 describe('getLocalWorkspaceDir', () => {
   it('returns workspaceDir for local source', () => {
@@ -53,17 +63,55 @@ describe('isLocalSource', () => {
 
 describe('hasRepo', () => {
   it('returns true when project has a source', () => {
-    const project = { source: localSource } as Project;
+    const project = { sources: [localSource] } as Project;
     expect(hasRepo(project)).toBe(true);
   });
 
   it('returns false when project has no source', () => {
-    const project = { source: undefined } as unknown as Project;
+    const project = { sources: [] } as unknown as Project;
     expect(hasRepo(project)).toBe(false);
   });
 
   it('returns false when source is null', () => {
-    const project = { source: null } as unknown as Project;
+    const project = { sources: [] } as unknown as Project;
     expect(hasRepo(project)).toBe(false);
+  });
+});
+
+describe('source identity', () => {
+  it('normalizes local paths by trimming separators and Windows casing', () => {
+    expect(normalizeLocalSourcePath(' C:\\Users\\Me\\Repo\\ ')).toBe('c:/users/me/repo');
+    expect(normalizeLocalSourcePath('/Users/Me/Repo///')).toBe('/Users/Me/Repo');
+  });
+
+  it('normalizes common Git URL spellings to the same identity', () => {
+    expect(normalizeGitRemoteUrl('https://github.com/Owner/Repo.git/')).toBe('github.com/owner/repo');
+    expect(normalizeGitRemoteUrl('git@github.com:owner/repo.git')).toBe('github.com/owner/repo');
+    expect(sourceIdentityKey({ id: 's1', mountName: 'repo', kind: 'git-remote', repoUrl: 'ssh://git@github.com/owner/repo.git' })).toBe(
+      'git-remote:github.com/owner/repo'
+    );
+  });
+
+  it('detects duplicate local source identities with different mount names', () => {
+    const duplicate = findDuplicateSourceIdentity([
+      { id: 's1', mountName: 'repo', kind: 'local', workspaceDir: '/tmp/repo' },
+      { id: 's2', mountName: 'repo-copy', kind: 'local', workspaceDir: '/tmp/repo/' },
+    ]);
+    expect(duplicate?.id).toBe('s2');
+  });
+
+  it('validates mount names and source identities independently', () => {
+    expect(() =>
+      validateProjectSources([
+        { id: 's1', mountName: 'repo', kind: 'git-remote', repoUrl: 'https://github.com/owner/repo.git' },
+        { id: 's2', mountName: 'repo-copy', kind: 'git-remote', repoUrl: 'git@github.com:owner/repo.git' },
+      ])
+    ).toThrow('already includes that repository');
+    expect(() =>
+      validateProjectSources([
+        { id: 's1', mountName: 'repo', kind: 'local', workspaceDir: '/tmp/repo-a' },
+        { id: 's2', mountName: 'repo', kind: 'local', workspaceDir: '/tmp/repo-b' },
+      ])
+    ).toThrow('Duplicate mount name');
   });
 });

--- a/src/shared/project-source.ts
+++ b/src/shared/project-source.ts
@@ -1,18 +1,80 @@
 import type { Project, ProjectSource } from '@/shared/types';
 
+const trimTrailingSlashes = (value: string): string => value.replace(/[\\/]+$/, '');
+
+export function normalizeLocalSourcePath(workspaceDir: string): string {
+  const normalized = trimTrailingSlashes(workspaceDir.trim().replace(/\\+/g, '/'));
+  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+export function normalizeGitRemoteUrl(repoUrl: string): string {
+  const trimmed = trimTrailingSlashes(repoUrl.trim()).replace(/\.git$/i, '');
+  const scpLike = trimmed.match(/^([^@\s]+)@([^:\s]+):(.+)$/);
+  const parseTarget = scpLike ? `ssh://${scpLike[1]}@${scpLike[2]}/${scpLike[3]}` : trimmed;
+
+  try {
+    const parsed = new URL(parseTarget);
+    const host = parsed.hostname.toLowerCase();
+    const pathname = trimTrailingSlashes(decodeURIComponent(parsed.pathname)).replace(/^\/+/, '').replace(/\.git$/i, '');
+    return `${host}/${pathname.toLowerCase()}`;
+  } catch {
+    return trimmed.toLowerCase();
+  }
+}
+
+export function sourceIdentityKey(source: ProjectSource): string {
+  if (source.kind === 'local') {
+    return `local:${normalizeLocalSourcePath(source.workspaceDir)}`;
+  }
+  return `git-remote:${normalizeGitRemoteUrl(source.repoUrl)}`;
+}
+
+export function duplicateSourceIdentityMessage(source: ProjectSource): string {
+  return source.kind === 'local'
+    ? 'This project already includes that local folder.'
+    : 'This project already includes that repository.';
+}
+
+export function findDuplicateSourceIdentity(sources: ProjectSource[]): ProjectSource | undefined {
+  const seen = new Set<string>();
+  for (const source of sources) {
+    const key = sourceIdentityKey(source);
+    if (seen.has(key)) {
+      return source;
+    }
+    seen.add(key);
+  }
+  return undefined;
+}
+
+export function validateProjectSources(sources: ProjectSource[]): void {
+  const seenMountNames = new Set<string>();
+  for (const source of sources) {
+    if (seenMountNames.has(source.mountName)) {
+      throw new Error(`Duplicate mount name: "${source.mountName}". Each source needs a unique name.`);
+    }
+    seenMountNames.add(source.mountName);
+  }
+
+  const duplicate = findDuplicateSourceIdentity(sources);
+  if (duplicate) {
+    throw new Error(duplicateSourceIdentityMessage(duplicate));
+  }
+}
+
 /** Extract the local workspace directory from a ProjectSource. Returns undefined for git-remote or undefined source. */
 export function getLocalWorkspaceDir(source: ProjectSource | undefined): string | undefined {
   if (source?.kind === 'local') {
-return source.workspaceDir;
-}
+    return source.workspaceDir;
+  }
   return undefined;
 }
 
 /** Assert source is local and return workspaceDir. Throws for git-remote or undefined source. */
 export function requireLocalWorkspaceDir(source: ProjectSource | undefined): string {
   if (source?.kind === 'local') {
-return source.workspaceDir;
-}
+    return source.workspaceDir;
+  }
   throw new Error(`Operation requires a local project source, but got "${source?.kind ?? 'none'}"`);
 }
 


### PR DESCRIPTION
## Summary
- Adds shared project source identity normalization for local paths and common Git URL forms.
- Blocks duplicate source identities in add/edit source dialogs before mount auto-suffixing can hide duplicates.
- Validates mount-name and source-identity uniqueness in `ProjectManager.updateProject` for non-UI callers.
- Adds focused coverage for normalization, duplicate detection, and backend persistence guards.

## Test plan
- `npm run build:packages`
- `npx vitest run src/shared/project-source.test.ts src/lib/project-manager.test.ts`
- `npx eslint src/shared/project-source.ts src/shared/project-source.test.ts src/renderer/features/Projects/source-draft.ts src/renderer/features/Projects/AddSourceDialog.tsx src/renderer/features/Projects/EditSourceDialog.tsx src/lib/project-manager-test-helpers.ts`
- `npm run lint:tsc` *(fails on pre-existing unrelated repo-wide type errors; no touched-file matches after filtering)*
