### PR TITLE
Add core user workflow E2E coverage

### DIFF
--- a/packages/projects-db/src/defaults.ts
+++ b/packages/projects-db/src/defaults.ts
@@ -28,8 +28,8 @@ export const DEFAULT_COLUMNS: ColumnDef[] = [
 
 export const SIMPLE_COLUMNS: ColumnDef[] = [
   { logicalId: 'backlog', label: 'Backlog' },
-  { logicalId: 'active', label: 'Active' },
-  { logicalId: 'done', label: 'Done' },
+  { logicalId: 'review', label: 'Review', gate: true },
+  { logicalId: 'completed', label: 'Completed' },
 ];
 
 /**
@@ -37,8 +37,7 @@ export const SIMPLE_COLUMNS: ColumnDef[] = [
  * logical id. Format: `${projectId}__${logicalId}`. Globally unique because
  * project IDs are themselves unique.
  */
-export const defaultColumnId = (projectId: string, logicalId: string): string =>
-  `${projectId}__${logicalId}`;
+export const defaultColumnId = (projectId: string, logicalId: string): string => `${projectId}__${logicalId}`;
 
 /**
  * Inverse of `defaultColumnId` — extract the logical id portion. Returns

--- a/src/lib/project-manager.test.ts
+++ b/src/lib/project-manager.test.ts
@@ -583,10 +583,12 @@ describe('ProjectManager', () => {
       store.set('projects', projects);
 
       const pipeline = pm.getPipeline('proj-1');
-      // SIMPLE_PIPELINE has 3 columns: backlog, in_progress, done
+      // SIMPLE_PIPELINE has 3 columns: backlog, review, completed
       expect(pipeline.columns).toHaveLength(3);
       expect(pipeline.columns[0]!.id).toBe('backlog');
-      expect(pipeline.columns[2]!.id).toBe('done');
+      expect(pipeline.columns[1]!.id).toBe('review');
+      expect(pipeline.columns[1]!.gate).toBe(true);
+      expect(pipeline.columns[2]!.id).toBe('completed');
     });
 
     it('falls back to DEFAULT_PIPELINE for projects with a source but no pipeline', () => {

--- a/src/lib/resolve-pipeline-defs.test.ts
+++ b/src/lib/resolve-pipeline-defs.test.ts
@@ -42,14 +42,7 @@ describe('resolvePipelineDefs', () => {
       workflow: null,
     });
     expect(defs).not.toBeNull();
-    expect(defs!.map((d) => d.logicalId)).toEqual([
-      'backlog',
-      'spec',
-      'implementation',
-      'review',
-      'pr',
-      'completed',
-    ]);
+    expect(defs!.map((d) => d.logicalId)).toEqual(['backlog', 'spec', 'implementation', 'review', 'pr', 'completed']);
     expect(defs!.find((d) => d.logicalId === 'review')!.gate).toBe(true);
   });
 
@@ -59,13 +52,12 @@ describe('resolvePipelineDefs', () => {
       hasExisting: false,
       workflow: null,
     });
-    expect(defs!.map((d) => d.logicalId)).toEqual(['backlog', 'active', 'done']);
+    expect(defs!.map((d) => d.logicalId)).toEqual(['backlog', 'review', 'completed']);
+    expect(defs!.find((d) => d.logicalId === 'review')!.gate).toBe(true);
   });
 
   it('returns null when SQLite has columns and FLEET.md is absent — leaves existing rows alone', () => {
-    expect(
-      resolvePipelineDefs({ hasSource: true, hasExisting: true, workflow: null })
-    ).toBeNull();
+    expect(resolvePipelineDefs({ hasSource: true, hasExisting: true, workflow: null })).toBeNull();
   });
 
   it('returns null when SQLite has columns and FLEET.md has no pipeline section', () => {

--- a/src/renderer/features/Inbox/InboxView.tsx
+++ b/src/renderer/features/Inbox/InboxView.tsx
@@ -154,8 +154,7 @@ export const InboxView = memo(
     const visible = tab === 'active' ? active : tab === 'later' ? later : promoted;
 
     useEffect(() => {
-      if (!selectedItemId) {
-        setSelectedId(null);
+      if (selectedItemId === undefined) {
         return;
       }
 
@@ -174,6 +173,19 @@ export const InboxView = memo(
       }
       setTab('active');
     }, [selectedItemId, itemsById]);
+
+    useEffect(() => {
+      if (!selectedItem || selectedItemId !== undefined) {
+        return;
+      }
+      if (selectedItem.promotedTo) {
+        setTab('archive');
+      } else if (selectedItem.status === 'later') {
+        setTab('later');
+      } else {
+        setTab('active');
+      }
+    }, [selectedItem, selectedItemId]);
 
     const handleBack = useCallback(() => {
       if (selectedItemId) {

--- a/src/renderer/features/Inbox/QuickCapture.tsx
+++ b/src/renderer/features/Inbox/QuickCapture.tsx
@@ -1,9 +1,9 @@
-import { makeStyles, mergeClasses, shorthands,tokens } from '@fluentui/react-components';
+import { makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
 import { ArrowUp20Regular, MailInbox20Regular } from '@fluentui/react-icons';
 import { useStore } from '@nanostores/react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { atom } from 'nanostores';
-import { memo, useCallback, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { inboxApi } from '@/renderer/features/Inbox/state';
@@ -34,7 +34,10 @@ const useStyles = makeStyles({
     transitionProperty: 'border-color, background-color',
     transitionDuration: '200ms',
   },
-  desktopCardDefault: { ...shorthands.borderColor(tokens.colorNeutralStroke1), backgroundColor: tokens.colorNeutralBackground2 },
+  desktopCardDefault: {
+    ...shorthands.borderColor(tokens.colorNeutralStroke1),
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
   desktopCardFlash: { ...shorthands.borderColor('rgba(34, 197, 94, 0.5)'), backgroundColor: 'rgba(6, 78, 59, 0.3)' },
   desktopHeader: {
     display: 'flex',
@@ -47,7 +50,11 @@ const useStyles = makeStyles({
     ...shorthands.borderBottom('1px', 'solid', tokens.colorNeutralStroke1),
   },
   captureIcon: { color: tokens.colorBrandForeground1, flexShrink: 0 },
-  captureTitle: { fontSize: tokens.fontSizeBase300, fontWeight: tokens.fontWeightMedium, color: tokens.colorNeutralForeground1 },
+  captureTitle: {
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: tokens.fontWeightMedium,
+    color: tokens.colorNeutralForeground1,
+  },
   headerSpacer: { flex: '1 1 0' },
   escKbd: {
     fontSize: tokens.fontSizeBase200,
@@ -89,7 +96,13 @@ const useStyles = makeStyles({
     '@media (min-width: 640px)': { display: 'none' },
   },
   dragHandle: { display: 'flex', justifyContent: 'center', paddingTop: '10px', paddingBottom: '4px' },
-  dragHandleBar: { width: '32px', height: '4px', borderRadius: '9999px', backgroundColor: tokens.colorNeutralForeground2, opacity: 0.3 },
+  dragHandleBar: {
+    width: '32px',
+    height: '4px',
+    borderRadius: '9999px',
+    backgroundColor: tokens.colorNeutralForeground2,
+    opacity: 0.3,
+  },
   mobileHeader: {
     display: 'flex',
     alignItems: 'center',
@@ -138,7 +151,11 @@ const useStyles = makeStyles({
     cursor: 'pointer',
   },
   submitActive: { backgroundColor: tokens.colorBrandBackground, color: tokens.colorNeutralForegroundOnBrand },
-  submitDisabled: { backgroundColor: tokens.colorNeutralBackground3, color: tokens.colorNeutralForeground2, opacity: 0.4 },
+  submitDisabled: {
+    backgroundColor: tokens.colorNeutralBackground3,
+    color: tokens.colorNeutralForeground2,
+    opacity: 0.4,
+  },
   safeArea: { height: 'env(safe-area-inset-bottom, 0px)' },
 });
 
@@ -153,7 +170,16 @@ export const QuickCapture = memo(() => {
   const open = useStore($quickCaptureOpen);
   const [value, setValue] = useState('');
   const [flash, setFlash] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(() => window.matchMedia('(min-width: 640px)').matches);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const media = window.matchMedia('(min-width: 640px)');
+    const update = () => setIsDesktop(media.matches);
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, []);
 
   const toggle = useCallback(() => {
     const willOpen = !$quickCaptureOpen.get();
@@ -173,8 +199,8 @@ export const QuickCapture = memo(() => {
   const submit = useCallback(async () => {
     const trimmed = value.trim();
     if (!trimmed) {
-return;
-}
+      return;
+    }
 
     // Capture lands as a global inbox item with no project context. Shaping
     // and promotion happen later from the Inbox view.
@@ -216,87 +242,84 @@ return;
           className={styles.overlay}
           onClick={(e) => {
             if (e.target === e.currentTarget) {
-close();
-}
+              close();
+            }
           }}
         >
           {/* Backdrop */}
           <div className={styles.backdrop} onClick={close} />
 
-          {/* Desktop: centered floating card */}
-          <div className={styles.desktopCenter}>
+          {isDesktop ? (
+            <div className={styles.desktopCenter}>
+              <motion.div
+                initial={{ opacity: 0, y: -12, scale: 0.97 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -8, scale: 0.97 }}
+                transition={{ type: 'spring', duration: 0.25, bounce: 0.1 }}
+                className={mergeClasses(
+                  styles.desktopCard,
+                  flash ? styles.desktopCardFlash : styles.desktopCardDefault
+                )}
+              >
+                <div className={styles.desktopHeader}>
+                  <MailInbox20Regular className={styles.captureIcon} style={{ width: 16, height: 16 }} />
+                  <span className={styles.captureTitle}>Quick Capture</span>
+                  <div className={styles.headerSpacer} />
+                  <kbd className={styles.escKbd}>Esc</kbd>
+                </div>
+                <div className={styles.inputWrap}>
+                  <input
+                    ref={inputRef}
+                    value={value}
+                    onChange={(e) => setValue(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    autoFocus
+                    placeholder="What needs capturing?"
+                    className={styles.desktopInput}
+                  />
+                </div>
+              </motion.div>
+            </div>
+          ) : (
             <motion.div
-              initial={{ opacity: 0, y: -12, scale: 0.97 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -8, scale: 0.97 }}
-              transition={{ type: 'spring', duration: 0.25, bounce: 0.1 }}
-              className={mergeClasses(styles.desktopCard, flash ? styles.desktopCardFlash : styles.desktopCardDefault)}
+              initial={{ y: '100%' }}
+              animate={{ y: 0 }}
+              exit={{ y: '100%' }}
+              transition={{ type: 'spring', duration: 0.35, bounce: 0.05 }}
+              className={mergeClasses(styles.mobileSheet, flash ? styles.desktopCardFlash : styles.desktopCardDefault)}
             >
-              <div className={styles.desktopHeader}>
+              <div className={styles.dragHandle}>
+                <div className={styles.dragHandleBar} />
+              </div>
+
+              <div className={styles.mobileHeader}>
                 <MailInbox20Regular className={styles.captureIcon} style={{ width: 16, height: 16 }} />
                 <span className={styles.captureTitle}>Quick Capture</span>
-                <div className={styles.headerSpacer} />
-                <kbd className={styles.escKbd}>
-                  Esc
-                </kbd>
               </div>
-              <div className={styles.inputWrap}>
+
+              <div className={styles.mobileInputRow}>
                 <input
-                  ref={inputRef}
                   value={value}
                   onChange={(e) => setValue(e.target.value)}
                   onKeyDown={handleKeyDown}
                   autoFocus
                   placeholder="What needs capturing?"
-                  className={styles.desktopInput}
+                  className={styles.mobileInput}
                 />
+                <button
+                  type="button"
+                  onClick={() => void submit()}
+                  disabled={!value.trim()}
+                  className={mergeClasses(styles.submitBtn, value.trim() ? styles.submitActive : styles.submitDisabled)}
+                  aria-label="Submit"
+                >
+                  <ArrowUp20Regular style={{ width: 18, height: 18 }} />
+                </button>
               </div>
+
+              <div className={styles.safeArea} />
             </motion.div>
-          </div>
-
-          {/* Mobile: bottom sheet */}
-          <motion.div
-            initial={{ y: '100%' }}
-            animate={{ y: 0 }}
-            exit={{ y: '100%' }}
-            transition={{ type: 'spring', duration: 0.35, bounce: 0.05 }}
-            className={mergeClasses(styles.mobileSheet, flash ? styles.desktopCardFlash : styles.desktopCardDefault)}
-          >
-            {/* Drag handle */}
-            <div className={styles.dragHandle}>
-              <div className={styles.dragHandleBar} />
-            </div>
-
-            {/* Header */}
-            <div className={styles.mobileHeader}>
-              <MailInbox20Regular className={styles.captureIcon} style={{ width: 16, height: 16 }} />
-              <span className={styles.captureTitle}>Quick Capture</span>
-            </div>
-
-            {/* Input row */}
-            <div className={styles.mobileInputRow}>
-              <input
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onKeyDown={handleKeyDown}
-                autoFocus
-                placeholder="What needs capturing?"
-                className={styles.mobileInput}
-              />
-              <button
-                type="button"
-                onClick={() => void submit()}
-                disabled={!value.trim()}
-                className={mergeClasses(styles.submitBtn, value.trim() ? styles.submitActive : styles.submitDisabled)}
-                aria-label="Submit"
-              >
-                <ArrowUp20Regular style={{ width: 18, height: 18 }} />
-              </button>
-            </div>
-
-            {/* Safe area spacer for phones with home indicator */}
-            <div className={styles.safeArea} />
-          </motion.div>
+          )}
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/shared/pipeline-defaults.test.ts
+++ b/src/shared/pipeline-defaults.test.ts
@@ -47,8 +47,14 @@ describe('SIMPLE_PIPELINE', () => {
     }
   });
 
-  it('starts with backlog and ends with done', () => {
+  it('starts with backlog and ends with completed', () => {
     expect(SIMPLE_PIPELINE.columns[0]!.id).toBe('backlog');
-    expect(SIMPLE_PIPELINE.columns[SIMPLE_PIPELINE.columns.length - 1]!.id).toBe('done');
+    expect(SIMPLE_PIPELINE.columns[SIMPLE_PIPELINE.columns.length - 1]!.id).toBe('completed');
+  });
+
+  it('has a gated review column', () => {
+    const review = SIMPLE_PIPELINE.columns.find((c) => c.id === 'review');
+    expect(review).toBeDefined();
+    expect(review!.gate).toBe(true);
   });
 });

--- a/tests/e2e/specs/chat-basics.spec.ts
+++ b/tests/e2e/specs/chat-basics.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { openChat } from 'tests/e2e/support/app';
+
+test.describe('chat basics', () => {
+  test('lets a user compose a message and preserves a safe chat surface after restart', async ({ app }) => {
+    const prompt = `E2E chat prompt ${Date.now()}`;
+
+    await openChat(app.page);
+    await expect(app.page.getByPlaceholder('How can I help you today?')).toBeVisible();
+    await expect(app.page.getByLabel('Attach files')).toBeVisible();
+
+    await app.page.getByPlaceholder('How can I help you today?').fill(prompt);
+    await expect(app.page.getByRole('button', { name: 'Send' })).toBeEnabled();
+    await app.page.getByRole('button', { name: 'Send' }).click();
+    await expect(app.page.getByPlaceholder('How can I help you today?')).toHaveValue('');
+
+    const restarted = await app.restart();
+    await openChat(restarted);
+    await expect(restarted.getByPlaceholder('How can I help you today?')).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/inbox-lifecycle.spec.ts
+++ b/tests/e2e/specs/inbox-lifecycle.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { addInboxItem, createProject, openInbox, openProject } from 'tests/e2e/support/app';
+
+test.describe('inbox lifecycle', () => {
+  test('captures, shapes, defers, reactivates, and promotes an inbox item', async ({ appPage }) => {
+    const projectName = `E2E Inbox Project ${Date.now()}`;
+    const itemTitle = `E2E Inbox Item ${Date.now()}`;
+    const outcome = 'Inbox item is shaped and ready for implementation.';
+
+    await createProject(appPage, projectName);
+    await addInboxItem(appPage, itemTitle);
+    const inboxRow = appPage.getByRole('button', { name: new RegExp(itemTitle) });
+    await inboxRow.focus();
+    await appPage.keyboard.press('Enter');
+    await expect(appPage.getByLabel('Outcome — what does success look like?')).toBeVisible();
+
+    await appPage.getByLabel('Outcome — what does success look like?').fill(outcome);
+    await appPage.getByLabel('Outcome — what does success look like?').blur();
+    await expect(appPage.getByText('Shaped', { exact: true }).first()).toBeVisible();
+
+    await appPage.getByRole('button', { name: 'More actions' }).click();
+    await appPage.getByRole('menuitem', { name: 'Defer to later' }).click();
+    await expect(appPage.getByText('Later')).toBeVisible();
+
+    await appPage.getByRole('button', { name: 'More actions' }).click();
+    await appPage.getByRole('menuitem', { name: 'Reactivate' }).click();
+    await expect(appPage.getByText('Shaped', { exact: true }).first()).toBeVisible();
+
+    await expect(appPage.getByLabel('Outcome — what does success look like?')).toBeVisible();
+    await appPage.locator('select').selectOption({ label: projectName });
+    const promoteToTicket = appPage.getByRole('button', { name: 'Promote to ticket' });
+    await expect(promoteToTicket).toBeVisible();
+    await promoteToTicket.click();
+
+    await openProject(appPage, projectName);
+    await appPage.getByRole('treeitem', { name: /Board/ }).click();
+    await expect(appPage.getByText(itemTitle).first()).toBeVisible();
+
+    await openInbox(appPage);
+    await appPage.getByRole('tab', { name: /Archive/ }).click();
+    await expect(appPage.getByText(itemTitle).first()).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/pages-lifecycle.spec.ts
+++ b/tests/e2e/specs/pages-lifecycle.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { createPage, createProject, openProject, projectTree } from 'tests/e2e/support/app';
+
+test.describe('pages lifecycle', () => {
+  test('creates, renames, navigates, and persists project pages', async ({ app }) => {
+    const projectName = `E2E Pages Project ${Date.now()}`;
+    const pageTitle = `E2E Spec ${Date.now()}`;
+    const renamedTitle = `${pageTitle} Updated`;
+
+    await createProject(app.page, projectName);
+    await openProject(app.page, projectName);
+    await createPage(app.page, pageTitle);
+
+    const titleInput = app.page.getByRole('textbox', { name: 'Page title' });
+    await expect(titleInput).toHaveValue(pageTitle);
+    await titleInput.fill(renamedTitle);
+    await titleInput.blur();
+    await expect(titleInput).toHaveValue(renamedTitle);
+
+    await app.page.getByRole('button', { name: 'Back' }).click();
+    const pagesGroup = projectTree(app.page).getByRole('treeitem', { name: /Pages \(1\)/ });
+    await expect(pagesGroup).toBeVisible();
+    await pagesGroup.focus();
+    await app.page.keyboard.press('ArrowRight');
+    await expect(projectTree(app.page).getByRole('treeitem', { name: new RegExp(renamedTitle) })).toBeVisible();
+
+    const restarted = await app.restart();
+    await openProject(restarted, projectName);
+    const restartedPagesGroup = projectTree(restarted).getByRole('treeitem', { name: /Pages \(1\)/ });
+    await expect(restartedPagesGroup).toBeVisible();
+    await restartedPagesGroup.focus();
+    await restarted.keyboard.press('ArrowRight');
+    await expect(projectTree(restarted).getByRole('treeitem', { name: new RegExp(renamedTitle) })).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/settings-basics.spec.ts
+++ b/tests/e2e/specs/settings-basics.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { openSettings } from 'tests/e2e/support/app';
+
+test.describe('settings basics', () => {
+  test('exposes core configuration areas without leaking seeded secrets', async ({ app }) => {
+    await openSettings(app.page);
+
+    for (const section of ['General', 'Environment', 'Models', 'MCP Servers', 'Git', 'Skills', 'Network']) {
+      await test.step(`open ${section}`, async () => {
+        await app.page.getByRole('button', { name: section }).first().click();
+        await expect(app.page.getByText(section).first()).toBeVisible();
+      });
+    }
+
+    await test.step('raw seeded secrets are not rendered', async () => {
+      await expect(app.page.getByText('test-key', { exact: true })).toHaveCount(0);
+      await expect(
+        app.page.getByText(process.env.OPENAI_API_KEY ?? process.env.SANDBOX_OPENAI_API_KEY ?? 'test-key')
+      ).toHaveCount(0);
+    });
+
+    const restarted = await app.restart();
+    await openSettings(restarted);
+    await expect(restarted.getByRole('button', { name: 'Models' }).first()).toBeVisible();
+    await expect(restarted.getByRole('button', { name: 'Git' }).first()).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/surfaces-availability.spec.ts
+++ b/tests/e2e/specs/surfaces-availability.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { createProject, openChat, openCode, openProject, openSettings } from 'tests/e2e/support/app';
+
+test.describe('surfaces availability', () => {
+  test('keeps primary user surfaces reachable and mode-appropriate', async ({ appPage, mode }) => {
+    await openChat(appPage);
+    await expect(appPage.getByPlaceholder('How can I help you today?')).toBeVisible();
+
+    await openCode(appPage);
+    await expect(appPage.getByText(/Spaces|No apps installed|Chat|Browser|Settings/).first()).toBeVisible();
+
+    await openSettings(appPage);
+    await appPage.getByRole('button', { name: 'Skills' }).first().click();
+    await expect(appPage.getByRole('button', { name: 'Install from marketplace' })).toBeVisible();
+    const installFromFile = appPage.getByRole('button', { name: 'Install from file' });
+    if (mode === 'electron-local') {
+      await expect(installFromFile).toBeVisible();
+    } else {
+      await expect(installFromFile).toHaveCount(0);
+    }
+
+    const projectName = `E2E Surface Project ${Date.now()}`;
+    await createProject(appPage, projectName);
+    await openProject(appPage, projectName);
+    await expect(appPage.getByRole('tree', { name: 'Project tree' })).toBeVisible();
+    await expect(appPage.getByRole('button', { name: 'New page' }).first()).toBeVisible();
+    await appPage.getByRole('treeitem', { name: /Board/ }).click();
+    await expect(appPage.getByRole('button', { name: 'New', exact: true }).first()).toBeVisible();
+  });
+});

--- a/tests/e2e/specs/ticket-lifecycle.spec.ts
+++ b/tests/e2e/specs/ticket-lifecycle.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { createProject, createTicket, openProject, openTicket } from 'tests/e2e/support/app';
+
+test.describe('ticket lifecycle', () => {
+  test('creates, edits, comments on, moves, and persists a ticket', async ({ app }) => {
+    const projectName = `E2E Ticket Project ${Date.now()}`;
+    const ticketTitle = `E2E Ticket ${Date.now()}`;
+    const renamedTitle = `${ticketTitle} Updated`;
+    const description = 'Ticket description added from the user-facing overview.';
+    const comment = 'Ticket discussion comment from E2E.';
+
+    await createProject(app.page, projectName);
+    await openProject(app.page, projectName);
+    await createTicket(app.page, ticketTitle);
+    await openTicket(app.page, ticketTitle);
+
+    await app.page.getByRole('button', { name: new RegExp(ticketTitle) }).click();
+    await app.page.getByRole('textbox').first().fill(renamedTitle);
+    await app.page.keyboard.press('Enter');
+    await expect(app.page.getByRole('button', { name: new RegExp(renamedTitle) })).toBeVisible();
+
+    await app.page.getByRole('button', { name: 'Edit description' }).click();
+    await app.page.getByPlaceholder('Ticket description...').fill(description);
+    await app.page.getByRole('button', { name: 'Save' }).click();
+    await expect(app.page.getByText(description)).toBeVisible();
+
+    await app.page.locator('select').nth(1).selectOption('high');
+    await app.page.locator('select').first().selectOption({ label: 'Review' });
+    await expect(app.page.locator('select').first()).toHaveValue(/review/);
+
+    await app.page.getByRole('tab', { name: 'Discussion' }).click();
+    await app.page.getByPlaceholder('Add a comment...').fill(comment);
+    await app.page.getByRole('button', { name: 'Send comment' }).click();
+    await expect(app.page.getByText(comment)).toBeVisible();
+
+    const restarted = await app.restart();
+    await openProject(restarted, projectName);
+    await openTicket(restarted, renamedTitle);
+    await expect(restarted.getByText(description)).toBeVisible();
+    await expect(restarted.locator('select').first()).toHaveValue(/review/);
+    await restarted.getByRole('tab', { name: 'Discussion' }).click();
+    await expect(restarted.getByText(comment)).toBeVisible();
+  });
+});

--- a/tests/e2e/support/app.ts
+++ b/tests/e2e/support/app.ts
@@ -6,6 +6,23 @@ export async function openProjects(page: Page): Promise<void> {
   await expect(page.getByRole('tab', { name: 'Projects' })).toHaveAttribute('aria-selected', 'true');
 }
 
+export async function openChat(page: Page): Promise<void> {
+  await page.getByRole('tab', { name: 'Chat' }).click();
+  await expect(page.getByRole('tab', { name: 'Chat' })).toHaveAttribute('aria-selected', 'true');
+}
+
+export async function openCode(page: Page): Promise<void> {
+  const codeTab = page.getByRole('tab', { name: 'Code' });
+  const spacesTab = page.getByRole('tab', { name: 'Spaces' });
+  if (await codeTab.count()) {
+    await codeTab.click();
+    await expect(codeTab).toHaveAttribute('aria-selected', 'true');
+  } else {
+    await spacesTab.click();
+    await expect(spacesTab).toHaveAttribute('aria-selected', 'true');
+  }
+}
+
 export async function openSettings(page: Page): Promise<void> {
   await page.getByRole('tab', { name: 'Settings' }).click();
   await expect(page.getByRole('tab', { name: 'Settings' })).toHaveAttribute('aria-selected', 'true');
@@ -16,13 +33,30 @@ export async function createProject(page: Page, projectName: string): Promise<vo
   await page.getByRole('button', { name: 'New project' }).first().click();
   await page.getByRole('textbox', { name: 'Project name' }).fill(projectName);
   await page.getByRole('button', { name: 'Create Project' }).click();
-  await expect(page.getByText(projectName).first()).toBeVisible();
+  await expect(projectTree(page).getByRole('treeitem', { name: new RegExp(projectName) })).toBeVisible();
 }
 
 export async function openProject(page: Page, projectName: string): Promise<void> {
   await openProjects(page);
-  await page.getByText(projectName).first().click();
-  await expect(page.getByText(projectName).first()).toBeVisible();
+  const project = projectTree(page)
+    .getByRole('treeitem', { name: new RegExp(projectName) })
+    .first();
+  await project.click();
+  await expect(project).toBeVisible();
+}
+
+export async function openInbox(page: Page): Promise<void> {
+  await openProjects(page);
+  await page.getByText('Inbox').first().click();
+  await expect(page.getByText('Inbox').first()).toBeVisible();
+}
+
+export async function addInboxItem(page: Page, title: string): Promise<void> {
+  await openInbox(page);
+  await page.getByRole('button', { name: /Add (inbox )?item/ }).click();
+  await page.getByPlaceholder('What needs capturing?').fill(title);
+  await page.keyboard.press('Enter');
+  await expect(page.getByText(title).first()).toBeVisible();
 }
 
 export function projectTree(page: Page) {
@@ -69,8 +103,32 @@ export async function createMilestone(page: Page, title: string): Promise<void> 
 }
 
 export async function createTicket(page: Page, title: string): Promise<void> {
-  await page.getByRole('button', { name: 'New ticket' }).first().click();
-  await page.getByRole('textbox', { name: 'Ticket title' }).fill(title);
-  await page.getByRole('button', { name: 'Create Ticket' }).click();
-  await expect(page.getByText(title).first()).toBeVisible();
+  const newTicketButton = page.getByRole('button', { name: 'New ticket' }).first();
+  if (await newTicketButton.count()) {
+    await newTicketButton.click();
+    await page.getByRole('textbox', { name: 'Ticket title' }).fill(title);
+    await page.getByRole('button', { name: 'Create Ticket' }).click();
+  } else {
+    await projectTree(page).getByRole('treeitem', { name: /Board/ }).click();
+    await page.getByRole('button', { name: 'New', exact: true }).first().click();
+    await page.getByRole('button', { name: 'Untitled' }).click();
+    await page.getByRole('textbox').first().fill(title);
+    await page.keyboard.press('Enter');
+  }
+  await expect(page.getByRole('button', { name: new RegExp(title) })).toBeVisible();
+}
+
+export async function openTicket(page: Page, title: string): Promise<void> {
+  if (await page.getByRole('tab', { name: 'Overview' }).count()) {
+    await expect(page.getByRole('button', { name: new RegExp(title) })).toBeVisible();
+    return;
+  }
+  await projectTree(page).getByRole('treeitem', { name: /Board/ }).focus();
+  await page.keyboard.press('ArrowRight');
+  await projectTree(page)
+    .getByRole('treeitem', { name: /Backlog/ })
+    .focus();
+  await page.keyboard.press('ArrowRight');
+  await page.getByText(title).last().click();
+  await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
 }


### PR DESCRIPTION
## Summary
- Add native Playwright E2E coverage for core end-user workflows: chat compose, settings discovery/secret masking, inbox lifecycle, page lifecycle, ticket lifecycle, and surface availability.
- Fix inbox lifecycle stability so detail views stay open across shape/defer/reactivate/project updates.
- Render only the active Quick Capture layout to avoid duplicate accessible inputs.
- Align sourceless project pipelines with the GA `Backlog → Review → Completed` flow.

## Validation
- `npm run build:packages && npx vitest run src/shared/pipeline-defaults.test.ts src/lib/resolve-pipeline-defs.test.ts src/lib/project-manager.test.ts`
- `npm run build:server && npx playwright test --project=server-local tests/e2e/specs/inbox-lifecycle.spec.ts tests/e2e/specs/ticket-lifecycle.spec.ts tests/e2e/specs/surfaces-availability.spec.ts tests/e2e/specs/projects-sources.spec.ts`
- `npx prettier --check src/renderer/features/Inbox/InboxView.tsx src/renderer/features/Inbox/QuickCapture.tsx packages/projects-db/src/defaults.ts src/shared/pipeline-defaults.test.ts src/lib/resolve-pipeline-defs.test.ts src/lib/project-manager.test.ts tests/e2e/support/app.ts tests/e2e/specs/inbox-lifecycle.spec.ts tests/e2e/specs/ticket-lifecycle.spec.ts`

## Notes
- Electron-local E2E specs are discoverable but were not run in this pass because they require the Electron/display/CDP path.
