### PR TITLE
Clear stale sandbox container ids on session change

### DIFF
--- a/src/renderer/features/Chat/Chat.tsx
+++ b/src/renderer/features/Chat/Chat.tsx
@@ -221,7 +221,12 @@ export const Chat = memo(() => {
 
   const chatSessionId = store.chatSessionId ?? undefined;
   const handleSessionChange = useCallback((sessionId: string | undefined) => {
-    persistedStoreApi.setKey('chatSessionId', sessionId ?? null);
+    const previous = persistedStoreApi.getKey('chatSessionId') ?? null;
+    const next = sessionId ?? null;
+    if (previous !== next) {
+      void persistedStoreApi.setKey('chatContainerId', null);
+    }
+    persistedStoreApi.setKey('chatSessionId', next);
   }, []);
 
   // Every chat goes through `omni serve` after the v22 cut — the JSON-RPC

--- a/src/renderer/features/Code/state.test.ts
+++ b/src/renderer/features/Code/state.test.ts
@@ -151,6 +151,25 @@ describe('code tab sandbox profile resolution', () => {
     expect(store.codeTabs[0]?.containerId).toBeUndefined();
   });
 
+  it('clears stale container id when session id changes', async () => {
+    resetStore({ codeTabs: [tab({ sessionId: 'session-1', containerId: 'old-container' })] });
+    const { codeApi } = await import('./state');
+
+    await codeApi.setTabSessionId('tab-1', 'session-2');
+
+    expect(store.codeTabs[0]).toMatchObject({ sessionId: 'session-2' });
+    expect(store.codeTabs[0]?.containerId).toBeUndefined();
+  });
+
+  it('preserves container id when session id is unchanged', async () => {
+    resetStore({ codeTabs: [tab({ sessionId: 'session-1', containerId: 'container-1' })] });
+    const { codeApi } = await import('./state');
+
+    await codeApi.setTabSessionId('tab-1', 'session-1');
+
+    expect(store.codeTabs[0]).toMatchObject({ sessionId: 'session-1', containerId: 'container-1' });
+  });
+
   it('sets created projects on the setup tab without replacing a one-off sandbox', async () => {
     resetStore({
       defaultProfileName: 'host',

--- a/src/renderer/features/Code/state.ts
+++ b/src/renderer/features/Code/state.ts
@@ -204,7 +204,17 @@ export const codeApi = {
   },
 
   setTabSessionId: async (tabId: CodeTabId, sessionId: string | undefined) => {
-    const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) => (t.id === tabId ? { ...t, sessionId } : t));
+    const tabs = (persistedStoreApi.getKey('codeTabs') ?? []).map((t) => {
+      if (t.id !== tabId) {
+        return t;
+      }
+      if ((t.sessionId ?? undefined) === sessionId) {
+        return { ...t, sessionId };
+      }
+      const { containerId: _drop, ...rest } = t;
+      void _drop;
+      return { ...rest, sessionId };
+    });
     await persistedStoreApi.setKey('codeTabs', tabs);
   },
 


### PR DESCRIPTION
## Summary
- Clear `chatContainerId` when the active chat session changes.
- Clear code-tab `containerId` when a tab's `sessionId` changes.
- Add code-tab tests for same-session preservation and changed-session clearing.

## Rationale
Warm Docker resume should only reuse containers for the same logical session. If a user starts a new chat or a tab changes sessions, the launcher should not pass a stale container id to `omni serve`.

## Testing
- `npm test -- --run src/renderer/features/Code/state.test.ts src/main/agent-process.test.ts`
