### PR TITLE
Normalize mobile safe-area surfaces

### DIFF
--- a/src/renderer/app/Sidebar.tsx
+++ b/src/renderer/app/Sidebar.tsx
@@ -48,6 +48,7 @@ const useStyles = makeStyles({
     borderTopWidth: '1px',
     borderTopStyle: 'solid',
     borderTopColor: tokens.colorNeutralStroke1,
+    boxSizing: 'border-box',
     paddingBottom: 'env(safe-area-inset-bottom, 0px)',
     '@media (min-width: 640px)': {
       flexDirection: 'column',
@@ -170,7 +171,7 @@ const useStyles = makeStyles({
   /* ── Active indicator bar ── */
   indicator: {
     position: 'absolute',
-    bottom: '0',
+    bottom: 'env(safe-area-inset-bottom, 0px)',
     left: '25%',
     right: '25%',
     height: '3px',

--- a/src/renderer/ds/BottomSheet.tsx
+++ b/src/renderer/ds/BottomSheet.tsx
@@ -1,10 +1,4 @@
-import {
-  Drawer,
-  DrawerBody,
-  makeStyles,
-  mergeClasses,
-  tokens,
-} from '@fluentui/react-components';
+import { Drawer, DrawerBody, makeStyles, mergeClasses, tokens } from '@fluentui/react-components';
 import type { PropsWithChildren } from 'react';
 import { useCallback } from 'react';
 
@@ -48,6 +42,7 @@ const useStyles = makeStyles({
     flex: '1 1 0',
     minHeight: 0,
     padding: 0,
+    paddingBottom: 'env(safe-area-inset-bottom, 0px)',
   },
 });
 
@@ -57,8 +52,8 @@ export const BottomSheet = ({ open, onClose, className, children }: PropsWithChi
   const handleOpenChange = useCallback(
     (_event: unknown, data: { open: boolean }) => {
       if (!data.open) {
-onClose();
-}
+        onClose();
+      }
     },
     [onClose]
   );

--- a/src/renderer/features/Code/CodeDeck.tsx
+++ b/src/renderer/features/Code/CodeDeck.tsx
@@ -525,6 +525,7 @@ const useStyles = makeStyles({
     ...shorthands.borderBottom('1px', 'solid', tokens.colorNeutralStroke1),
     backgroundColor: tokens.colorNeutralBackground2,
     overflowX: 'auto',
+    paddingTop: 'env(safe-area-inset-top, 0px)',
     [`@media (min-width: ${SNAP_SCROLL_WIDTH + 1}px)`]: { display: 'none' },
   },
   mobileTabBarInner: {

--- a/src/renderer/features/Code/EnvironmentDock.tsx
+++ b/src/renderer/features/Code/EnvironmentDock.tsx
@@ -35,6 +35,9 @@ const useStyles = makeStyles({
     backgroundColor: tokens.colorNeutralBackground1,
     boxShadow: `0 1px 12px rgba(0,0,0,0.10), 0 0 0 1px ${tokens.colorNeutralStroke1}`,
     flexShrink: 0,
+    '@media (max-width: 639px)': {
+      paddingBottom: `calc(5px + env(safe-area-inset-bottom, 0px))`,
+    },
   },
   dockGlass: {
     backgroundColor: `color-mix(in srgb, ${tokens.colorNeutralBackground1} 18%, transparent)`,

--- a/src/renderer/features/Tickets/Sidebar.tsx
+++ b/src/renderer/features/Tickets/Sidebar.tsx
@@ -1,5 +1,6 @@
 import {
   makeStyles,
+  mergeClasses,
   NavDrawer,
   NavDrawerBody,
   type NavDrawerProps,
@@ -53,6 +54,11 @@ const useStyles = makeStyles({
        to match the Settings sidebar and the rest of the app's page plane. */
     backgroundColor: tokens.colorNeutralBackground1,
   },
+  drawerOverlay: {
+    boxSizing: 'border-box',
+    paddingLeft: 'env(safe-area-inset-left, 0px)',
+    paddingRight: 'env(safe-area-inset-right, 0px)',
+  },
   header: {
     display: 'flex',
     alignItems: 'center',
@@ -61,11 +67,17 @@ const useStyles = makeStyles({
     paddingTop: tokens.spacingVerticalXXL,
     paddingBottom: tokens.spacingVerticalL,
   },
+  headerOverlay: {
+    paddingTop: `calc(${tokens.spacingVerticalXXL} + env(safe-area-inset-top, 0px))`,
+  },
   headerTitle: {
     flex: '1 1 0',
   },
   body: {
     flex: '1 1 0',
+  },
+  bodyOverlay: {
+    paddingBottom: `calc(${tokens.spacingVerticalL} + env(safe-area-inset-bottom, 0px))`,
   },
   sectionHeader: {
     display: 'flex',
@@ -212,7 +224,10 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
   }, []);
   const handleAddSource = useCallback((projectId: string) => setAddSourceProjectId(projectId), []);
   const handleCloseAddSource = useCallback(() => setAddSourceProjectId(null), []);
-  const handleOpenSource = useCallback((projectId: string, sourceId: string) => setSourceDetail({ projectId, sourceId }), []);
+  const handleOpenSource = useCallback(
+    (projectId: string, sourceId: string) => setSourceDetail({ projectId, sourceId }),
+    []
+  );
   const handleCloseSource = useCallback(() => setSourceDetail(null), []);
   const handleEditSource = useCallback(
     (projectId: string, sourceId: string) => setEditSource({ projectId, sourceId }),
@@ -309,11 +324,11 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
       open={open}
       onOpenChange={handleOpenChange}
       selectedValue={selectedValue}
-      className={styles.drawer}
+      className={mergeClasses(styles.drawer, type === 'overlay' && styles.drawerOverlay)}
       size="small"
     >
       {/* ── Header ── */}
-      <div className={styles.header}>
+      <div className={mergeClasses(styles.header, type === 'overlay' && styles.headerOverlay)}>
         <Subtitle2 className={styles.headerTitle}>Projects</Subtitle2>
         <TeamSwitcher />
         <IconButton aria-label="New project" icon={<Add20Regular />} size="sm" onClick={handleOpenForm} />
@@ -322,7 +337,7 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
         )}
       </div>
 
-      <NavDrawerBody className={styles.body}>
+      <NavDrawerBody className={mergeClasses(styles.body, type === 'overlay' && styles.bodyOverlay)}>
         {/* ── Pinned: Home + Inbox as tree leaves so they share exact
               geometry with the projects tree below. ── */}
         <Tree aria-label="Pinned" className={styles.pinnedTree}>
@@ -377,12 +392,7 @@ export const TicketsSidebar = memo(({ onNavigate, type = 'inline', open = true, 
         />
       )}
       {editSourceProject && editSourceSource && (
-        <EditSourceDialog
-          open
-          onClose={handleCloseEditSource}
-          project={editSourceProject}
-          source={editSourceSource}
-        />
+        <EditSourceDialog open onClose={handleCloseEditSource} project={editSourceProject} source={editSourceSource} />
       )}
       <AnimatedDialog
         open={milestoneFormProjectId !== null || editingMilestone !== null}

--- a/src/renderer/features/WorkspaceSync/SyncBar.tsx
+++ b/src/renderer/features/WorkspaceSync/SyncBar.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     gap: '10px',
     height: '32px',
+    paddingBottom: 'env(safe-area-inset-bottom, 0px)',
     paddingLeft: '12px',
     paddingRight: '12px',
     backgroundColor: tokens.colorNeutralBackground1,
@@ -31,6 +32,7 @@ const useStyles = makeStyles({
     borderTopColor: tokens.colorNeutralStroke2,
     fontSize: '12px',
     color: tokens.colorNeutralForeground2,
+    boxSizing: 'content-box',
     '@media (min-width: 640px)': {
       left: '78px', // sidebar width
     },
@@ -82,8 +84,8 @@ const useStyles = makeStyles({
 
 function formatEta(seconds: number): string {
   if (seconds < 60) {
-return `${seconds}s left`;
-}
+    return `${seconds}s left`;
+  }
   const mins = Math.floor(seconds / 60);
   const secs = seconds % 60;
   return secs > 0 ? `${mins}m ${secs}s left` : `${mins}m left`;
@@ -91,11 +93,11 @@ return `${seconds}s left`;
 
 function formatRate(bytesPerSecond: number): string {
   if (bytesPerSecond < 1024) {
-return `${Math.round(bytesPerSecond)} B/s`;
-}
+    return `${Math.round(bytesPerSecond)} B/s`;
+  }
   if (bytesPerSecond < 1024 * 1024) {
-return `${(bytesPerSecond / 1024).toFixed(1)} KB/s`;
-}
+    return `${(bytesPerSecond / 1024).toFixed(1)} KB/s`;
+  }
   return `${(bytesPerSecond / (1024 * 1024)).toFixed(1)} MB/s`;
 }
 
@@ -104,8 +106,8 @@ function useAggregateStatus(statuses: Record<string, WorkspaceSyncStatus>) {
   return useMemo(() => {
     const entries = Object.values(statuses);
     if (entries.length === 0) {
-return null;
-}
+      return null;
+    }
 
     // Find the most "active" status
     const error = entries.find((s) => s.state === 'error');
@@ -130,8 +132,7 @@ return null;
     if (active?.progress) {
       const p = active.progress;
       const pct = p.totalFiles > 0 ? p.completedFiles / p.totalFiles : 0;
-      const phaseLabel =
-        p.phase === 'uploading' ? 'Uploading' : p.phase === 'downloading' ? 'Downloading' : 'Syncing';
+      const phaseLabel = p.phase === 'uploading' ? 'Uploading' : p.phase === 'downloading' ? 'Downloading' : 'Syncing';
       return {
         type: 'progress' as const,
         message: `${phaseLabel} ${p.completedFiles} of ${p.totalFiles} files`,
@@ -172,8 +173,8 @@ export const SyncBar = memo(() => {
   const agg = useAggregateStatus(statuses);
 
   if (!agg) {
-return null;
-}
+    return null;
+  }
 
   const icon =
     agg.type === 'error' ? (
@@ -203,12 +204,7 @@ return null;
 
       {agg.type === 'progress' && agg.progress && (
         <>
-          <ProgressBar
-            className={styles.progress}
-            value={agg.progress.percent}
-            thickness="medium"
-            shape="rounded"
-          />
+          <ProgressBar className={styles.progress} value={agg.progress.percent} thickness="medium" shape="rounded" />
           {agg.progress.rate > 0 && <span className={styles.eta}>{formatRate(agg.progress.rate)}</span>}
           {agg.progress.eta != null && agg.progress.eta > 0 && (
             <span className={styles.eta}>{formatEta(agg.progress.eta)}</span>

--- a/src/renderer/omniagents-ui/components/Sidebar.tsx
+++ b/src/renderer/omniagents-ui/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   MenuList,
   MenuPopover,
   MenuTrigger,
+  mergeClasses,
   NavDrawer,
   NavDrawerBody,
   NavDrawerHeader,
@@ -45,9 +46,7 @@ import type { SessionItem } from './SessionList';
 // `display: none` at every viewport size.
 function useIsDesktop(breakpointPx = 768): boolean {
   const [isDesktop, setIsDesktop] = useState(() =>
-    typeof window !== 'undefined'
-      ? window.matchMedia(`(min-width: ${breakpointPx}px)`).matches
-      : true
+    typeof window !== 'undefined' ? window.matchMedia(`(min-width: ${breakpointPx}px)`).matches : true
   );
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -73,9 +72,10 @@ const BUCKET_LABELS: Record<Bucket, string> = {
 const BUCKET_ORDER: Bucket[] = ['today', 'yesterday', 'previous7', 'previous30', 'older'];
 
 function sessionTimestamp(s: SessionItem): number {
-  const raw = (s as { last_message?: { timestamp?: string }; created_at?: string }).last_message?.timestamp
-    ?? (s as { created_at?: string }).created_at
-    ?? '';
+  const raw =
+    (s as { last_message?: { timestamp?: string }; created_at?: string }).last_message?.timestamp ??
+    (s as { created_at?: string }).created_at ??
+    '';
   const n = Date.parse(raw);
   return Number.isNaN(n) ? 0 : n;
 }
@@ -115,6 +115,11 @@ const useStyles = makeStyles({
     maxWidth: '288px',
     backgroundColor: tokens.colorNeutralBackground1,
   },
+  drawerOverlay: {
+    boxSizing: 'border-box',
+    paddingLeft: 'env(safe-area-inset-left, 0px)',
+    paddingRight: 'env(safe-area-inset-right, 0px)',
+  },
   /* 24px top to match the Settings sidebar and app nav rail. */
   headerStack: {
     display: 'flex',
@@ -122,6 +127,9 @@ const useStyles = makeStyles({
     gap: tokens.spacingVerticalS,
     paddingTop: tokens.spacingVerticalXXL,
     paddingBottom: tokens.spacingVerticalL,
+  },
+  headerStackOverlay: {
+    paddingTop: `calc(${tokens.spacingVerticalXXL} + env(safe-area-inset-top, 0px))`,
   },
   headerRow: {
     display: 'flex',
@@ -196,6 +204,9 @@ const useStyles = makeStyles({
     paddingTop: tokens.spacingVerticalM,
     paddingBottom: tokens.spacingVerticalM,
   },
+  bodyOverlay: {
+    paddingBottom: `calc(${tokens.spacingVerticalL} + env(safe-area-inset-bottom, 0px))`,
+  },
 });
 
 export function Sidebar({
@@ -220,10 +231,7 @@ export function Sidebar({
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const isDesktop = useIsDesktop();
 
-  const nonEmpty = useMemo(
-    () => sessions.filter((s) => s.message_count > 0),
-    [sessions],
-  );
+  const nonEmpty = useMemo(() => sessions.filter((s) => s.message_count > 0), [sessions]);
 
   const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -271,16 +279,13 @@ export function Sidebar({
   const renderSessionRow = (s: SessionItem) => {
     const title = generateSessionTitle(s);
     const timestamp = formatRelativeTime(
-      (s as { last_message?: { timestamp?: string } }).last_message?.timestamp ?? (s as { created_at?: string }).created_at,
+      (s as { last_message?: { timestamp?: string } }).last_message?.timestamp ??
+        (s as { created_at?: string }).created_at
     );
 
     return (
       <div key={s.id} className={styles.sessionRow}>
-        <NavItem
-          className={styles.sessionNavItem}
-          value={s.id}
-          onClick={() => handleSelect(s.id)}
-        >
+        <NavItem className={styles.sessionNavItem} value={s.id} onClick={() => handleSelect(s.id)}>
           <div className={styles.sessionLabel}>
             <span className={styles.sessionTitle}>{title}</span>
             <Caption1 className={styles.sessionMeta}>
@@ -293,19 +298,11 @@ export function Sidebar({
           <div data-reveal="kebab" className={styles.kebabWrap}>
             <Menu>
               <MenuTrigger disableButtonEnhancement>
-                <Button
-                  appearance="subtle"
-                  size="small"
-                  icon={<MoreHorizontal20Regular />}
-                  aria-label="More actions"
-                />
+                <Button appearance="subtle" size="small" icon={<MoreHorizontal20Regular />} aria-label="More actions" />
               </MenuTrigger>
               <MenuPopover>
                 <MenuList>
-                  <MenuItem
-                    icon={<Delete20Regular />}
-                    onClick={() => setDeleteTargetId(s.id)}
-                  >
+                  <MenuItem icon={<Delete20Regular />} onClick={() => setDeleteTargetId(s.id)}>
                     Delete conversation
                   </MenuItem>
                 </MenuList>
@@ -323,7 +320,7 @@ export function Sidebar({
   return (
     <>
       <NavDrawer
-        className={styles.drawer}
+        className={mergeClasses(styles.drawer, !isDesktop && styles.drawerOverlay)}
         type={isDesktop ? 'inline' : 'overlay'}
         open={open}
         onOpenChange={(_e, d) => {
@@ -336,7 +333,7 @@ export function Sidebar({
         separator
       >
         <NavDrawerHeader>
-          <div className={styles.headerStack}>
+          <div className={mergeClasses(styles.headerStack, !isDesktop && styles.headerStackOverlay)}>
             <div className={styles.headerRow}>
               <Subtitle2>Conversations</Subtitle2>
               <div className={styles.headerActions}>
@@ -368,7 +365,7 @@ export function Sidebar({
           </div>
         </NavDrawerHeader>
 
-        <NavDrawerBody>
+        <NavDrawerBody className={!isDesktop ? styles.bodyOverlay : undefined}>
           {!hasAnySession ? (
             <div className={styles.emptyState}>
               <Chat48Regular className={styles.emptyIcon} />
@@ -403,9 +400,7 @@ export function Sidebar({
         <DialogSurface>
           <DialogBody>
             <DialogTitle>Delete conversation?</DialogTitle>
-            <DialogContent>
-              This conversation will be permanently deleted. You can&apos;t undo this.
-            </DialogContent>
+            <DialogContent>This conversation will be permanently deleted. You can&apos;t undo this.</DialogContent>
             <DialogActions>
               <DialogTrigger disableButtonEnhancement>
                 <Button appearance="secondary">Cancel</Button>


### PR DESCRIPTION
## Summary
- Normalize safe-area handling for mobile sidebars, drawers, bottom sheets, and bottom surfaces.
- Keep bottom safe-area spacing inside the owning bar/dock surfaces so the home-indicator region matches the surface color.
- Preserve desktop layout by scoping drawer/dock adjustments to overlay/mobile contexts or zero-inset-safe properties.

## Test plan
- [x] `npm install`
- [x] `npm run build:server`
- [x] `npx prettier --check src/renderer/app/Sidebar.tsx src/renderer/features/Code/EnvironmentDock.tsx`
- [x] Visual proof captured in `/workspace/.omni-artifacts/tkt_FuKFusjtNdgB/proof/`, including `mobile-390x844-bottom-nav-refined.png`
- [ ] `npm run lint:tsc` — blocked by unrelated baseline repo-wide TypeScript errors, including missing `omni-projects-db` types and pre-existing test/type mismatches
