### PR TITLE
Open PR links in their source code column

### DIFF
--- a/src/renderer/features/Tickets/PullRequestBadge.tsx
+++ b/src/renderer/features/Tickets/PullRequestBadge.tsx
@@ -29,9 +29,12 @@ const useStyles = makeStyles({
  * (same bridge the agent's ``browser_open`` tool uses). Shared by the ticket PR
  * overview and the per-source Files Changed view (ticket + code-tab scopes).
  */
-export const PullRequestBadge = memo(({ pr }: { pr: ContainerPullRequest }) => {
+export const PullRequestBadge = memo(({ pr, tabId }: { pr: ContainerPullRequest; tabId?: string }) => {
   const styles = useStyles();
-  const handleOpen = useCallback(() => requestPreviewOpen(pr.url), [pr.url]);
+  const handleOpen = useCallback(
+    () => (tabId === undefined ? requestPreviewOpen(pr.url) : requestPreviewOpen(pr.url, tabId)),
+    [pr.url, tabId]
+  );
   const handleKeyDown = useCallback(
     (e: ReactKeyboardEvent) => {
       if (e.key === 'Enter' || e.key === ' ') {

--- a/src/renderer/features/Tickets/PullRequestBanner.test.tsx
+++ b/src/renderer/features/Tickets/PullRequestBanner.test.tsx
@@ -1,0 +1,107 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { emitter } from '@/renderer/services/ipc';
+import type { ContainerPullRequest } from '@/shared/types';
+
+import { requestPreviewOpen } from './preview-bridge';
+import { PullRequestBanner } from './PullRequestBanner';
+
+vi.mock('@fluentui/react-components', () => ({
+  makeStyles: () => () => ({
+    banner: 'banner',
+    floating: 'floating',
+    label: 'label',
+    prBadge: 'prBadge',
+  }),
+  mergeClasses: (...classes: Array<string | false | undefined>) => classes.filter(Boolean).join(' '),
+  shorthands: {
+    border: () => ({}),
+    borderBottom: () => ({}),
+    borderLeft: () => ({}),
+  },
+  tokens: new Proxy({}, { get: (_target, prop) => String(prop) }),
+}));
+
+vi.mock('@fluentui/react-icons', () => ({
+  Open16Regular: () => <span data-testid="open-icon" />,
+}));
+
+vi.mock('@/renderer/services/ipc', () => ({
+  emitter: {
+    invoke: vi.fn(),
+  },
+}));
+
+vi.mock('./preview-bridge', () => ({
+  requestPreviewOpen: vi.fn(),
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const pullRequest: ContainerPullRequest = {
+  number: 42,
+  url: 'https://github.com/acme/app/pull/42',
+  state: 'OPEN',
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+const invokeMock = vi.mocked(emitter.invoke);
+const requestPreviewOpenMock = vi.mocked(requestPreviewOpen);
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  invokeMock.mockResolvedValue([pullRequest]);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.clearAllMocks();
+});
+
+async function renderBanner(
+  scope: { kind: 'chat' } | { kind: 'code-tab'; tabId: string }
+): Promise<HTMLSpanElement> {
+  await act(async () => {
+    root.render(<PullRequestBanner scope={scope} />);
+    await Promise.resolve();
+  });
+  const badge = container.querySelector('[role="button"]');
+  if (!badge) {
+    throw new Error('PR badge not found');
+  }
+  return badge as HTMLSpanElement;
+}
+
+describe('PullRequestBanner PR links', () => {
+  it('opens code-tab pull requests in the originating tab preview', async () => {
+    const badge = await renderBanner({ kind: 'code-tab', tabId: 'tab_123' });
+
+    act(() => {
+      badge.click();
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('project:detect-code-tab-pull-requests', 'tab_123');
+    expect(requestPreviewOpenMock).toHaveBeenCalledWith(pullRequest.url, 'tab_123');
+  });
+
+  it('keeps chat pull requests untargeted', async () => {
+    const badge = await renderBanner({ kind: 'chat' });
+
+    act(() => {
+      badge.click();
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith('project:detect-chat-pull-requests');
+    expect(requestPreviewOpenMock).toHaveBeenCalledWith(pullRequest.url);
+  });
+});

--- a/src/renderer/features/Tickets/PullRequestBanner.tsx
+++ b/src/renderer/features/Tickets/PullRequestBanner.tsx
@@ -91,11 +91,12 @@ export const PullRequestBanner = memo(
     if (prs.length === 0) {
       return null;
     }
+    const tabId = scope.kind === 'code-tab' ? scope.tabId : undefined;
     return (
       <div className={mergeClasses(styles.banner, floating && styles.floating)}>
         <span className={styles.label}>Pull request{prs.length > 1 ? 's' : ''}</span>
         {prs.map((pr) => (
-          <PullRequestBadge key={pr.url} pr={pr} />
+          <PullRequestBadge key={pr.url} pr={pr} tabId={tabId} />
         ))}
       </div>
     );


### PR DESCRIPTION
## Summary
- Preserve code deck column context when rendering pull request badges from code-tab PR banners.
- Forward the originating tab id into the preview bridge so PR links open the built-in browser in the clicked column instead of the last active column.
- Add focused regression coverage for code-tab PR links and unchanged chat PR behavior.

## Test plan
- [x] `npx vitest run src/renderer/features/Tickets/PullRequestBanner.test.tsx`
- [x] `npx eslint src/renderer/features/Tickets/PullRequestBadge.tsx src/renderer/features/Tickets/PullRequestBanner.tsx src/renderer/features/Tickets/PullRequestBanner.test.tsx`
- [ ] `npm run lint:tsc` — attempted, currently blocked by existing unrelated repo-wide type errors including missing `omni-projects-db` type declarations and pre-existing Project fixture mismatches.
