### PR TITLE
Fix Teams webview auth loop

### DIFF
--- a/src/main/app-control-manager.ts
+++ b/src/main/app-control-manager.ts
@@ -10,7 +10,7 @@
  * Per the Phase-2 design, everything is Electron-only. Screenshot/console
  * use Electron APIs directly; snapshot/click/fill use CDP via `wc.debugger`.
  */
-import { ipcMain, webContents as webContentsNS } from 'electron';
+import { ipcMain, shell, webContents as webContentsNS } from 'electron';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -188,14 +188,12 @@ export class AppControlManager {
   // -- popup handler ------------------------------------------------------
 
   /**
-   * Install `setWindowOpenHandler` on a browser-kind webContents so
-   * `window.open` and `target="_blank"` create a new tab in the same tabset
-   * instead of opening a native OS window. Idempotent per webContents via
-   * the `popupHandlerInstalled` flag.
+   * Install `setWindowOpenHandler` on controllable webContents so popups are
+   * either routed into browser tabs or handed to the user's default browser.
+   * Idempotent per webContents via the `popupHandlerInstalled` flag.
    */
   private attachPopupHandler(entry: AppEntry): void {
-    const tabsetId = entry.registration.browserTabsetId;
-    if (!tabsetId || entry.popupHandlerInstalled || !this.onBrowserPopup) {
+    if (entry.popupHandlerInstalled) {
       return;
     }
     if (entry.webContentsId === undefined) {
@@ -205,9 +203,17 @@ export class AppControlManager {
     if (!wc || wc.isDestroyed()) {
       return;
     }
+    const tabsetId = entry.registration.browserTabsetId;
+    if (!tabsetId && entry.registration.kind !== 'webview') {
+      return;
+    }
     const onPopup = this.onBrowserPopup;
     wc.setWindowOpenHandler((details) => {
-      onPopup(tabsetId, details.url, details.disposition);
+      if (tabsetId && onPopup) {
+        onPopup(tabsetId, details.url, details.disposition);
+      } else {
+        void shell.openExternal(details.url);
+      }
       return { action: 'deny' };
     });
     entry.popupHandlerInstalled = true;

--- a/src/renderer/common/Webview.tsx
+++ b/src/renderer/common/Webview.tsx
@@ -15,6 +15,18 @@ import { isControllableKind } from '@/shared/app-control-types';
 
 const isElectron = typeof window !== 'undefined' && 'electron' in window;
 
+const embeddedUserAgent = (() => {
+  if (typeof navigator === 'undefined') {
+    return undefined;
+  }
+  const normalized = navigator.userAgent
+    .replace(/\s+Electron\/\S+/g, '')
+    .replace(/\s+omni-desktop\/\S+/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+  return normalized || undefined;
+})();
+
 /**
  * Metadata a surface passes to `<Webview>` so it can self-register with the
  * app-control registry. Omit to opt out (e.g. transient previews).
@@ -737,6 +749,7 @@ return;
         key={`${partition ?? 'default'}:${reloadNonce}`}
         ref={callbackRef}
         src={src}
+        useragent={embeddedUserAgent}
         {...(partition ? { partition } : {})}
         style={{ width: '100%', height: '100%' }}
       />

--- a/src/renderer/webview.d.ts
+++ b/src/renderer/webview.d.ts
@@ -5,6 +5,8 @@ declare global {
     interface IntrinsicElements {
       webview: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
         src?: string;
+        partition?: string;
+        useragent?: string;
       };
     }
   }


### PR DESCRIPTION
## Summary
- Strip Electron-specific tokens from embedded webview user agents so Teams receives a browser-like UA.
- Route custom webview popups to the user's default browser while preserving built-in browser popup-to-tab behavior.
- Add webview intrinsic typings for `partition` and `useragent`.

## Why
Teams v2 detects Electron and repeatedly opens MSAL auth popups. Those popups hit COOP restrictions and cannot close cleanly, causing a redirect/reload-like loop. This hardens both sides: avoid triggering the Electron-specific path and contain any popups that still occur.

## Validation
- `npm run lint:tsc` was run after `npm install`.
- Typecheck still fails on existing unrelated repo issues, including missing `omni-projects-db` declarations and existing strictness/type drift in tests and UI components.
