### PR TITLE
Link pull requests to project sources

### DIFF
--- a/src/lib/container-pull-request.test.ts
+++ b/src/lib/container-pull-request.test.ts
@@ -16,11 +16,13 @@ describe('parsePullRequestJson', () => {
       number: 42,
       url: 'https://github.com/acme/repo/pull/42',
       state: 'OPEN',
+      title: 'Ship source details',
     });
     expect(parsePullRequestJson(out)).toEqual({
       number: 42,
       url: 'https://github.com/acme/repo/pull/42',
       state: 'OPEN',
+      title: 'Ship source details',
     });
   });
 
@@ -124,12 +126,12 @@ describe('parseAzurePullRequestList', () => {
 describe('parsePullRequestListJson (GitHub, all open PRs)', () => {
   it('returns every open PR in the array', () => {
     const out = JSON.stringify([
-      { number: 1, url: 'https://x/pull/1', state: 'OPEN' },
+      { number: 1, url: 'https://x/pull/1', state: 'OPEN', title: 'One' },
       { number: 2, url: 'https://x/pull/2', state: 'CLOSED' },
       { number: 3, url: 'https://x/pull/3', state: 'OPEN' },
     ]);
     expect(parsePullRequestListJson(out)).toEqual([
-      { number: 1, url: 'https://x/pull/1', state: 'OPEN' },
+      { number: 1, url: 'https://x/pull/1', state: 'OPEN', title: 'One' },
       { number: 3, url: 'https://x/pull/3', state: 'OPEN' },
     ]);
   });

--- a/src/lib/container-pull-request.ts
+++ b/src/lib/container-pull-request.ts
@@ -92,11 +92,12 @@ export function isAzureDevOpsHost(host: string): boolean {
 // GitHub (pure parse + I/O)
 // ---------------------------------------------------------------------------
 
-/** Shape of the JSON ``gh pr view --json number,url,state`` returns. */
+/** Shape of the JSON ``gh pr view --json number,url,state,title`` returns. */
 interface GhPrView {
   number?: number;
   url?: string;
   state?: string;
+  title?: string;
 }
 
 /**
@@ -117,7 +118,7 @@ export function parsePullRequestJson(stdout: string): ContainerPullRequest | nul
     return null;
   }
 
-  return { number: parsed.number, url: parsed.url, state: parsed.state };
+  return { number: parsed.number, url: parsed.url, state: parsed.state, ...(parsed.title ? { title: parsed.title } : {}) };
 }
 
 /**
@@ -138,7 +139,7 @@ export function parsePullRequestListJson(stdout: string): ContainerPullRequest[]
   const out: ContainerPullRequest[] = [];
   for (const item of arr as GhPrView[]) {
     if (typeof item?.number === 'number' && typeof item.url === 'string' && item.state === 'OPEN') {
-      out.push({ number: item.number, url: item.url, state: item.state });
+      out.push({ number: item.number, url: item.url, state: item.state, ...(item.title ? { title: item.title } : {}) });
     }
   }
   return out;
@@ -242,8 +243,12 @@ async function resolveProvider(
 /** GitHub: ``gh pr view`` resolves the primary PR for the current branch. */
 async function detectGitHubPullRequest(containerId: string, mountName: string): Promise<ContainerPullRequest | null> {
   try {
-    const out = await containerExec(containerId, mountName, ['gh', 'pr', 'view', '--json', 'number,url,state']);
-    return parsePullRequestJson(out);
+    const [out, branch] = await Promise.all([
+      containerExec(containerId, mountName, ['gh', 'pr', 'view', '--json', 'number,url,state,title']),
+      containerCurrentBranch(containerId, mountName),
+    ]);
+    const pr = parsePullRequestJson(out);
+    return pr ? { ...pr, provider: 'github', ...(branch ? { branch } : {}) } : null;
   } catch {
     return null;
   }
@@ -268,9 +273,9 @@ async function detectGitHubPullRequests(containerId: string, mountName: string):
       '--state',
       'open',
       '--json',
-      'number,url,state',
+      'number,url,state,title',
     ]);
-    return parsePullRequestListJson(out);
+    return parsePullRequestListJson(out).map((pr) => ({ ...pr, provider: 'github' as const, branch }));
   } catch {
     return [];
   }
@@ -296,7 +301,7 @@ async function detectAzurePullRequestList(containerId: string, mountName: string
       'json',
       ...(branch ? ['--source-branch', branch] : []),
     ]);
-    return parseAzurePullRequestListAll(out);
+    return parseAzurePullRequestListAll(out).map((pr) => ({ ...pr, provider: 'azure' as const, ...(branch ? { branch } : {}) }));
   } catch {
     return [];
   }

--- a/src/main/db-store-bridge.ts
+++ b/src/main/db-store-bridge.ts
@@ -39,6 +39,7 @@ import type {
   Project,
   ProjectId,
   ProjectSource,
+  PullRequestLink,
   ShapingData,
   StoreData,
   Task,
@@ -158,6 +159,9 @@ export function rowToTicket(row: TicketRow, comments?: CommentRow[]): Ticket {
 
   const runs = parseJsonOr<unknown[]>(row.runs, []);
   if (runs.length > 0) ticket.runs = runs as Ticket['runs'];
+
+  const pullRequests = parseJsonOr<PullRequestLink[]>(row.pr_review, []);
+  if (Array.isArray(pullRequests) && pullRequests.length > 0) ticket.pullRequests = pullRequests;
 
   if (row.pr_merged_at) {
     try {
@@ -327,9 +331,7 @@ export function ticketToRow(t: Ticket): TicketRow {
     supervisor_task_id: (t.supervisorTaskId as string) ?? null,
     token_usage: jsonStrOrNull(t.tokenUsage),
     runs: JSON.stringify(t.runs ?? []),
-    // Legacy column — per-source review was removed with the local PR flow.
-    // Kept null so the omni-projects-db row schema stays satisfied.
-    pr_review: null,
+    pr_review: t.pullRequests && t.pullRequests.length > 0 ? JSON.stringify(t.pullRequests) : null,
     pr_merged_at: t.prMergedAt && Object.keys(t.prMergedAt).length > 0 ? JSON.stringify(t.prMergedAt) : null,
     assignee: t.assignee ?? null,
     created_at: toIso(t.createdAt),

--- a/src/main/project-manager.ts
+++ b/src/main/project-manager.ts
@@ -73,6 +73,8 @@ import type {
   PrMergeResult,
   Project,
   ProjectId,
+  ProjectSource,
+  PullRequestLink,
   StoreData,
   Task,
   Ticket,
@@ -1451,10 +1453,13 @@ export class ProjectManager {
   };
 
   /** Resolve a code tab's project + running container, or null if unavailable. */
-  private codeTabPrContext = (tabId: CodeTabId): { project: Project; containerId: string } | null => {
+  private codeTabPrContext = (tabId: CodeTabId): { project: Project; containerId: string; tab: { id: string; projectId: ProjectId | null; ticketId?: TicketId; sessionId?: string; workspaceDir?: string } } | null => {
     const tab = ((this.store.get('codeTabs') ?? []) as Array<{
       id: string;
       projectId: ProjectId | null;
+      ticketId?: TicketId;
+      sessionId?: string;
+      workspaceDir?: string;
     }>).find((t) => t.id === tabId);
     if (!tab?.projectId) {
       return null;
@@ -1467,7 +1472,58 @@ export class ProjectManager {
     if (!containerId) {
       return null;
     }
-    return { project, containerId };
+    return { project, containerId, tab };
+  };
+
+  private attachPrContext = (
+    pr: ContainerPullRequest,
+    project: Project,
+    source: ProjectSource,
+    context: { ticketId?: TicketId; codeTabId?: CodeTabId; sessionId?: string; workspaceDir?: string }
+  ): ContainerPullRequest => ({
+    ...pr,
+    projectId: project.id,
+    sourceId: source.id,
+    sourceMountName: source.mountName,
+    ...context,
+  });
+
+  private persistTicketPullRequests = (ticketId: TicketId | undefined, prs: ContainerPullRequest[]): void => {
+    if (!ticketId || prs.length === 0) {
+      return;
+    }
+    const ticket = this.getTicketById(ticketId);
+    if (!ticket) {
+      return;
+    }
+    const now = Date.now();
+    const byKey = new Map((ticket.pullRequests ?? []).map((link) => [`${link.sourceId}:${link.url}`, link]));
+    for (const pr of prs) {
+      if (!pr.projectId || !pr.sourceId || !pr.sourceMountName) {
+        continue;
+      }
+      const key = `${pr.sourceId}:${pr.url}`;
+      const existing = byKey.get(key);
+      const link: PullRequestLink = {
+        ...(existing ?? { createdAt: now }),
+        url: pr.url,
+        number: pr.number,
+        state: pr.state,
+        projectId: pr.projectId,
+        sourceId: pr.sourceId,
+        sourceMountName: pr.sourceMountName,
+        ...(pr.provider ? { provider: pr.provider } : {}),
+        ...(pr.branch ? { branch: pr.branch } : {}),
+        ...(pr.title ? { title: pr.title } : {}),
+        ticketId,
+        ...(pr.codeTabId ? { codeTabId: pr.codeTabId } : {}),
+        ...(pr.sessionId ? { sessionId: pr.sessionId } : {}),
+        ...(pr.workspaceDir ? { workspaceDir: pr.workspaceDir } : {}),
+        lastSeenAt: now,
+      };
+      byKey.set(key, link);
+    }
+    this.updateTicket(ticketId, { pullRequests: [...byKey.values()] });
   };
 
   /**
@@ -1484,7 +1540,18 @@ export class ProjectManager {
     if (!ctx || !source) {
       return null;
     }
-    return detectContainerPullRequest(ctx.containerId, source.mountName);
+    const pr = await detectContainerPullRequest(ctx.containerId, source.mountName);
+    if (!pr) {
+      return null;
+    }
+    const enriched = this.attachPrContext(pr, ctx.project, source, {
+      ticketId: ctx.tab.ticketId,
+      codeTabId: tabId,
+      sessionId: ctx.tab.sessionId,
+      workspaceDir: ctx.tab.workspaceDir,
+    });
+    this.persistTicketPullRequests(ctx.tab.ticketId, [enriched]);
+    return enriched;
   };
 
   /**
@@ -1499,8 +1566,17 @@ export class ProjectManager {
     }
     const found: ContainerPullRequest[] = [];
     for (const source of ctx.project.sources) {
-      found.push(...(await detectContainerPullRequests(ctx.containerId, source.mountName)));
+      const prs = (await detectContainerPullRequests(ctx.containerId, source.mountName)).map((pr) =>
+        this.attachPrContext(pr, ctx.project, source, {
+          ticketId: ctx.tab.ticketId,
+          codeTabId: tabId,
+          sessionId: ctx.tab.sessionId,
+          workspaceDir: ctx.tab.workspaceDir,
+        })
+      );
+      found.push(...prs);
     }
+    this.persistTicketPullRequests(ctx.tab.ticketId, found);
     return found;
   };
 
@@ -1636,7 +1712,12 @@ export class ProjectManager {
       return null;
     }
     const pr = await detectContainerPullRequest(containerId, source.mountName);
-    return pr;
+    if (!pr) {
+      return null;
+    }
+    const enriched = this.attachPrContext(pr, project, source, { ticketId });
+    this.persistTicketPullRequests(ticketId, [enriched]);
+    return enriched;
   };
 
   // #endregion

--- a/src/renderer/features/Projects/SourceDetailDialog.tsx
+++ b/src/renderer/features/Projects/SourceDetailDialog.tsx
@@ -1,0 +1,231 @@
+import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
+import { Open16Regular } from '@fluentui/react-icons';
+import { memo, useCallback, useMemo } from 'react';
+
+import { AnimatedDialog, Button, DialogBody, DialogContent, DialogFooter, DialogHeader } from '@/renderer/ds';
+import { requestPreviewOpen } from '@/renderer/features/Tickets/preview-bridge';
+import { ticketApi } from '@/renderer/features/Tickets/state';
+import type { Project, ProjectSource, PullRequestLink, Ticket } from '@/shared/types';
+
+const useStyles = makeStyles({
+  body: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalM,
+  },
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalXS,
+  },
+  sectionTitle: {
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground3,
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+  },
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalS,
+    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground2,
+    padding: tokens.spacingVerticalM,
+  },
+  row: {
+    display: 'grid',
+    gridTemplateColumns: '96px minmax(0, 1fr)',
+    gap: tokens.spacingHorizontalM,
+    alignItems: 'baseline',
+  },
+  key: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  value: {
+    minWidth: 0,
+    overflowWrap: 'anywhere',
+    color: tokens.colorNeutralForeground1,
+    fontSize: tokens.fontSizeBase300,
+  },
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: tokens.spacingHorizontalM,
+  },
+  itemText: {
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  itemTitle: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    color: tokens.colorNeutralForeground1,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  itemMeta: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  footer: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  footerGroup: {
+    display: 'flex',
+    gap: tokens.spacingHorizontalS,
+  },
+});
+
+type SourceDetailDialogProps = {
+  open: boolean;
+  onClose: () => void;
+  project: Project;
+  source: ProjectSource;
+  tickets: Ticket[];
+  onEdit: () => void;
+  onRemove: () => void;
+};
+
+const sourceLocation = (source: ProjectSource): string =>
+  source.kind === 'local' ? source.workspaceDir : source.repoUrl;
+
+export const SourceDetailDialog = memo(({ open, onClose, project, source, tickets, onEdit, onRemove }: SourceDetailDialogProps) => {
+  const styles = useStyles();
+  const relatedTickets = useMemo(
+    () => tickets.filter((ticket) => ticket.projectId === project.id && ticket.pullRequests?.some((pr) => pr.sourceId === source.id)),
+    [project.id, source.id, tickets]
+  );
+  const pullRequests = useMemo(() => {
+    const byUrl = new Map<string, PullRequestLink>();
+    for (const ticket of tickets) {
+      if (ticket.projectId !== project.id) {
+        continue;
+      }
+      for (const pr of ticket.pullRequests ?? []) {
+        if (pr.sourceId === source.id) {
+          byUrl.set(pr.url, pr);
+        }
+      }
+    }
+    return [...byUrl.values()].sort((a, b) => b.lastSeenAt - a.lastSeenAt);
+  }, [project.id, source.id, tickets]);
+
+  const handleOpenPullRequest = useCallback((url: string) => requestPreviewOpen(url), []);
+  const handleOpenTicket = useCallback((ticketId: string) => ticketApi.goToTicket(ticketId), []);
+
+  return (
+    <AnimatedDialog open={open} onClose={onClose}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>{source.mountName}</DialogHeader>
+        <DialogBody className={styles.body}>
+          <div className={styles.section}>
+            <span className={styles.sectionTitle}>Source</span>
+            <div className={styles.panel}>
+              <div className={styles.row}>
+                <span className={styles.key}>Kind</span>
+                <span className={styles.value}>{source.kind}</span>
+              </div>
+              <div className={styles.row}>
+                <span className={styles.key}>Location</span>
+                <span className={styles.value}>{sourceLocation(source)}</span>
+              </div>
+              <div className={styles.row}>
+                <span className={styles.key}>Mount</span>
+                <span className={styles.value}>/workspace/{source.mountName}</span>
+              </div>
+              {source.kind === 'git-remote' && source.defaultBranch && (
+                <div className={styles.row}>
+                  <span className={styles.key}>Branch</span>
+                  <span className={styles.value}>{source.defaultBranch}</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className={styles.section}>
+            <span className={styles.sectionTitle}>Pull Requests</span>
+            <div className={styles.panel}>
+              {pullRequests.length === 0 ? (
+                <span className={styles.empty}>No pull requests linked to this source yet.</span>
+              ) : (
+                pullRequests.map((pr) => (
+                  <PullRequestRow key={pr.url} pullRequest={pr} onOpen={handleOpenPullRequest} />
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className={styles.section}>
+            <span className={styles.sectionTitle}>Linked Tickets</span>
+            <div className={styles.panel}>
+              {relatedTickets.length === 0 ? (
+                <span className={styles.empty}>No tickets have linked PRs for this source.</span>
+              ) : (
+                relatedTickets.map((ticket) => (
+                  <TicketRow key={ticket.id} ticket={ticket} onOpen={handleOpenTicket} />
+                ))
+              )}
+            </div>
+          </div>
+        </DialogBody>
+        <DialogFooter className={styles.footer}>
+          <Button variant="ghost" onClick={onClose}>Close</Button>
+          <div className={styles.footerGroup}>
+            <Button variant="ghost" onClick={onEdit}>Edit</Button>
+            <Button variant="destructive" onClick={onRemove}>Remove</Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </AnimatedDialog>
+  );
+});
+SourceDetailDialog.displayName = 'SourceDetailDialog';
+
+const PullRequestRow = memo(({ pullRequest, onOpen }: { pullRequest: PullRequestLink; onOpen: (url: string) => void }) => {
+  const styles = useStyles();
+  const handleOpen = useCallback(() => onOpen(pullRequest.url), [onOpen, pullRequest.url]);
+  return (
+    <div className={styles.item}>
+      <div className={styles.itemText}>
+        <span className={styles.itemTitle}>{pullRequest.title || `PR #${pullRequest.number}`}</span>
+        <span className={styles.itemMeta}>
+          PR #{pullRequest.number}{pullRequest.branch ? ` · ${pullRequest.branch}` : ''}
+          {pullRequest.sessionId ? ` · session ${pullRequest.sessionId.slice(0, 8)}` : ''} · seen{' '}
+          {new Date(pullRequest.lastSeenAt).toLocaleString()}
+        </span>
+      </div>
+      <Button size="sm" variant="ghost" leftIcon={<Open16Regular />} onClick={handleOpen}>
+        Open
+      </Button>
+    </div>
+  );
+});
+PullRequestRow.displayName = 'PullRequestRow';
+
+const TicketRow = memo(({ ticket, onOpen }: { ticket: Ticket; onOpen: (ticketId: string) => void }) => {
+  const styles = useStyles();
+  const handleOpen = useCallback(() => onOpen(ticket.id), [onOpen, ticket.id]);
+  return (
+    <div className={styles.item}>
+      <div className={styles.itemText}>
+        <span className={styles.itemTitle}>{ticket.title}</span>
+        <span className={styles.itemMeta}>{ticket.phase || ticket.priority}</span>
+      </div>
+      <Button size="sm" variant="ghost" onClick={handleOpen}>
+        Open
+      </Button>
+    </div>
+  );
+});
+TicketRow.displayName = 'TicketRow';

--- a/src/renderer/features/Tickets/PullRequestBadge.tsx
+++ b/src/renderer/features/Tickets/PullRequestBadge.tsx
@@ -31,6 +31,8 @@ const useStyles = makeStyles({
  */
 export const PullRequestBadge = memo(({ pr, tabId }: { pr: ContainerPullRequest; tabId?: string }) => {
   const styles = useStyles();
+  const label = pr.sourceMountName ? `${pr.sourceMountName} · PR #${pr.number}` : `PR #${pr.number}`;
+  const title = [pr.title, pr.sourceMountName, pr.branch, pr.url].filter(Boolean).join(' · ');
   const handleOpen = useCallback(
     () => (tabId === undefined ? requestPreviewOpen(pr.url) : requestPreviewOpen(pr.url, tabId)),
     [pr.url, tabId]
@@ -49,12 +51,12 @@ export const PullRequestBadge = memo(({ pr, tabId }: { pr: ContainerPullRequest;
       role="button"
       tabIndex={0}
       className={styles.prBadge}
-      title={pr.url}
+      title={title || pr.url}
       onClick={handleOpen}
       onKeyDown={handleKeyDown}
     >
       <Open16Regular />
-      PR #{pr.number}
+      {label}
     </span>
   );
 });

--- a/src/renderer/features/Tickets/PullRequestBanner.test.tsx
+++ b/src/renderer/features/Tickets/PullRequestBanner.test.tsx
@@ -45,6 +45,7 @@ const pullRequest: ContainerPullRequest = {
   number: 42,
   url: 'https://github.com/acme/app/pull/42',
   state: 'OPEN',
+  sourceMountName: 'omni-desktop',
 };
 
 let container: HTMLDivElement;
@@ -85,6 +86,8 @@ async function renderBanner(
 describe('PullRequestBanner PR links', () => {
   it('opens code-tab pull requests in the originating tab preview', async () => {
     const badge = await renderBanner({ kind: 'code-tab', tabId: 'tab_123' });
+
+    expect(badge.textContent).toContain('omni-desktop · PR #42');
 
     act(() => {
       badge.click();

--- a/src/renderer/features/Tickets/Sidebar.tsx
+++ b/src/renderer/features/Tickets/Sidebar.tsx
@@ -34,6 +34,7 @@ import { $milestones, milestoneApi } from '@/renderer/features/Initiatives/state
 import { $pages, pageApi } from '@/renderer/features/Pages/state';
 import { AddSourceDialog } from '@/renderer/features/Projects/AddSourceDialog';
 import { EditSourceDialog } from '@/renderer/features/Projects/EditSourceDialog';
+import { SourceDetailDialog } from '@/renderer/features/Projects/SourceDetailDialog';
 import { TeamSwitcher } from '@/renderer/features/Teams/TeamSwitcher';
 import { persistedStoreApi } from '@/renderer/services/store';
 import type { Milestone } from '@/shared/types';
@@ -190,6 +191,7 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
   const [editingMilestone, setEditingMilestone] = useState<Milestone | null>(null);
   const [addSourceProjectId, setAddSourceProjectId] = useState<string | null>(null);
   const [editSource, setEditSource] = useState<{ projectId: string; sourceId: string } | null>(null);
+  const [sourceDetail, setSourceDetail] = useState<{ projectId: string; sourceId: string } | null>(null);
   const [projectsOpen, setProjectsOpen] = useState(true);
 
   const projects = store.projects;
@@ -197,6 +199,8 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
   const addSourceProject = projects.find((p) => p.id === addSourceProjectId);
   const editSourceProject = editSource ? projects.find((p) => p.id === editSource.projectId) : undefined;
   const editSourceSource = editSourceProject?.sources.find((s) => s.id === editSource?.sourceId);
+  const sourceDetailProject = sourceDetail ? projects.find((p) => p.id === sourceDetail.projectId) : undefined;
+  const sourceDetailSource = sourceDetailProject?.sources.find((s) => s.id === sourceDetail?.sourceId);
 
   const handleOpenForm = useCallback(() => setFormOpen(true), []);
   const handleCloseForm = useCallback(() => setFormOpen(false), []);
@@ -208,6 +212,8 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
   }, []);
   const handleAddSource = useCallback((projectId: string) => setAddSourceProjectId(projectId), []);
   const handleCloseAddSource = useCallback(() => setAddSourceProjectId(null), []);
+  const handleOpenSource = useCallback((projectId: string, sourceId: string) => setSourceDetail({ projectId, sourceId }), []);
+  const handleCloseSource = useCallback(() => setSourceDetail(null), []);
   const handleEditSource = useCallback(
     (projectId: string, sourceId: string) => setEditSource({ projectId, sourceId }),
     []
@@ -223,6 +229,20 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
     },
     [projects]
   );
+  const handleEditSourceFromDetail = useCallback(() => {
+    if (!sourceDetail) {
+      return;
+    }
+    setEditSource(sourceDetail);
+    setSourceDetail(null);
+  }, [sourceDetail]);
+  const handleRemoveSourceFromDetail = useCallback(() => {
+    if (!sourceDetail) {
+      return;
+    }
+    handleRemoveSource(sourceDetail.projectId, sourceDetail.sourceId);
+    setSourceDetail(null);
+  }, [handleRemoveSource, sourceDetail]);
   const toggleProjects = useCallback(() => setProjectsOpen((v) => !v), []);
   const handleOpenChange = useCallback(
     (_event: unknown, data: { open: boolean }) => {
@@ -269,10 +289,15 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
         ticketApi.goToMilestone(milestoneId, projectId);
       } else if (val.startsWith('ticket:')) {
         ticketApi.goToTicket(val.slice(7));
+      } else if (val.startsWith('source:')) {
+        const [, projectId, sourceId] = val.split(':');
+        if (projectId && sourceId) {
+          handleOpenSource(projectId, sourceId);
+        }
       }
       onNavigate?.();
     },
-    [onNavigate]
+    [handleOpenSource, onNavigate]
   );
 
   const activeInbox = useStore($activeInbox);
@@ -331,6 +356,7 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
               onCreateMilestone={handleCreateMilestone}
               onEditMilestone={handleEditMilestone}
               onAddSource={handleAddSource}
+              onOpenSource={handleOpenSource}
               onEditSource={handleEditSource}
               onRemoveSource={handleRemoveSource}
             />
@@ -339,6 +365,17 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
 
       <ProjectForm open={formOpen} onClose={handleCloseForm} />
       {addSourceProject && <AddSourceDialog open onClose={handleCloseAddSource} project={addSourceProject} />}
+      {sourceDetailProject && sourceDetailSource && (
+        <SourceDetailDialog
+          open
+          onClose={handleCloseSource}
+          project={sourceDetailProject}
+          source={sourceDetailSource}
+          tickets={Object.values(tickets)}
+          onEdit={handleEditSourceFromDetail}
+          onRemove={handleRemoveSourceFromDetail}
+        />
+      )}
       {editSourceProject && editSourceSource && (
         <EditSourceDialog
           open

--- a/src/renderer/features/Tickets/SidebarTree.tsx
+++ b/src/renderer/features/Tickets/SidebarTree.tsx
@@ -352,6 +352,8 @@ type SidebarTreeProps = {
   onEditMilestone?: (milestone: Milestone) => void;
   /** Called when user requests to add a source to a project. */
   onAddSource?: (projectId: ProjectId) => void;
+  /** Called when user opens source details. */
+  onOpenSource?: (projectId: ProjectId, sourceId: string) => void;
   /** Called when user requests to edit an existing source. */
   onEditSource?: (projectId: ProjectId, sourceId: string) => void;
   /** Called when user requests to remove a source from a project. */
@@ -618,6 +620,7 @@ export const SidebarTree = memo(
     onCreateMilestone,
     onEditMilestone,
     onAddSource,
+    onOpenSource,
     onEditSource,
     onRemoveSource,
   }: SidebarTreeProps) => {
@@ -1235,6 +1238,7 @@ export const SidebarTree = memo(
                             className={styles.hoverableItem}
                           >
                             <TreeItemLayout
+                              onClick={() => onOpenSource?.(project.id, s.id)}
                               iconBefore={
                                 isLocal ? (
                                   <Link16Regular className={styles.icon} />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1489,6 +1489,24 @@ export type TicketRun = {
   tokenUsage?: TokenUsage;
 };
 
+export type PullRequestLink = {
+  url: string;
+  number: number;
+  state: string;
+  projectId: ProjectId;
+  sourceId: string;
+  sourceMountName: string;
+  provider?: 'github' | 'azure';
+  branch?: string;
+  title?: string;
+  ticketId?: TicketId;
+  codeTabId?: CodeTabId;
+  sessionId?: string;
+  workspaceDir?: string;
+  createdAt: number;
+  lastSeenAt: number;
+};
+
 export type Ticket = {
   id: TicketId;
   projectId: ProjectId;
@@ -1562,6 +1580,7 @@ export type Ticket = {
   assignee?: string;
   /** History of supervisor runs on this ticket. */
   runs?: TicketRun[];
+  pullRequests?: PullRequestLink[];
   /** Populated by the seed script; tracked in seed-manifest for reset. */
   seedKey?: string;
 };
@@ -1681,8 +1700,17 @@ export type PrMergeResult = { ok: true; mergeCommitSha: string } | { ok: false; 
 export interface ContainerPullRequest {
   number: number;
   url: string;
-  /** GitHub PR state, e.g. ``"OPEN"``. We only surface OPEN PRs. */
   state: string;
+  title?: string;
+  sourceId?: string;
+  sourceMountName?: string;
+  projectId?: ProjectId;
+  ticketId?: TicketId;
+  codeTabId?: CodeTabId;
+  sessionId?: string;
+  workspaceDir?: string;
+  provider?: 'github' | 'azure';
+  branch?: string;
 }
 
 // #endregion


### PR DESCRIPTION
## Summary
- Persist detected pull requests with project source, ticket, session, provider, branch, and timestamp context.
- Keep the PR banner lean by rendering compact source-aware badges instead of larger cards.
- Add a source detail modal from the project sidebar with source metadata, linked PRs, and linked tickets.

## Validation
- [x] `npx vitest run src/lib/container-pull-request.test.ts src/renderer/features/Tickets/PullRequestBanner.test.tsx --run`
- [x] `npx eslint src/renderer/features/Projects/SourceDetailDialog.tsx src/renderer/features/Tickets/PullRequestBadge.tsx src/renderer/features/Tickets/PullRequestBanner.test.tsx src/lib/container-pull-request.test.ts src/renderer/features/Tickets/Sidebar.tsx`
- [x] Verified in Electron/VNC with a seeded project and git repo source.

## Notes
- This PR targets `feat/merge-seed-data` because it builds on the existing launcher seed-data branch.
