### PR TITLE
Fix launcher panel dismissal lifecycle

### DIFF
--- a/src/renderer/omniagents-ui/App.tsx
+++ b/src/renderer/omniagents-ui/App.tsx
@@ -226,6 +226,7 @@ export function App({ sessionId: sessionIdProp, onSessionChange, variables: vari
     })
     const offRunStarted = client.on('run_started', () => {
       setRunActive(true)
+      setRecap(null)
       onSessionChangeRef.current?.(actor.getSnapshot().context.sessionId)
       refreshSessions()
     })
@@ -497,7 +498,7 @@ export function App({ sessionId: sessionIdProp, onSessionChange, variables: vari
   // metadata carries a `tasks_snapshot` / `bash_jobs_snapshot` overwrites the
   // running snapshot, so the latest one wins. This makes the panels self-
   // populating on session load (history replay) without a separate listener.
-  const { tasks, derivedBashJobs } = useMemo(() => {
+  const { rawTasks, tasks, derivedBashJobs } = useMemo(() => {
     let lastTasks: TaskSummary[] = []
     let lastJobs: BashJobSummary[] = []
     for (const it of items) {
@@ -517,7 +518,7 @@ export function App({ sessionId: sessionIdProp, onSessionChange, variables: vari
     // the panel quiets down between runs.
     const liveTasks = lastTasks.filter(t => !(t.status === 'completed' && dismissedTaskIds.has(t.id)))
     const filteredTasks = runActive ? liveTasks : liveTasks.filter(t => t.status !== 'completed')
-    return { tasks: filteredTasks, derivedBashJobs: lastJobs }
+    return { rawTasks: lastTasks, tasks: filteredTasks, derivedBashJobs: lastJobs }
   }, [items, runActive, dismissedTaskIds])
 
   // Live override (from ui.bash_jobs.update broadcasts and bash_jobs.* server
@@ -590,6 +591,25 @@ export function App({ sessionId: sessionIdProp, onSessionChange, variables: vari
     }
   }, [client, sessionId])
 
+  const handleBashDismiss = useCallback((job_id: string) => {
+    setDismissedJobIds(prev => {
+      const next = new Set(prev)
+      next.add(job_id)
+      return next
+    })
+  }, [])
+
+  const handleWorkerDismiss = useCallback((worker_id: string) => {
+    setDismissedWorkerIds(prev => {
+      const next = new Set(prev)
+      next.add(worker_id)
+      return next
+    })
+  }, [])
+
+  const handleGoalDismiss = useCallback(() => setGoalSnapshot(null), [])
+  const handleWakeupDismiss = useCallback(() => setWakeupSnapshot(null), [])
+
   useEffect(() => {
     const handler = () => setIsLargeScreen(window.innerWidth >= 1024)
     window.addEventListener('resize', handler)
@@ -640,10 +660,16 @@ export function App({ sessionId: sessionIdProp, onSessionChange, variables: vari
     })
     setDismissedTaskIds(prev => {
       const next = new Set(prev)
-      for (const t of tasks) {
+      for (const t of rawTasks) {
         if (t.status === 'completed') next.add(t.id)
       }
       return next
+    })
+    setGoalSnapshot(prev => {
+      if (prev?.status === 'completed' || prev?.status === 'cancelled') {
+        return null
+      }
+      return prev
     })
 
     // Escalation reply: when the agent is paused on an ``escalate``
@@ -908,7 +934,7 @@ setWorkspaceLocked(true)
       submitError(String((e as Error)?.message || 'Failed to start run'))
       return undefined
     }
-  }, [client, sessionId, actor, bootState.actor, variablesProp, submit, submitError, workspacePath, workspaceSupported, stagedContext, clearStagedContext, runActive, queuedMessages.length, escalation, workers, liveBashJobs, derivedBashJobs, tasks])
+  }, [client, sessionId, actor, bootState.actor, variablesProp, submit, submitError, workspacePath, workspaceSupported, stagedContext, clearStagedContext, runActive, queuedMessages.length, escalation, workers, liveBashJobs, derivedBashJobs, rawTasks])
 
   const handleStop = useCallback(() => {
     if (!runId) {
@@ -1475,15 +1501,16 @@ args.text = text
                   )}
                 </AnimatePresence>
               </div>
-              <GoalPanel snapshot={goalSnapshot} />
-              <WakeupPanel snapshot={wakeupSnapshot} />
+              <GoalPanel snapshot={goalSnapshot} onDismiss={handleGoalDismiss} />
+              <WakeupPanel snapshot={wakeupSnapshot} onDismiss={handleWakeupDismiss} />
               <Tasks tasks={tasks} />
-              <WorkersPanel workers={visibleWorkers} onKill={handleWorkerKill} />
+              <WorkersPanel workers={visibleWorkers} onKill={handleWorkerKill} onDismiss={handleWorkerDismiss} />
               <BashJobs
                 jobs={bashJobs}
                 onKill={handleBashKill}
                 onTail={handleBashTail}
                 onWarmup={handleBashWarmup}
+                onDismiss={handleBashDismiss}
               />
               <QueuedMessages
                 items={queuedMessages}

--- a/src/renderer/omniagents-ui/components/BashJobs.tsx
+++ b/src/renderer/omniagents-ui/components/BashJobs.tsx
@@ -79,12 +79,13 @@ type BashJobRowProps = {
   isKilling: boolean
   onShowLogs?: (jobId: string) => void
   onKill?: (jobId: string) => void
+  onDismiss?: (jobId: string) => void
 }
 
 // One row of the docked panel. Pulled out of the parent map so the per-row
 // callbacks can use `.bind(null, jobId)` instead of inline arrows — keeps
 // `react/jsx-no-bind` satisfied without growing the parent component.
-function BashJobRow({ job, nowMs, isKilling, onShowLogs, onKill }: BashJobRowProps) {
+function BashJobRow({ job, nowMs, isKilling, onShowLogs, onKill, onDismiss }: BashJobRowProps) {
   const elapsed = formatElapsed(liveElapsedMs(job, nowMs))
   const tail = job.running ? elapsed : `exit ${job.exit_code} · ${elapsed}`
   return (
@@ -126,6 +127,17 @@ function BashJobRow({ job, nowMs, isKilling, onShowLogs, onKill }: BashJobRowPro
           {isKilling ? '…' : '✕'}
         </button>
       ) : null}
+      {onDismiss && !job.running ? (
+        <button
+          type="button"
+          onClick={onDismiss.bind(null, job.job_id)}
+          className="text-textSubtle hover:text-textPrimary transition-colors px-1.5 py-0.5 rounded hover:bg-bgCardAlt"
+          title={`Dismiss job ${job.job_id}`}
+          aria-label={`Dismiss job ${job.job_id}`}
+        >
+          dismiss
+        </button>
+      ) : null}
     </li>
   )
 }
@@ -134,13 +146,14 @@ type Props = {
   jobs: BashJobSummary[]
   onKill?: (job_id: string) => Promise<BashJobsKillResult>
   onTail?: (job_id: string, lines?: number) => Promise<BashJobsTailResult>
+  onDismiss?: (job_id: string) => void
   // Optional: fired once on mount when at least one job is running, so the
   // server-side sweeper has a chance to capture a service handle and start
   // pushing ``ui.bash_jobs.update`` broadcasts on natural exits.
   onWarmup?: () => Promise<unknown>
 }
 
-export function BashJobs({ jobs, onKill, onTail, onWarmup }: Props) {
+export function BashJobs({ jobs, onKill, onTail, onWarmup, onDismiss }: Props) {
   // 1Hz tick while at least one job is running so elapsed time updates.
   const [, setNowTick] = useState(0)
   const anyRunning = jobs.some(j => j.running)
@@ -250,6 +263,7 @@ return null
                 isKilling={killing.has(j.job_id)}
                 onShowLogs={rowShowLogs}
                 onKill={rowKill}
+                onDismiss={onDismiss}
               />
             ))}
           </ul>

--- a/src/renderer/omniagents-ui/components/GoalPanel.tsx
+++ b/src/renderer/omniagents-ui/components/GoalPanel.tsx
@@ -37,8 +37,9 @@ function dotClass(status: GoalSnapshot['status']): string {
 //   Active:    ● goal · <text>
 //   Completed: ● goal · <text> · completed
 //   Cancelled: ● goal · <text> · cancelled
-export function GoalPanel({ snapshot }: { snapshot: GoalSnapshot | null }) {
+export function GoalPanel({ snapshot, onDismiss }: { snapshot: GoalSnapshot | null; onDismiss?: () => void }) {
   if (!snapshot) return null
+  const terminal = snapshot.status === 'completed' || snapshot.status === 'cancelled'
   return (
     <div className="px-3 pt-2">
       <div className="rounded-md border border-bgCardAlt bg-bgCardAlt/60 px-2.5 py-1.5">
@@ -66,6 +67,17 @@ export function GoalPanel({ snapshot }: { snapshot: GoalSnapshot | null }) {
               {snapshot.status}
             </span>
           )}
+          {terminal && onDismiss ? (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="ml-1 text-textSubtle hover:text-textPrimary transition-colors px-1.5 py-0.5 rounded hover:bg-bgCardAlt"
+              title="Dismiss goal status"
+              aria-label="Dismiss goal status"
+            >
+              dismiss
+            </button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/renderer/omniagents-ui/components/WakeupPanel.tsx
+++ b/src/renderer/omniagents-ui/components/WakeupPanel.tsx
@@ -48,7 +48,7 @@ function dotClass(status: WakeupSnapshot['status']): string {
 //   Active recurring:  ● wakeup · <text> · every 5m · 3 fires
 //   Active one-shot:   ● wakeup · <text> · in 30s
 //   Cancelled:         ● wakeup · <text>                   cancelled
-export function WakeupPanel({ snapshot }: { snapshot: WakeupSnapshot | null }) {
+export function WakeupPanel({ snapshot, onDismiss }: { snapshot: WakeupSnapshot | null; onDismiss?: () => void }) {
   if (!snapshot) return null
 
   const tail: string[] = []
@@ -95,6 +95,17 @@ export function WakeupPanel({ snapshot }: { snapshot: WakeupSnapshot | null }) {
               {snapshot.status}
             </span>
           )}
+          {snapshot.status !== 'active' && onDismiss ? (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="ml-1 text-textSubtle hover:text-textPrimary transition-colors px-1.5 py-0.5 rounded hover:bg-bgCardAlt"
+              title="Dismiss wakeup status"
+              aria-label="Dismiss wakeup status"
+            >
+              dismiss
+            </button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/renderer/omniagents-ui/components/WorkersPanel.tsx
+++ b/src/renderer/omniagents-ui/components/WorkersPanel.tsx
@@ -62,9 +62,10 @@ type RowProps = {
   nowMs: number
   isKilling: boolean
   onKill?: (worker_id: string) => void
+  onDismiss?: (worker_id: string) => void
 }
 
-function WorkerRow({ worker, nowMs, isKilling, onKill }: RowProps) {
+function WorkerRow({ worker, nowMs, isKilling, onKill, onDismiss }: RowProps) {
   const elapsed = formatElapsed(liveElapsedMs(worker, nowMs))
   const tail = worker.status === 'running' ? elapsed : `${worker.status} · ${elapsed}`
   return (
@@ -93,6 +94,17 @@ function WorkerRow({ worker, nowMs, isKilling, onKill }: RowProps) {
           {isKilling ? '…' : '✕'}
         </button>
       ) : null}
+      {onDismiss && worker.status !== 'running' ? (
+        <button
+          type="button"
+          onClick={onDismiss.bind(null, worker.worker_id)}
+          className="text-textSubtle hover:text-textPrimary transition-colors px-1.5 py-0.5 rounded hover:bg-bgCardAlt"
+          title={`Dismiss worker ${worker.worker_id}`}
+          aria-label={`Dismiss worker ${worker.worker_id}`}
+        >
+          dismiss
+        </button>
+      ) : null}
     </li>
   )
 }
@@ -100,11 +112,12 @@ function WorkerRow({ worker, nowMs, isKilling, onKill }: RowProps) {
 type Props = {
   workers: WorkerSummary[]
   onKill?: (worker_id: string) => Promise<WorkersKillResult>
+  onDismiss?: (worker_id: string) => void
 }
 
 // Docked workers panel. Mirrors BashJobs structurally so the two stack
 // as a single visual unit. Renders nothing when there are no workers.
-export function WorkersPanel({ workers, onKill }: Props) {
+export function WorkersPanel({ workers, onKill, onDismiss }: Props) {
   const [, setNowTick] = useState(0)
   const anyRunning = workers.some(w => w.status === 'running')
   useEffect(() => {
@@ -181,6 +194,7 @@ export function WorkersPanel({ workers, onKill }: Props) {
               nowMs={nowMs}
               isKilling={killing.has(w.worker_id)}
               onKill={onKill ? handleKill : undefined}
+              onDismiss={onDismiss}
             />
           ))}
         </ul>


### PR DESCRIPTION
## Summary

- Fix completed task dismissal by tracking the raw task snapshot separately from the visible filtered task list.
- Clear stale recaps when a new launcher run starts.
- Clear terminal completed/cancelled goal chips on next submit.
- Add explicit dismiss controls for terminal Bash jobs, terminal Workers, terminal Goal snapshots, and terminal Wakeup snapshots.

## Test plan

- `git diff --check -- src/renderer/omniagents-ui/App.tsx src/renderer/omniagents-ui/components/BashJobs.tsx src/renderer/omniagents-ui/components/WorkersPanel.tsx src/renderer/omniagents-ui/components/GoalPanel.tsx src/renderer/omniagents-ui/components/WakeupPanel.tsx`
- `npm run lint:tsc -- --pretty false` *(fails on existing unrelated repository type errors, including missing `omni-projects-db` declarations and pre-existing strictness errors)*
- `npx eslint --max-warnings=0 src/renderer/omniagents-ui/App.tsx` *(fails on pre-existing lint issues in `App.tsx`)*
