### PR TITLE
Make launcher toasts dismiss consistently

### DIFF
--- a/src/renderer/features/Toast/ToastContainer.test.tsx
+++ b/src/renderer/features/Toast/ToastContainer.test.tsx
@@ -1,0 +1,148 @@
+import type { ReactElement, ReactNode } from 'react';
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { $toasts, addToast } from './state';
+import { ToastContainer } from './ToastContainer';
+
+const fluentMocks = vi.hoisted(() => ({
+  dispatchToast: vi.fn(),
+  dismissToast: vi.fn(),
+}));
+
+vi.mock('@fluentui/react-components', () => {
+  return {
+    Button: ({ children, icon, onClick }: { children: ReactNode; icon?: ReactNode; onClick?: () => void }) =>
+      React.createElement('button', { type: 'button', onClick }, icon, children),
+    Toast: ({ children }: { children: ReactNode }) => React.createElement('article', null, children),
+    ToastBody: ({ children }: { children: ReactNode }) => React.createElement('div', null, children),
+    ToastFooter: ({ children }: { children: ReactNode }) => React.createElement('footer', null, children),
+    ToastTitle: ({ children }: { children: ReactNode }) => React.createElement('h2', null, children),
+    Toaster: ({ toasterId }: { toasterId: string }) => React.createElement('div', { 'data-toaster-id': toasterId }),
+    useId: (prefix: string) => prefix,
+    useToastController: () => ({
+      dispatchToast: fluentMocks.dispatchToast,
+      dismissToast: fluentMocks.dismissToast,
+    }),
+  };
+});
+
+vi.mock('@fluentui/react-icons', () => {
+  return {
+    Copy20Regular: () => React.createElement('span', { 'aria-hidden': 'true' }),
+  };
+});
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let renderedToastRoots: Root[] = [];
+let renderedToastContainers: HTMLDivElement[] = [];
+
+beforeEach(() => {
+  $toasts.set([]);
+  fluentMocks.dispatchToast.mockClear();
+  fluentMocks.dismissToast.mockClear();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+    for (const toastRoot of renderedToastRoots) {
+      toastRoot.unmount();
+    }
+  });
+  renderedToastRoots = [];
+  for (const toastContainer of renderedToastContainers) {
+    toastContainer.remove();
+  }
+  renderedToastContainers = [];
+  container.remove();
+});
+
+const renderContainer = async () => {
+  await act(async () => {
+    root.render(<ToastContainer />);
+    await Promise.resolve();
+  });
+};
+
+const renderDispatchedToast = async (index: number): Promise<HTMLDivElement> => {
+  const toastContainer = document.createElement('div');
+  document.body.appendChild(toastContainer);
+  const toastRoot = createRoot(toastContainer);
+  renderedToastContainers.push(toastContainer);
+  renderedToastRoots.push(toastRoot);
+
+  await act(async () => {
+    const dispatchedToast = fluentMocks.dispatchToast.mock.calls[index]?.[0];
+    expect(dispatchedToast).toBeDefined();
+    toastRoot.render(dispatchedToast as ReactElement);
+    await Promise.resolve();
+  });
+
+  return toastContainer;
+};
+
+const buttonNamed = (toastContainer: HTMLDivElement, label: string): HTMLButtonElement => {
+  const button = Array.from(toastContainer.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(label)
+  );
+  if (!button) {
+    throw new Error(`${label} button not found`);
+  }
+  return button;
+};
+
+describe('ToastContainer', () => {
+  it('dispatches every toast level with a Dismiss action', async () => {
+    const ids = [
+      addToast({ level: 'info', title: 'Info', durationMs: 5000 }),
+      addToast({ level: 'success', title: 'Success', durationMs: 5000 }),
+      addToast({ level: 'warning', title: 'Warning', durationMs: 7000 }),
+      addToast({ level: 'error', title: 'Error', durationMs: 10000 }),
+    ];
+
+    await renderContainer();
+
+    expect(fluentMocks.dispatchToast).toHaveBeenCalledTimes(4);
+
+    for (const [index, id] of ids.entries()) {
+      const dispatchedToast = await renderDispatchedToast(index);
+      const dismissButton = buttonNamed(dispatchedToast, 'Dismiss');
+
+      act(() => {
+        dismissButton.click();
+      });
+
+      expect(fluentMocks.dismissToast).toHaveBeenCalledWith(id);
+    }
+  });
+
+  it('dispatches copy error toasts with Copy error and Dismiss actions', async () => {
+    const id = addToast({
+      level: 'error',
+      title: 'Launch failed',
+      description: 'Could not start agent',
+      copyText: 'stack trace',
+      durationMs: 10000,
+    });
+
+    await renderContainer();
+
+    const dispatchedToast = await renderDispatchedToast(0);
+    expect(buttonNamed(dispatchedToast, 'Copy error')).toBeTruthy();
+
+    act(() => {
+      buttonNamed(dispatchedToast, 'Dismiss').click();
+    });
+
+    expect(fluentMocks.dismissToast).toHaveBeenCalledWith(id);
+  });
+});

--- a/src/renderer/features/Toast/ToastContainer.tsx
+++ b/src/renderer/features/Toast/ToastContainer.tsx
@@ -60,20 +60,16 @@ export const ToastContainer = memo(() => {
         <Toast>
           <ToastTitle>{toastData.title}</ToastTitle>
           {toastData.description && <ToastBody>{toastData.description}</ToastBody>}
-          {toastData.copyText && (
-            <ToastFooter>
-              <Button
-                size="small"
-                icon={<Copy20Regular />}
-                onClick={() => void copyToClipboard(toastData.copyText!)}
-              >
+          <ToastFooter>
+            {toastData.copyText && (
+              <Button size="small" icon={<Copy20Regular />} onClick={() => void copyToClipboard(toastData.copyText!)}>
                 Copy error
               </Button>
-              <Button size="small" onClick={() => dismissToast(toastData.id)}>
-                Dismiss
-              </Button>
-            </ToastFooter>
-          )}
+            )}
+            <Button size="small" onClick={() => dismissToast(toastData.id)}>
+              Dismiss
+            </Button>
+          </ToastFooter>
         </Toast>,
         {
           intent: LEVEL_TO_INTENT[toastData.level],

--- a/src/renderer/features/Toast/state.test.ts
+++ b/src/renderer/features/Toast/state.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { $toasts, toast } from './state';
+
+beforeEach(() => {
+  $toasts.set([]);
+});
+
+describe('toast state', () => {
+  it('uses a positive default duration for error toasts', () => {
+    toast.error('Launcher failed', 'Something went wrong');
+
+    const [errorToast] = $toasts.get();
+    expect(errorToast).toBeDefined();
+    expect(errorToast).toMatchObject({
+      level: 'error',
+      title: 'Launcher failed',
+      description: 'Something went wrong',
+    });
+    expect(errorToast!.durationMs).toBeGreaterThan(0);
+  });
+
+  it('keeps explicitly sticky error toasts sticky', () => {
+    toast.error('Launcher failed', 'Something went wrong', { durationMs: 0 });
+
+    expect($toasts.get()[0]?.durationMs).toBe(0);
+  });
+});

--- a/src/renderer/features/Toast/state.ts
+++ b/src/renderer/features/Toast/state.ts
@@ -35,7 +35,6 @@ export const toast = {
     addToast({ level: 'success', title, description, copyText: opts.copyText, durationMs: opts.durationMs ?? 5000 }),
   warning: (title: string, description?: string, opts: ToastOpts = {}) =>
     addToast({ level: 'warning', title, description, copyText: opts.copyText, durationMs: opts.durationMs ?? 7000 }),
-  // Errors default to no auto-dismiss so users have time to read/copy them.
   error: (title: string, description?: string, opts: ToastOpts = {}) =>
-    addToast({ level: 'error', title, description, copyText: opts.copyText, durationMs: opts.durationMs ?? 0 }),
+    addToast({ level: 'error', title, description, copyText: opts.copyText, durationMs: opts.durationMs ?? 10000 }),
 };


### PR DESCRIPTION
**Summary**
- Make launcher error toasts transient by default with a 10-second timeout while preserving explicit `durationMs: 0` sticky behavior.
- Always render a `Dismiss` action for launcher toasts, regardless of whether copy details are present.
- Preserve `Copy error` support for toasts with `copyText`.
- Add focused Vitest coverage for error timeout defaults, explicit sticky errors, universal dismiss actions, and copy-error actions.

**Test plan**
- Passed: `npx vitest run src/renderer/features/Toast/state.test.ts src/renderer/features/Toast/ToastContainer.test.tsx`
- Passed: `npx eslint src/renderer/features/Toast/state.test.ts src/renderer/features/Toast/ToastContainer.test.tsx`
- Known unrelated failure: `npm run lint:tsc` currently fails on pre-existing repo-wide TypeScript errors outside this toast change, plus missing `omni-projects-db` type resolution.
