### PR TITLE
Let assistant chat messages use full width

### DIFF
--- a/src/renderer/omniagents-ui/components/MessageList.tsx
+++ b/src/renderer/omniagents-ui/components/MessageList.tsx
@@ -232,7 +232,7 @@ function MessageBubble({ index, role, content, attachments, stagedContext, react
   if (role === 'system') {
     return (
       <div className="flex justify-start">
-        <div className="flex min-w-0 max-w-[85%] flex-col items-start sm:max-w-[70%]">
+        <div className="flex w-full min-w-0 max-w-full flex-col items-start">
           {attachments && attachments.length > 0 ? (
             <div className="mb-1 flex flex-wrap gap-2 w-full">
               {attachments.map((att, i) => (
@@ -250,7 +250,7 @@ function MessageBubble({ index, role, content, attachments, stagedContext, react
   // assistant
   return (
     <div className="flex justify-start">
-      <div className="flex min-w-0 max-w-[85%] flex-col items-start sm:max-w-[70%]">
+      <div className="flex w-full min-w-0 max-w-full flex-col items-start">
         {attachments && attachments.length > 0 ? (
           <div className="mb-1 flex flex-wrap gap-2 w-full">
             {attachments.map((att, i) => (


### PR DESCRIPTION
## Summary
- Let assistant chat responses use the full available chat column width.
- Apply the same full-width layout to system messages.
- Keep user message bubbles constrained for the existing compact appearance.

## Testing
- [x] `git diff --check -- src/renderer/omniagents-ui/components/MessageList.tsx`
- [ ] `npm run lint:tsc` — fails on pre-existing repo-wide TypeScript errors unrelated to this change.
- [ ] `npm run lint:eslint -- src/renderer/omniagents-ui/components/MessageList.tsx` — fails because the script lints the full repo.
- [ ] `npx eslint --max-warnings=0 src/renderer/omniagents-ui/components/MessageList.tsx` — fails on pre-existing lint issues already present in this file.
