### PR TITLE
Redesign Code Deck empty launch flow

### DIFF
--- a/src/renderer/features/Code/CodeDeck.tsx
+++ b/src/renderer/features/Code/CodeDeck.tsx
@@ -90,6 +90,7 @@ const SYNTHETIC_BROWSER_APP: CustomAppEntry = {
 
 const COLUMN_WIDTH = 480;
 const COLUMN_WIDTH_SMALL = 360;
+const LAUNCH_COLUMN_MAX_WIDTH = 640;
 const EXPANDED_COLUMN_WIDTH = 860;
 /** Below this width, deck columns use COLUMN_WIDTH_SMALL. */
 const NARROW_DECK_WIDTH = 800;
@@ -995,7 +996,12 @@ const DeckColumn = memo(
           <div className={styles.flex1MinH0Relative}>
             {children}
             {(tab.ticketId || tab.projectId) && (
-              <TicketPanelOverlay panel={activePanel} ticketId={tab.ticketId as TicketId | undefined} tabId={tab.id} onClose={handleClosePanel} />
+              <TicketPanelOverlay
+                panel={activePanel}
+                ticketId={tab.ticketId as TicketId | undefined}
+                tabId={tab.id}
+                onClose={handleClosePanel}
+              />
             )}
           </div>
         </div>
@@ -1197,15 +1203,7 @@ type SidecarBodyProps = {
  * browser page, loaded code-server session, etc.
  */
 const SidecarBody = memo(
-  ({
-    app,
-    originTabId,
-    sandboxUrls,
-    previewUrl,
-    onPreviewUrlChange,
-    isGlass,
-    hidden,
-  }: SidecarBodyProps) => {
+  ({ app, originTabId, sandboxUrls, previewUrl, onPreviewUrlChange, isGlass, hidden }: SidecarBodyProps) => {
     const styles = useStyles();
     const registryProps = useMemo(
       () => ({
@@ -1658,7 +1656,12 @@ const CodeSessionPane = memo(
             isGlass={isGlass}
           />
           {(tab.ticketId || tab.projectId) && (
-            <TicketPanelOverlay panel={activePanel} ticketId={tab.ticketId as TicketId | undefined} tabId={tab.id} onClose={handleClosePanel} />
+            <TicketPanelOverlay
+              panel={activePanel}
+              ticketId={tab.ticketId as TicketId | undefined}
+              tabId={tab.id}
+              onClose={handleClosePanel}
+            />
           )}
         </div>
       </div>
@@ -1759,6 +1762,7 @@ export const CodeDeck = memo(() => {
   const [previewUrls, setPreviewUrls] = useState<Record<CodeTabId, string>>({});
   const [expandedTabIds, setExpandedTabIds] = useState<ReadonlySet<CodeTabId>>(() => new Set());
   const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
+  const [deckViewportWidth, setDeckViewportWidth] = useState(() => window.innerWidth);
 
   useEffect(() => {
     const handler = () => setViewportWidth(window.innerWidth);
@@ -1770,6 +1774,18 @@ export const CodeDeck = memo(() => {
   // single row). Leaves trackpad horizontal gestures alone and ignores wheel
   // events that originated inside a column (chat scrollbacks, etc.).
   const deckScrollRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = deckScrollRef.current;
+    if (!el) {
+      return;
+    }
+    const update = () => setDeckViewportWidth(el.clientWidth || window.innerWidth);
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     const el = deckScrollRef.current;
     if (!el) {
@@ -1960,6 +1976,23 @@ export const CodeDeck = memo(() => {
       return COLUMN_WIDTH;
     },
     [expandedTabIds, viewportWidth]
+  );
+
+  const getTabColumnWidth = useCallback(
+    (tab: CodeTab) => {
+      if (!tab.projectId && !tab.customAppId) {
+        const availableWidth = deckViewportWidth || viewportWidth;
+        if (availableWidth <= SNAP_SCROLL_WIDTH) {
+          return Math.max(280, Math.round(availableWidth * 0.96));
+        }
+        if (availableWidth <= NARROW_DECK_WIDTH) {
+          return COLUMN_WIDTH_SMALL;
+        }
+        return Math.min(LAUNCH_COLUMN_MAX_WIDTH, Math.round(availableWidth * 0.62));
+      }
+      return getColumnWidth(tab.id);
+    },
+    [deckViewportWidth, getColumnWidth, viewportWidth]
   );
 
   const handleSelect = useCallback((id: CodeTabId) => {
@@ -2180,7 +2213,7 @@ export const CodeDeck = memo(() => {
                       : undefined;
                   return (
                     <Fragment key={tab.id}>
-                      <div style={{ width: getColumnWidth(tab.id) }} className={styles.deckColumnWrap}>
+                      <div style={{ width: getTabColumnWidth(tab) }} className={styles.deckColumnWrap}>
                         {isLauncher ? (
                           <AppLauncherColumn
                             tab={tab}

--- a/src/renderer/features/Code/CodeEmptyState.tsx
+++ b/src/renderer/features/Code/CodeEmptyState.tsx
@@ -1,11 +1,11 @@
 import { Badge, makeStyles, shorthands, tokens } from '@fluentui/react-components';
-import { Add20Regular, Cube20Regular, FolderOpen20Regular } from '@fluentui/react-icons';
+import { Add20Regular, FolderOpen20Regular } from '@fluentui/react-icons';
 import { useStore } from '@nanostores/react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Button, Heading } from '@/renderer/ds';
+import { Button, Heading, ListItem } from '@/renderer/ds';
 import { ProjectForm } from '@/renderer/features/Projects/ProjectForm';
-import { getAvailableProfileNames, getProfileMenuLabel } from '@/renderer/features/SandboxProfile/profile-list';
+import { getAvailableProfileNames } from '@/renderer/features/SandboxProfile/profile-list';
 import { SandboxPicker } from '@/renderer/features/SandboxProfile/SandboxPicker';
 import { emitter } from '@/renderer/services/ipc';
 import { $machines } from '@/renderer/services/machines';
@@ -16,46 +16,13 @@ import { firstSource } from '@/shared/types';
 import { codeApi, resolveCodeTabProfileName } from './state';
 
 const useStyles = makeStyles({
-  projectCard: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: tokens.spacingHorizontalM,
-    borderRadius: tokens.borderRadiusLarge,
-    ...shorthands.border('1px', 'solid', `color-mix(in srgb, ${tokens.colorNeutralStroke1} 50%, transparent)`),
-    backgroundColor: 'transparent',
-    padding: tokens.spacingHorizontalL,
-    textAlign: 'left',
-    transitionProperty: 'border-color, background-color',
-    transitionDuration: '150ms',
-    cursor: 'pointer',
-    ':hover': {
-      ...shorthands.borderColor(`color-mix(in srgb, ${tokens.colorBrandStroke1} 70%, transparent)`),
-      backgroundColor: `color-mix(in srgb, ${tokens.colorNeutralForeground1} 6%, transparent)`,
-    },
-  },
-  projectIcon: { color: tokens.colorNeutralForeground2, flexShrink: 0 },
-  projectContent: { minWidth: 0, flex: '1 1 auto' },
-  projectLabel: {
-    fontSize: tokens.fontSizeBase300,
-    fontWeight: tokens.fontWeightMedium,
-    color: tokens.colorNeutralForeground1,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  projectDir: {
-    fontSize: tokens.fontSizeBase200,
-    color: tokens.colorNeutralForeground2,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
   rootEmbedded: {
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'center',
-    gap: tokens.spacingVerticalXXL,
+    alignItems: 'stretch',
     width: '100%',
+    height: '100%',
+    minHeight: 0,
   },
   rootFull: {
     display: 'flex',
@@ -64,24 +31,110 @@ const useStyles = makeStyles({
     justifyContent: 'center',
     height: '100%',
     width: '100%',
-    gap: tokens.spacingVerticalXXL,
-    padding: '32px',
+    padding: tokens.spacingHorizontalXL,
+    overflow: 'auto',
+  },
+  launchSurface: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalS,
+    width: '100%',
+    minHeight: 0,
+    maxWidth: '860px',
+    padding: tokens.spacingHorizontalM,
+  },
+  launchSurfaceFull: {
+    borderRadius: tokens.borderRadiusXLarge,
+    ...shorthands.border('1px', 'solid', `color-mix(in srgb, ${tokens.colorNeutralStroke1} 72%, transparent)`),
+    backgroundColor: `color-mix(in srgb, ${tokens.colorNeutralBackground1} 86%, transparent)`,
+    boxShadow: tokens.shadow8,
+    '@media (min-width: 760px)': {
+      gridTemplateColumns: 'minmax(0, 1fr) 260px',
+      alignItems: 'start',
+      padding: tokens.spacingHorizontalXXL,
+    },
+  },
+  primaryColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalS,
+    minWidth: 0,
+    minHeight: 0,
+  },
+  sideColumn: {
+    display: 'none',
+  },
+  launchHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: tokens.spacingHorizontalM,
+    flexWrap: 'nowrap',
+  },
+  launchActions: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: tokens.spacingHorizontalXS,
+    flex: '0 1 auto',
+    minWidth: 0,
+    flexWrap: 'nowrap',
+  },
+  sandboxAction: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    minWidth: 0,
+  },
+  sandboxActionLabel: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightMedium,
+  },
+  launchTitle: {
+    fontSize: tokens.fontSizeBase400,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
+  },
+  launchTitleBlock: { flex: '1 1 auto', minWidth: 0 },
+  intro: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacingVerticalS,
+  },
+  kicker: {
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorBrandForeground1,
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
   },
   description: {
     fontSize: tokens.fontSizeBase300,
     color: tokens.colorNeutralForeground2,
-    textAlign: 'center',
-    maxWidth: '448px',
+    maxWidth: '560px',
+    margin: 0,
+  },
+  sectionTitle: {
+    fontSize: tokens.fontSizeBase300,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
   },
   grid: {
     display: 'grid',
     gridTemplateColumns: '1fr',
-    gap: tokens.spacingVerticalM,
-    maxWidth: '512px',
+    gap: 0,
     width: '100%',
-    maxHeight: '400px',
+    maxHeight: 'none',
     overflowY: 'auto',
-    '@media (min-width: 640px)': { gridTemplateColumns: '1fr 1fr' },
+    overflowX: 'hidden',
+    borderRadius: tokens.borderRadiusLarge,
+    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  projectRow: {
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    ':last-child': { borderBottom: 'none' },
   },
   sandboxPanel: {
     display: 'flex',
@@ -89,12 +142,10 @@ const useStyles = makeStyles({
     justifyContent: 'space-between',
     gap: tokens.spacingHorizontalM,
     width: '100%',
-    maxWidth: '512px',
-    borderRadius: tokens.borderRadiusXLarge,
-    ...shorthands.border('1px', 'solid', tokens.colorNeutralStroke1),
-    backgroundColor: tokens.colorNeutralBackground1,
-    padding: tokens.spacingHorizontalL,
-    '@media (max-width: 520px)': { alignItems: 'flex-start', flexDirection: 'column' },
+    borderRadius: tokens.borderRadiusLarge,
+    ...shorthands.border('1px', 'solid', `color-mix(in srgb, ${tokens.colorNeutralStroke1} 58%, transparent)`),
+    backgroundColor: 'transparent',
+    padding: tokens.spacingHorizontalM,
   },
   sandboxTitle: {
     display: 'flex',
@@ -103,97 +154,52 @@ const useStyles = makeStyles({
     fontWeight: tokens.fontWeightSemibold,
   },
   sandboxHint: { color: tokens.colorNeutralForeground2, fontSize: tokens.fontSizeBase200, marginTop: '2px' },
-  projectMeta: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: tokens.spacingHorizontalXS,
-    marginTop: tokens.spacingVerticalXS,
-    flexWrap: 'wrap',
-  },
+  sandboxControl: { alignSelf: 'flex-start' },
   unavailable: { color: tokens.colorPaletteRedForeground1 },
+  emptyProjects: {
+    borderRadius: tokens.borderRadiusLarge,
+    ...shorthands.border('1px', 'dashed', tokens.colorNeutralStroke1),
+    color: tokens.colorNeutralForeground2,
+    padding: tokens.spacingHorizontalL,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
   newProjectIcon: { marginRight: '6px' },
 });
-
-type SandboxResolution = {
-  profileName: string;
-  source: 'oneOff' | 'project' | 'default' | 'fallback';
-  available: boolean;
-};
-
-const resolveSandboxForProject = (
-  project: Project,
-  explicitProfileName: string | null,
-  availableProfiles: string[],
-  defaultProfileName: string
-): SandboxResolution => {
-  const requested = explicitProfileName ?? project.sandboxProfile ?? defaultProfileName;
-  const source = explicitProfileName ? 'oneOff' : project.sandboxProfile ? 'project' : 'default';
-  if (availableProfiles.length === 0) {
-    return { profileName: requested, source, available: true };
-  }
-  if (availableProfiles.includes(requested)) {
-    return { profileName: requested, source, available: true };
-  }
-  return { profileName: availableProfiles[0] ?? 'host', source: 'fallback', available: false };
-};
 
 type CodeEmptyStateProps = {
   tabId: CodeTabId;
   embedded?: boolean;
 };
 
-const ProjectCard = memo(
-  ({
-    project,
-    resolution,
-    onSelect,
-  }: {
-    project: Project;
-    resolution: SandboxResolution;
-    onSelect: (project: Project) => void;
-  }) => {
-    const styles = useStyles();
-    const machines = useStore($machines);
-    const handleClick = useCallback(() => {
-      onSelect(project);
-    }, [project, onSelect]);
+const ProjectCard = memo(({ project, onSelect }: { project: Project; onSelect: (project: Project) => void }) => {
+  const styles = useStyles();
+  const handleClick = useCallback(() => {
+    onSelect(project);
+  }, [project, onSelect]);
 
-    const sourceLabel =
-      resolution.source === 'oneOff'
-        ? 'One-off'
-        : resolution.source === 'project'
-          ? 'Project'
-          : resolution.source === 'fallback'
-            ? 'Fallback'
-            : 'Default';
+  const projectSourceLabel = (() => {
+    const source = firstSource(project);
+    if (source?.kind === 'local') {
+      const parts = source.workspaceDir.split('/').filter(Boolean);
+      return `Local · ${parts.at(-1) ?? source.workspaceDir}`;
+    }
+    if (source?.kind === 'git-remote') {
+      const match = source.repoUrl.match(/[:/]([^/:]+\/[^/]+?)(?:\.git)?$/);
+      return `Git · ${match?.[1] ?? source.repoUrl}`;
+    }
+    return '';
+  })();
 
-    return (
-      <button onClick={handleClick} className={styles.projectCard}>
-        <FolderOpen20Regular className={styles.projectIcon} />
-        <div className={styles.projectContent}>
-          <div className={styles.projectLabel}>{project.label}</div>
-          <div className={styles.projectDir}>
-            {(() => {
-              const s = firstSource(project);
-              if (s?.kind === 'local') {
-                return s.workspaceDir;
-              }
-              if (s?.kind === 'git-remote') {
-                return s.repoUrl;
-              }
-              return '';
-            })()}
-          </div>
-          <div className={styles.projectMeta}>
-            <Badge size="small" appearance="outline" color={resolution.available ? 'informative' : 'danger'}>
-              {sourceLabel} · {getProfileMenuLabel(resolution.profileName, machines)}
-            </Badge>
-          </div>
-        </div>
-      </button>
-    );
-  }
-);
+  return (
+    <ListItem
+      icon={<FolderOpen20Regular />}
+      label={project.label}
+      detail={projectSourceLabel}
+      onClick={handleClick}
+      className={styles.projectRow}
+    />
+  );
+});
 ProjectCard.displayName = 'ProjectCard';
 
 export const CodeEmptyState = memo(({ tabId, embedded = false }: CodeEmptyStateProps) => {
@@ -213,9 +219,7 @@ export const CodeEmptyState = memo(({ tabId, embedded = false }: CodeEmptyStateP
     () => getAvailableProfileNames({ isEnterprise, available: store.availableSandboxProfiles, machines }),
     [isEnterprise, store.availableSandboxProfiles, machines]
   );
-  const defaultProfileName = store.defaultProfileName ?? 'host';
   const selectedProfileName = tab?.profileName ?? resolveCodeTabProfileName(null);
-  const explicitProfileName = tab?.profileNameExplicit ? selectedProfileName : null;
   const selectedProfileAvailable = availableProfiles.length === 0 || availableProfiles.includes(selectedProfileName);
 
   const handleSelectProject = useCallback(
@@ -249,53 +253,51 @@ export const CodeEmptyState = memo(({ tabId, embedded = false }: CodeEmptyStateP
 
   return (
     <div className={embedded ? styles.rootEmbedded : styles.rootFull}>
-      {!embedded && <Heading size="md">Select a Project</Heading>}
-      {!embedded && (
-        <p className={styles.description}>Choose an existing project to open in this tab, or create a new one.</p>
-      )}
-
-      <div className={styles.sandboxPanel}>
-        <div>
-          <div className={styles.sandboxTitle}>
-            <Cube20Regular /> Sandbox for this session
+      <div className={embedded ? styles.launchSurface : `${styles.launchSurface} ${styles.launchSurfaceFull}`}>
+        <div className={styles.primaryColumn}>
+          <div className={styles.launchHeader}>
+            <div className={styles.launchTitleBlock}>
+              {!embedded && <div className={styles.kicker}>Code Deck</div>}
+              {embedded ? (
+                <div className={styles.launchTitle}>Projects</div>
+              ) : (
+                <Heading size="md">Start a session</Heading>
+              )}
+              {!embedded && <p className={styles.description}>Choose a project. Change sandbox only if needed.</p>}
+            </div>
+            <div className={styles.launchActions}>
+              <div className={styles.sandboxAction}>
+                <span className={styles.sandboxActionLabel}>Run in</span>
+                {availableProfiles.length > 0 ? (
+                  <SandboxPicker
+                    value={selectedProfileAvailable ? selectedProfileName : (availableProfiles[0] ?? 'host')}
+                    onChange={handleSandboxChange}
+                    context={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
+                    compact
+                  />
+                ) : (
+                  <Badge appearance="outline">No sandboxes</Badge>
+                )}
+              </div>
+              <Button variant="ghost" size="sm" onClick={handleOpenNewProject}>
+                <Add20Regular className={styles.newProjectIcon} style={{ width: 14, height: 14 }} />
+                New
+              </Button>
+            </div>
           </div>
-          <div
-            className={selectedProfileAvailable ? styles.sandboxHint : `${styles.sandboxHint} ${styles.unavailable}`}
-          >
-            {tab?.profileNameExplicit
-              ? 'One-off override for this Agent Session.'
-              : 'Defaults update when you choose a project.'}
-            {!selectedProfileAvailable
-              ? ' Selected profile is unavailable; project launch will use a safe fallback.'
-              : ''}
+
+          <div className={styles.grid}>
+            {projects.length > 0 ? (
+              projects.map((project) => (
+                <ProjectCard key={project.id} project={project} onSelect={handleSelectProject} />
+              ))
+            ) : (
+              <div className={styles.emptyProjects}>Create your first project to start.</div>
+            )}
           </div>
         </div>
-        {availableProfiles.length > 0 ? (
-          <SandboxPicker
-            value={selectedProfileAvailable ? selectedProfileName : (availableProfiles[0] ?? 'host')}
-            onChange={handleSandboxChange}
-            context={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
-          />
-        ) : (
-          <Badge appearance="outline">No sandbox profiles</Badge>
-        )}
+        <div className={styles.sideColumn} />
       </div>
-
-      <div className={styles.grid}>
-        {projects.map((project) => (
-          <ProjectCard
-            key={project.id}
-            project={project}
-            resolution={resolveSandboxForProject(project, explicitProfileName, availableProfiles, defaultProfileName)}
-            onSelect={handleSelectProject}
-          />
-        ))}
-      </div>
-
-      <Button variant="ghost" onClick={handleOpenNewProject}>
-        <Add20Regular className={styles.newProjectIcon} style={{ width: 14, height: 14 }} />
-        Create new project
-      </Button>
 
       <ProjectForm
         open={showNewProject}

--- a/src/renderer/features/Code/CodeTabContent.tsx
+++ b/src/renderer/features/Code/CodeTabContent.tsx
@@ -5,7 +5,6 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getArtifactsDir, getContainerArtifactsDir, profileRunsOnHost } from '@/lib/artifacts';
 import { buildSessionVariables } from '@/lib/client-tools';
-import { SessionStartupShell } from '@/renderer/common/SessionStartupShell';
 import { Button, Spinner } from '@/renderer/ds';
 import { SessionStatusBanner } from '@/renderer/features/Banner/SessionStatusBanner';
 import { getAvailableProfileNames, getProfileMenuLabel } from '@/renderer/features/SandboxProfile/profile-list';
@@ -35,10 +34,25 @@ const useStyles = makeStyles({
   fullSizeRelative: { width: '100%', height: '100%', position: 'relative' },
   hidden: { display: 'none' },
   flexCenter: { width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' },
-  errorWrap: { maxWidth: '448px', textAlign: 'center', paddingLeft: tokens.spacingHorizontalL, paddingRight: tokens.spacingHorizontalL },
-  errorText: { fontSize: tokens.fontSizeBase400, fontWeight: tokens.fontWeightMedium, color: tokens.colorNeutralForeground1 },
+  errorWrap: {
+    maxWidth: '448px',
+    textAlign: 'center',
+    paddingLeft: tokens.spacingHorizontalL,
+    paddingRight: tokens.spacingHorizontalL,
+  },
+  errorText: {
+    fontSize: tokens.fontSizeBase400,
+    fontWeight: tokens.fontWeightMedium,
+    color: tokens.colorNeutralForeground1,
+  },
   errorRetry: { marginTop: tokens.spacingVerticalL },
-  flexColFullRelative: { display: 'flex', flexDirection: 'column', width: '100%', height: '100%', position: 'relative' },
+  flexColFullRelative: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    height: '100%',
+    position: 'relative',
+  },
   flex1Relative: { flex: '1 1 0', minHeight: 0, position: 'relative' },
   // In-place sandbox-switch scrim — dims the still-mounted agent column while
   // the sandbox is rebuilt; the conversation reappears intact when it clears.
@@ -65,7 +79,11 @@ const useStyles = makeStyles({
     maxWidth: '320px',
     textAlign: 'center',
   },
-  switchTitle: { fontSize: tokens.fontSizeBase400, fontWeight: tokens.fontWeightSemibold, color: tokens.colorNeutralForeground1 },
+  switchTitle: {
+    fontSize: tokens.fontSizeBase400,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
+  },
   switchHint: { fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3 },
   spinnerPill: {
     display: 'inline-flex',
@@ -240,7 +258,20 @@ type CodeTabContentProps = {
 };
 
 export const CodeTabContent = memo(
-  ({ tab, isVisible, activeApp = 'chat', onActiveAppChange, uiMinimal, headerActionsTargetId, headerActionsCompact, previewUrl, onPreviewUrlChange, dockTargetId, isGlass, sidecarMode }: CodeTabContentProps) => {
+  ({
+    tab,
+    isVisible,
+    activeApp = 'chat',
+    onActiveAppChange,
+    uiMinimal,
+    headerActionsTargetId,
+    headerActionsCompact,
+    previewUrl,
+    onPreviewUrlChange,
+    dockTargetId,
+    isGlass,
+    sidecarMode,
+  }: CodeTabContentProps) => {
     const styles = useStyles();
     const store = useStore(persistedStoreApi.$atom);
     const project = useMemo(
@@ -252,7 +283,8 @@ export const CodeTabContent = memo(
     // lazily so the sandbox can start even when the user hasn't picked a
     // workspace.
     const projectSource = firstSource(project);
-    const linkedWorkspaceDir = tab.workspaceDir ?? (projectSource?.kind === 'local' ? projectSource.workspaceDir : null) ?? null;
+    const linkedWorkspaceDir =
+      tab.workspaceDir ?? (projectSource?.kind === 'local' ? projectSource.workspaceDir : null) ?? null;
     const [resolvedProjectDir, setResolvedProjectDir] = useState<string | null>(null);
     useEffect(() => {
       if (linkedWorkspaceDir || !tab.projectId) {
@@ -279,8 +311,7 @@ export const CodeTabContent = memo(
     // ``useStore``. The ``project?.sandboxProfile`` / ``store.defaultProfileName``
     // fallbacks below only kick in for tabs predating the migration that
     // somehow got loaded without a stored profileName (defensive).
-    const profileName =
-      tab.profileName ?? project?.sandboxProfile ?? store.defaultProfileName ?? 'host';
+    const profileName = tab.profileName ?? project?.sandboxProfile ?? store.defaultProfileName ?? 'host';
     const handleProfileChange = useCallback(
       (value: string) => {
         void codeApi.setTabProfile(tab.id, value);
@@ -296,10 +327,11 @@ export const CodeTabContent = memo(
       emitter.invoke('platform:is-enterprise').then(setIsEnterprise);
     }, []);
     const sandboxOptions = useMemo(
-      () => getAvailableProfileNames({ isEnterprise, available: store.availableSandboxProfiles }).map((name) => ({
-        value: name,
-        label: getProfileMenuLabel(name, machines),
-      })),
+      () =>
+        getAvailableProfileNames({ isEnterprise, available: store.availableSandboxProfiles }).map((name) => ({
+          value: name,
+          label: getProfileMenuLabel(name, machines),
+        })),
       [isEnterprise, store.availableSandboxProfiles, machines]
     );
 
@@ -335,12 +367,12 @@ export const CodeTabContent = memo(
     // which is exactly what we want to persist for the next start.
     useEffect(() => {
       if (sandboxStatus?.type !== 'running') {
-return;
-}
+        return;
+      }
       const next = sandboxStatus.data.containerId;
       if ((tab.containerId ?? undefined) === next) {
-return;
-}
+        return;
+      }
       void codeApi.setTabContainerId(tab.id, next);
     }, [sandboxStatus, tab.id, tab.containerId]);
 
@@ -367,9 +399,7 @@ return;
     const handleClientToolCall = useMemo(
       () =>
         buildClientToolHandler({
-          ...(tab.ticketId && tab.projectId
-            ? { ticketId: tab.ticketId as TicketId, projectId: tab.projectId }
-            : {}),
+          ...(tab.ticketId && tab.projectId ? { ticketId: tab.ticketId as TicketId, projectId: tab.projectId } : {}),
           tabId: tab.id,
         }),
       [tab.id, tab.ticketId, tab.projectId]
@@ -426,28 +456,19 @@ return;
     const onColumnMouseEnter = useCallback(() => $hoveredVoiceScope.set(tab.id), [tab.id]);
     const onColumnMouseLeave = useCallback(() => {
       if ($hoveredVoiceScope.get() === tab.id) {
-$hoveredVoiceScope.set(null);
-}
+        $hoveredVoiceScope.set(null);
+      }
     }, [tab.id]);
     const voiceVariables = useMemo(
-      () =>
-        localVoice
-          ? buildSessionVariables({ ...baseSessionArgs, voice: true, personaInstructions })
-          : undefined,
-      [baseSessionArgs, localVoice, personaInstructions],
+      () => (localVoice ? buildSessionVariables({ ...baseSessionArgs, voice: true, personaInstructions }) : undefined),
+      [baseSessionArgs, localVoice, personaInstructions]
     );
 
     // No project selected — show project picker
     if (!tab.projectId) {
       return (
         <div className={mergeClasses(styles.fullSize, !isVisible && styles.hidden)}>
-          <SessionStartupShell
-            eyebrow="Workspace Setup"
-            title="Choose a project"
-            description="Open an existing project in this session or create a new one to start working."
-          >
-            <CodeEmptyState tabId={tab.id} embedded />
-          </SessionStartupShell>
+          <CodeEmptyState tabId={tab.id} embedded />
         </div>
       );
     }
@@ -461,33 +482,33 @@ $hoveredVoiceScope.set(null);
         <SessionStatusBanner status={sandboxStatus} />
         {sandboxUrls ? (
           <VoiceScopeContext.Provider value={tab.id}>
-          <CodeRunningView
-            sandboxUrls={sandboxUrls}
-            sessionId={tab.sessionId}
-            onSessionChange={handleSessionChange}
-            variables={clientToolVariables}
-            voiceVariables={voiceVariables}
-            activeApp={activeApp}
-            onActiveAppChange={onActiveAppChange}
-            onReady={() => {}}
-            uiMinimal={uiMinimal}
-            headerActionsTargetId={headerActionsTargetId}
-            headerActionsCompact={headerActionsCompact}
-            sandboxLabel={sandboxLabel}
-            sandboxOptions={sandboxOptions}
-            currentSandboxProfile={profileName}
-            onSandboxChange={handleProfileChange}
-            onClientToolCall={handleClientToolCall}
-            previewUrl={previewUrl}
-            onPreviewUrlChange={onPreviewUrlChange}
-            dockTargetId={dockTargetId}
-            isGlass={isGlass}
-            tabId={tab.id}
-            agentWorkspaceDir={agentWorkspaceDir}
-            sidecarMode={sidecarMode}
-            ticketId={tab.ticketId as TicketId | undefined}
-            switching={sandboxStatus?.type === 'running' && !!sandboxStatus.data.switching}
-          />
+            <CodeRunningView
+              sandboxUrls={sandboxUrls}
+              sessionId={tab.sessionId}
+              onSessionChange={handleSessionChange}
+              variables={clientToolVariables}
+              voiceVariables={voiceVariables}
+              activeApp={activeApp}
+              onActiveAppChange={onActiveAppChange}
+              onReady={() => {}}
+              uiMinimal={uiMinimal}
+              headerActionsTargetId={headerActionsTargetId}
+              headerActionsCompact={headerActionsCompact}
+              sandboxLabel={sandboxLabel}
+              sandboxOptions={sandboxOptions}
+              currentSandboxProfile={profileName}
+              onSandboxChange={handleProfileChange}
+              onClientToolCall={handleClientToolCall}
+              previewUrl={previewUrl}
+              onPreviewUrlChange={onPreviewUrlChange}
+              dockTargetId={dockTargetId}
+              isGlass={isGlass}
+              tabId={tab.id}
+              agentWorkspaceDir={agentWorkspaceDir}
+              sidecarMode={sidecarMode}
+              ticketId={tab.ticketId as TicketId | undefined}
+              switching={sandboxStatus?.type === 'running' && !!sandboxStatus.data.switching}
+            />
           </VoiceScopeContext.Provider>
         ) : phase === 'error' ? (
           <CodeErrorView tabId={tab.id} retry={retry} />
@@ -517,9 +538,7 @@ $hoveredVoiceScope.set(null);
                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                 />
               </svg>
-              <span className={styles.spinnerText}>
-                {phase === 'idle' ? 'Restarting sandbox…' : 'Connecting…'}
-              </span>
+              <span className={styles.spinnerText}>{phase === 'idle' ? 'Restarting sandbox…' : 'Connecting…'}</span>
             </motion.div>
           </div>
         )}

--- a/src/renderer/features/SandboxProfile/SandboxPicker.tsx
+++ b/src/renderer/features/SandboxProfile/SandboxPicker.tsx
@@ -19,12 +19,18 @@ import { memo, useCallback } from 'react';
 import { Menu, MenuItem, MenuList, MenuPopover, MenuTrigger } from '@/renderer/ds';
 import { $machines } from '@/renderer/services/machines';
 
-import {
-  type ProfileListContext,
-  getAvailableProfileNames,
-  getProfileMenuLabel,
-  isLocalProfile,
-} from './profile-list';
+import { getAvailableProfileNames, getProfileMenuLabel, isLocalProfile, type ProfileListContext } from './profile-list';
+
+const COMPACT_PROFILE_LABELS: Record<string, string> = {
+  host: 'Host',
+  devbox: 'Devbox',
+  platform: 'Platform',
+  aci: 'Cloud',
+  'aci-desktop': 'Desktop',
+};
+
+const getCompactProfileLabel = (name: string): string =>
+  COMPACT_PROFILE_LABELS[name] ?? name.replace(/^local:/, 'Local ');
 
 export type SandboxPickerProps = {
   /** Currently-chosen profile name. */
@@ -35,9 +41,11 @@ export type SandboxPickerProps = {
   context: ProfileListContext;
   /** Disable the picker (e.g. when the agent is already launching). */
   disabled?: boolean;
+  /** Use a shorter trigger for tight toolbar/action-bar placements. */
+  compact?: boolean;
 };
 
-export const SandboxPicker = memo(({ value, onChange, context, disabled }: SandboxPickerProps) => {
+export const SandboxPicker = memo(({ value, onChange, context, disabled, compact = false }: SandboxPickerProps) => {
   const machines = useStore($machines);
   const names = getAvailableProfileNames({ ...context, machines });
 
@@ -61,13 +69,19 @@ export const SandboxPicker = memo(({ value, onChange, context, disabled }: Sandb
         <button
           type="button"
           disabled={disabled}
-          className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-stroke-1 bg-bgCard text-fg-muted text-xs font-medium hover:bg-bgHover hover:border-stroke-2 disabled:opacity-50"
+          className={
+            compact
+              ? 'inline-flex min-w-0 max-w-24 items-center justify-between gap-1 px-2 py-1 rounded-md border border-stroke-1 bg-bgCard text-fg-muted text-xs font-medium hover:bg-bgHover hover:border-stroke-2 disabled:opacity-50'
+              : 'inline-flex items-center gap-1 px-2 py-1 rounded-md border border-stroke-1 bg-bgCard text-fg-muted text-xs font-medium hover:bg-bgHover hover:border-stroke-2 disabled:opacity-50'
+          }
         >
-          <span className="inline-flex items-center gap-1">
-            <Cube16Regular />
-            {getProfileMenuLabel(value, machines)}
+          <span className="inline-flex min-w-0 items-center gap-1">
+            {!compact && <Cube16Regular />}
+            <span className="truncate">
+              {compact ? getCompactProfileLabel(value) : getProfileMenuLabel(value, machines)}
+            </span>
           </span>
-          <ChevronDown16Regular />
+          <ChevronDown16Regular className="shrink-0" />
         </button>
       </MenuTrigger>
       <MenuPopover>
@@ -78,9 +92,7 @@ export const SandboxPicker = memo(({ value, onChange, context, disabled }: Sandb
               <MenuItem
                 key={name}
                 onClick={() => handleSelect(name)}
-                icon={
-                  selected ? <Checkmark16Regular className="text-brand" /> : <span className="w-4" />
-                }
+                icon={selected ? <Checkmark16Regular className="text-brand" /> : <span className="w-4" />}
               >
                 {getProfileMenuLabel(name, machines)}
               </MenuItem>
@@ -97,9 +109,7 @@ export const SandboxPicker = memo(({ value, onChange, context, disabled }: Sandb
                   <MenuItem
                     key={name}
                     onClick={() => handleSelect(name)}
-                    icon={
-                      selected ? <Checkmark16Regular className="text-brand" /> : <span className="w-4" />
-                    }
+                    icon={selected ? <Checkmark16Regular className="text-brand" /> : <span className="w-4" />}
                   >
                     {getProfileMenuLabel(name, machines)}
                   </MenuItem>


### PR DESCRIPTION
## Summary

- Redesigns the Code Deck no-project state into a compact action-bar launcher instead of a verbose empty-state panel.
- Removes the legacy workspace-setup wrapper copy so the visible affordances are project selection, `Run in` sandbox selection, and new-project creation.
- Uses dense flat project rows with compact source labels (`Local · <folder>` or `Git · <owner>/<repo>`) instead of full paths/URLs.
- Shows sandbox once in the header action bar as `Run in <sandbox>` and sizes no-project launch tabs against the actual deck container to avoid horizontal overflow.

## Test plan

- `npx prettier --check src/renderer/features/Code/CodeEmptyState.tsx src/renderer/features/Code/CodeTabContent.tsx src/renderer/features/Code/CodeDeck.tsx`
- `npx eslint src/renderer/features/Code/CodeEmptyState.tsx`
- Captured and inspected visual proof screenshots:
  - `/workspace/.omni-artifacts/tkt_NogyuR1d2z54/screenshots/code-empty-state-narrow.png`
  - `/workspace/.omni-artifacts/tkt_NogyuR1d2z54/screenshots/code-empty-state-desktop.png`
- CDP proof showed body horizontal overflow `false` for narrow and desktop captures.
- `npm run lint:tsc` was attempted after `npm install`; it fails on pre-existing repo-wide TypeScript errors outside this change.
- `npx eslint src/renderer/features/Code/CodeDeck.tsx src/renderer/features/Code/CodeTabContent.tsx` was attempted; those files have pre-existing unrelated lint errors outside this patch.
