### PR TITLE
Fix glass styling gaps in chat UI

### DIFF
--- a/src/renderer/omniagents-ui/components/ActivityGroup.tsx
+++ b/src/renderer/omniagents-ui/components/ActivityGroup.tsx
@@ -1,31 +1,32 @@
-import { AnimatePresence,motion } from 'framer-motion'
-import { ChevronDownIcon } from 'lucide-react'
-import React, { useMemo, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion';
+import { ChevronDownIcon } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
 
-import type { ActivityGroupData } from './activity-group'
-import { computeGroupSummary, formatGroupSummary } from './activity-group'
-import { formatArgsPreview,ToolCard } from './MessageList'
+import type { ActivityGroupData } from './activity-group';
+import { computeGroupSummary, formatGroupSummary } from './activity-group';
+import { formatArgsPreview, ToolCard } from './MessageList';
 
 export function ActivityGroup({ group, statusText }: { group: ActivityGroupData; statusText?: string }) {
   // Singleton without grouping — render as plain ToolCard
   if (group.tools.length === 1 && !group.runId) {
-    return <ToolCard item={group.tools[0]!} />
+    return <ToolCard item={group.tools[0]!} />;
   }
 
-  return <GroupCard group={group} statusText={statusText} />
+  return <GroupCard group={group} statusText={statusText} />;
 }
 
 function GroupCard({ group, statusText }: { group: ActivityGroupData; statusText?: string }) {
-  const [expanded, setExpanded] = useState(false)
-  const summary = useMemo(() => computeGroupSummary(group.tools), [group.tools])
-  const summaryText = useMemo(() => formatGroupSummary(summary), [summary])
-  const latest = group.tools[group.tools.length - 1]
-  const preview = formatArgsPreview(latest?.input || '', 60)
+  const [expanded, setExpanded] = useState(false);
+  const summary = useMemo(() => computeGroupSummary(group.tools), [group.tools]);
+  const summaryText = useMemo(() => formatGroupSummary(summary), [summary]);
+  const latest = group.tools[group.tools.length - 1];
+  const preview = formatArgsPreview(latest?.input || '', 60);
 
   return (
-    <motion.div layout className="space-y-2">
+    <motion.div layout data-slot="activity-group" className="space-y-2">
       <button
-        onClick={() => setExpanded(v => !v)}
+        onClick={() => setExpanded((v) => !v)}
+        data-slot="activity-group-trigger"
         className="w-full flex items-center gap-2 px-3 py-3 rounded-md bg-secondary text-sm hover:bg-accent transition-colors text-left min-w-0"
       >
         {group.isRunning ? (
@@ -35,7 +36,7 @@ function GroupCard({ group, statusText }: { group: ActivityGroupData; statusText
               <AnimatePresence mode="wait">
                 {statusText ? (
                   <motion.span
-                    key={`status-${  statusText}`}
+                    key={`status-${statusText}`}
                     initial={{ opacity: 0, y: 8 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -8 }}
@@ -81,7 +82,7 @@ function GroupCard({ group, statusText }: { group: ActivityGroupData; statusText
             transition={{ duration: 0.25 }}
             className="overflow-hidden"
           >
-            <div className="space-y-2 pl-4 border-l-2 border-border ml-3">
+            <div data-slot="activity-group-content" className="space-y-2 pl-4 border-l-2 border-border ml-3">
               {group.tools.map((t, i) => (
                 <ToolCard key={t.call_id || i} item={t} />
               ))}
@@ -90,5 +91,5 @@ function GroupCard({ group, statusText }: { group: ActivityGroupData; statusText
         )}
       </AnimatePresence>
     </motion.div>
-  )
+  );
 }

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -211,22 +211,30 @@
 }
 
 .omni-glass [data-slot='card'],
+.omni-glass [data-slot='plan'],
 .omni-glass [data-slot='tool'],
 .omni-glass [data-slot='artifact'],
-.omni-glass [data-slot='alert'] {
+.omni-glass [data-slot='alert'],
+.omni-glass [data-slot='activity-group-trigger'] {
   background: var(--glass-panel);
   border-color: var(--glass-panel-border);
-  box-shadow: 0 1px 0 rgb(255 255 255 / 0.08) inset, 0 18px 48px rgb(0 0 0 / 0.16);
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 0.08) inset,
+    0 18px 48px rgb(0 0 0 / 0.16);
   backdrop-filter: var(--glass-blur-light);
   -webkit-backdrop-filter: var(--glass-blur-light);
 }
 
 .omni-glass [data-slot='card-header'],
 .omni-glass [data-slot='card-footer'],
+.omni-glass [data-slot='plan-header'],
+.omni-glass [data-slot='plan-content'],
+.omni-glass [data-slot='plan-footer'],
 .omni-glass [data-slot='artifact-header'],
 .omni-glass [data-slot='tool-input-panel'],
 .omni-glass [data-slot='tool-output-panel']:not([data-error='true']),
 .omni-glass [data-slot='code-block'],
+.omni-glass [data-streamdown='code-block'],
 .omni-glass [data-slot='markdown'] pre {
   background: var(--glass-panel-soft);
   border-color: var(--glass-panel-border);
@@ -235,12 +243,22 @@
 }
 
 .omni-glass [data-slot='code-block'] pre,
+.omni-glass [data-streamdown='code-block-body'],
 .omni-glass [data-slot='markdown'] pre {
   background-color: var(--glass-code-bg) !important;
 }
 
-.omni-glass [data-slot='code-block'] [data-slot='code-block-header'] {
+.omni-glass [data-slot='code-block'] [data-slot='code-block-header'],
+.omni-glass [data-streamdown='code-block-header'] {
   background: var(--glass-panel-strong);
+}
+
+.omni-glass [data-slot='activity-group-trigger']:hover {
+  background: var(--glass-panel-strong);
+}
+
+.omni-glass [data-slot='activity-group-content'] {
+  border-color: var(--glass-panel-border);
 }
 
 .omni-glass [data-slot='markdown'] {


### PR DESCRIPTION
## Summary
- Adds glass styling coverage for plan panels in the chat component gallery, including static and streaming plan states.
- Covers Streamdown-rendered markdown code blocks so chat responses inherit the same glass treatment as PromptKit markdown/code blocks.
- Adds stable activity-group slots and glass styling for grouped tool-call summaries and expanded group borders.

## Test plan
- `npx prettier --check src/renderer/styles/tailwind.css src/renderer/omniagents-ui/components/ActivityGroup.tsx`
- `git diff --check`

## Notes
- `npm run check` is not defined in this repository, so validation used the focused formatting and whitespace checks above.
