### PR TITLE
Make PWA safe areas follow active theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,9 @@
        manifest-src 'self'). -->
   <link rel="manifest" href="/manifest.webmanifest" crossorigin="use-credentials" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
-  <meta name="theme-color" content="#09090b" />
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)" />
+  <meta name="theme-color" content="#ffffff" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -18,8 +20,26 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src <%- cspScriptSrc %>; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' ws: wss: http: https:; frame-src 'self' http: https:; manifest-src 'self';" />
   <title>Omni Code</title>
   <style>
+    :root {
+      color-scheme: light dark;
+      --safe-area-background: #ffffff;
+      background-color: var(--safe-area-background);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --safe-area-background: #09090b;
+      }
+    }
+
+    html,
+    body,
+    #root {
+      min-height: 100%;
+      background-color: var(--safe-area-background);
+    }
+
     body {
-      background-color: #09090b !important;
       margin: 0;
     }
   </style>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -5,8 +5,8 @@
   "scope": "/",
   "display": "standalone",
   "orientation": "any",
-  "background_color": "#09090b",
-  "theme_color": "#09090b",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
   "icons": [
     {
       "src": "/icons/icon-192.png",

--- a/src/renderer/app/App.tsx
+++ b/src/renderer/app/App.tsx
@@ -24,7 +24,7 @@ import { ToastContainer } from '@/renderer/features/Toast/ToastContainer';
 import { VoiceHotkeys } from '@/renderer/features/Voice/VoiceHotkeys';
 import { SyncBar } from '@/renderer/features/WorkspaceSync/SyncBar';
 import { persistedStoreApi } from '@/renderer/services/store';
-import { applyCssVars, fluentThemes, isThemeDark } from '@/renderer/theme/fluent-themes';
+import { applyCssVars, applyPwaTheme, fluentThemes, isThemeDark } from '@/renderer/theme/fluent-themes';
 
 import { usePreloadTerminalFont } from './use-preload-terminal-font';
 
@@ -67,6 +67,7 @@ export const App = () => {
     // CSS vars are now injected from fluent-themes.ts (single source of truth).
     // data-theme attribute kept for omniagents-ui backward compat.
     applyCssVars(themeName);
+    applyPwaTheme(themeName);
     if (themeName === 'default') {
       document.documentElement.removeAttribute('data-theme');
     } else {

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -160,6 +160,7 @@
 
 /* XTerm CSS vars for terminal theming */
 :root {
+  --safe-area-background: #ffffff;
   --xterm-bg: transparent;
   --xterm-fg: #fafafa;
   --xterm-black: #fafafa;
@@ -185,6 +186,18 @@
   --scrollbar-thumb-hover: #52525b;
   --selection-color: rgb(99 102 241 / 0.3);
   --focus-ring-color: rgb(99 102 241 / 0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --safe-area-background: #09090b;
+  }
+}
+
+html,
+body,
+#root {
+  background-color: var(--safe-area-background);
 }
 
 /* Theme CSS vars are now injected at runtime from fluent-themes.ts (single source of truth).

--- a/src/renderer/theme/fluent-themes.ts
+++ b/src/renderer/theme/fluent-themes.ts
@@ -500,22 +500,33 @@ function buildFluentTheme(def: ThemeDef): Theme {
  *  This is the core deduplication: colors are defined once in `overrides`
  *  and automatically flow to both Fluent tokens AND CSS vars. */
 function buildCssVars(def: ThemeDef, theme: Theme): Record<string, string> {
-  const t = theme as Record<string, string>;
   const b = def.brand;
   const x = def.xterm;
+  const themeColor = (key: keyof Theme, fallback: string): string => {
+    const value = theme[key];
+    return typeof value === 'string' ? value : fallback;
+  };
+  const background1 = themeColor('colorNeutralBackground1', '#09090b');
+  const background2 = themeColor('colorNeutralBackground2', '#18181b');
+  const background3 = themeColor('colorNeutralBackground3', '#27272a');
+  const stroke1 = themeColor('colorNeutralStroke1', '#3f3f46');
+  const foreground1 = themeColor('colorNeutralForeground1', '#fafafa');
+  const foreground2 = themeColor('colorNeutralForeground2', '#a1a1aa');
+  const foreground3 = themeColor('colorNeutralForeground3', '#71717a');
 
   return {
     // Surface / foreground — derived from Fluent theme tokens
-    '--color-surface': t.colorNeutralBackground1,
-    '--color-surface-raised': t.colorNeutralBackground2,
-    '--color-surface-overlay': t.colorNeutralBackground3,
-    '--color-surface-border': t.colorNeutralStroke1,
-    '--color-fg': t.colorNeutralForeground1,
-    '--color-fg-muted': t.colorNeutralForeground2,
-    '--color-fg-subtle': t.colorNeutralForeground3,
-    '--color-fg-error': t.colorPaletteRedForeground1,
-    '--color-fg-success': t.colorPaletteGreenForeground1,
-    '--color-fg-warning': t.colorPaletteYellowForeground1,
+    '--color-surface': background1,
+    '--safe-area-background': background1,
+    '--color-surface-raised': background2,
+    '--color-surface-overlay': background3,
+    '--color-surface-border': stroke1,
+    '--color-fg': foreground1,
+    '--color-fg-muted': foreground2,
+    '--color-fg-subtle': foreground3,
+    '--color-fg-error': themeColor('colorPaletteRedForeground1', '#f87171'),
+    '--color-fg-success': themeColor('colorPaletteGreenForeground1', '#4ade80'),
+    '--color-fg-warning': themeColor('colorPaletteYellowForeground1', '#fbbf24'),
 
     // Accent ramp — derived from BrandVariants (reversed: 150→50, 100→500, etc.)
     '--color-accent-50': b[150],
@@ -531,9 +542,9 @@ function buildCssVars(def: ThemeDef, theme: Theme): Record<string, string> {
     '--color-accent-950': b[20],
 
     // Header — defaults to surface colors, can be overridden (e.g. UTRGV branded header)
-    '--color-header': def.header?.bg ?? t.colorNeutralBackground1,
-    '--color-header-fg': def.header?.fg ?? t.colorNeutralForeground1,
-    '--color-header-border': def.header?.border ?? t.colorNeutralStroke1,
+    '--color-header': def.header?.bg ?? background1,
+    '--color-header-fg': def.header?.fg ?? foreground1,
+    '--color-header-border': def.header?.border ?? stroke1,
 
     // Terminal (xterm) palette
     '--xterm-fg': x.fg,
@@ -588,6 +599,37 @@ export const fluentThemes: Record<OmniTheme, Theme> = fluentThemesBuilt;
 /** Whether a theme uses dark mode. */
 export function isThemeDark(theme: OmniTheme): boolean {
   return themeDefs[theme].mode === 'dark';
+}
+
+export function getThemeSurfaceColor(theme: OmniTheme): string {
+  return themeCssVarsBuilt[theme]['--color-surface'] ?? '#09090b';
+}
+
+export function applyPwaTheme(theme: OmniTheme): void {
+  const surfaceColor = getThemeSurfaceColor(theme);
+
+  document.documentElement.style.setProperty('--safe-area-background', surfaceColor);
+  document.documentElement.style.backgroundColor = surfaceColor;
+
+  if (document.body) {
+    document.body.style.backgroundColor = surfaceColor;
+  }
+
+  const root = document.getElementById('root');
+  if (root) {
+    root.style.backgroundColor = surfaceColor;
+  }
+
+  for (const meta of document.querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]')) {
+    meta.content = surfaceColor;
+  }
+
+  const statusBarMeta = document.querySelector<HTMLMetaElement>(
+    'meta[name="apple-mobile-web-app-status-bar-style"]',
+  );
+  if (statusBarMeta) {
+    statusBarMeta.content = isThemeDark(theme) ? 'black-translucent' : 'default';
+  }
 }
 
 /** Apply CSS custom properties for the given theme onto :root. */


### PR DESCRIPTION
## Summary
- Updates the PWA manifest and HTML bootstrap theme colors so light launcher installs do not inherit the old black safe-area background.
- Adds runtime PWA chrome and safe-area synchronization from the active Fluent theme surface color, covering `html`, `body`, `#root`, `theme-color`, and Apple status-bar metadata.
- Preserves dark startup behavior with `prefers-color-scheme: dark` fallbacks so dark themes avoid white flashes before React applies the stored theme.

## Test plan
- [x] `npm install`
- [x] `npm run build:packages`
- [x] `npm run build`
- [x] Mobile Chromium proof at `/workspace/.omni-artifacts/tkt_CDaxd_TOH5P1/browser-evidence/mobile-safe-area-report.md`
- [ ] `npm run lint:tsc` — existing unrelated repo-wide failures remain; changed-file filtering reported no diagnostics for touched files
