### PR TITLE
Add pipeline workflow contracts

### DIFF
--- a/packages/projects-db/src/defaults.ts
+++ b/packages/projects-db/src/defaults.ts
@@ -1,35 +1,168 @@
 /**
  * Default pipeline columns for new projects — single source of truth.
  *
- * Each column has:
- * - `logicalId`: stable per-project string (`backlog`, `spec`, ...) used in
- *   prompts and database sync.
- * - `label`: human-readable display name.
- * - `gate`: whether this column requires human review.
- *
  * The actual SQLite `pipeline_columns.id` is computed by `defaultColumnId`
  * as `${projectId}__${logicalId}` so it is globally unique while staying
  * deterministic and reproducible across database syncs.
  */
+export type ColumnWorkflowContract = {
+  purpose?: string;
+  entryCriteria?: string[];
+  definitionOfDone?: string[];
+  agentInstructions?: string;
+  recommendedSkills?: string[];
+  allowedTransitions?: string[];
+  autoDispatch?: boolean;
+};
+
 export type ColumnDef = {
   logicalId: string;
   label: string;
+  description?: string;
   gate?: boolean;
+  maxConcurrent?: number;
+  workflow?: ColumnWorkflowContract;
 };
 
 export const DEFAULT_COLUMNS: ColumnDef[] = [
-  { logicalId: 'backlog', label: 'Backlog' },
-  { logicalId: 'spec', label: 'Spec' },
-  { logicalId: 'implementation', label: 'Implementation' },
-  { logicalId: 'review', label: 'Review', gate: true },
-  { logicalId: 'pr', label: 'PR' },
-  { logicalId: 'completed', label: 'Completed' },
+  {
+    logicalId: 'backlog',
+    label: 'Backlog',
+    description: 'Capture unscheduled or unstarted software work.',
+    workflow: {
+      purpose: 'Capture unscheduled or unstarted software work.',
+      definitionOfDone: [
+        'Ticket is ready to start or intentionally parked.',
+        'Ticket has enough title and description for a human to understand the request.',
+      ],
+      agentInstructions: 'Do not edit source code in this column. If auto-dispatch starts here, move to the first active non-terminal column before working.',
+      recommendedSkills: [],
+    },
+  },
+  {
+    logicalId: 'spec',
+    label: 'Spec',
+    description: 'Understand the request and produce a decision-complete implementation plan.',
+    workflow: {
+      purpose: 'Understand the request and produce a decision-complete implementation plan.',
+      entryCriteria: [
+        'Ticket has a title and project assignment.',
+        'Any blocker tickets have been checked.',
+      ],
+      definitionOfDone: [
+        'Ticket, project pages, milestone brief, and relevant comments have been read.',
+        'Relevant source files and existing patterns have been inspected.',
+        'A plan page exists with scope, implementation approach, test strategy, risks, and out-of-scope items.',
+        'No source edits were made unless explicitly required to investigate a failing reproduction.',
+      ],
+      agentInstructions: 'Activate software-planning for feature, refactor, or spec work. Activate debug if this is a failure investigation and the root cause is not localized. Do not move to Implementation until the plan is decision-complete.',
+      recommendedSkills: ['software-planning', 'debug'],
+    },
+  },
+  {
+    logicalId: 'implementation',
+    label: 'Implementation',
+    description: 'Make the planned source changes.',
+    workflow: {
+      purpose: 'Make the planned source changes.',
+      entryCriteria: [
+        'The ticket has a decision-complete plan, or the ticket is small enough that the title and description fully define the change.',
+        'Required source context has been read.',
+      ],
+      definitionOfDone: [
+        'Planned code changes are implemented with minimal unrelated churn.',
+        'Tests are added or updated where the codebase has an appropriate testing pattern.',
+        'Targeted tests pass.',
+        'PR title/body artifacts are current.',
+        'No debug prints, stale TODOs, or commented-out code remain.',
+      ],
+      agentInstructions: 'Follow AGENTS.md in every source touched. Use worker agents only for independent subtasks with explicit file ownership and acceptance criteria. For bug fixes, prefer red-before-green testing when practical.',
+      recommendedSkills: ['debug', 'software-planning'],
+    },
+  },
+  {
+    logicalId: 'review',
+    label: 'Review',
+    description: 'Human review gate.',
+    gate: true,
+    workflow: {
+      purpose: 'Human review gate.',
+      definitionOfDone: [
+        'Human has reviewed the changes, artifacts, and test evidence.',
+        'Human decides whether to advance, request changes, or stop.',
+      ],
+      agentInstructions: 'This is a gate. Move tickets into this column when ready for human review, then stop. Never advance past this column automatically. Add a ticket comment summarizing completed work, test evidence, known risks, and next recommended action.',
+      recommendedSkills: [],
+    },
+  },
+  {
+    logicalId: 'pr',
+    label: 'PR',
+    description: 'Prepare, update, and shepherd pull request state after human review approval.',
+    workflow: {
+      purpose: 'Prepare, update, and shepherd pull request state after human review approval.',
+      entryCriteria: [
+        'Ticket has passed the Review gate by human action.',
+        'Source changes are ready to publish or already published.',
+      ],
+      definitionOfDone: [
+        'PR title/body are accurate.',
+        'Branch/PR metadata is linked to the ticket where available.',
+        'CI or local validation status is recorded.',
+        'Merge readiness is clear, or blockers are documented.',
+      ],
+      agentInstructions: 'Use push/PR-related skills only when explicitly asked or when the project workflow expects PR preparation. Do not merge unless the user or project policy explicitly allows it.',
+      recommendedSkills: ['push', 'pull', 'land'],
+    },
+  },
+  {
+    logicalId: 'completed',
+    label: 'Completed',
+    description: 'Terminal resolved state.',
+    workflow: {
+      purpose: 'Terminal resolved state.',
+      definitionOfDone: [
+        'Work is complete and accepted.',
+        'Cleanup has run or been explicitly deferred because worktree changes remain.',
+      ],
+      agentInstructions: 'Do not start autopilot in this column. Entering this column stops supervision and cleans up workspace state when safe.',
+      recommendedSkills: [],
+    },
+  },
 ];
 
 export const SIMPLE_COLUMNS: ColumnDef[] = [
-  { logicalId: 'backlog', label: 'Backlog' },
-  { logicalId: 'review', label: 'Review', gate: true },
-  { logicalId: 'completed', label: 'Completed' },
+  {
+    logicalId: 'backlog',
+    label: 'Backlog',
+    description: 'Capture unstarted ideas, notes, or tasks.',
+    workflow: {
+      purpose: 'Capture unstarted ideas, notes, or tasks.',
+      definitionOfDone: ['Item is clear enough to review or act on.'],
+      recommendedSkills: [],
+    },
+  },
+  {
+    logicalId: 'review',
+    label: 'Review',
+    description: 'Human review, shaping, or approval.',
+    gate: true,
+    workflow: {
+      purpose: 'Human review, shaping, or approval.',
+      definitionOfDone: ['Human has decided whether the item is complete, needs more detail, or should become source-backed work.'],
+      recommendedSkills: [],
+    },
+  },
+  {
+    logicalId: 'completed',
+    label: 'Completed',
+    description: 'Terminal state for finished work.',
+    workflow: {
+      purpose: 'Terminal state for finished work.',
+      definitionOfDone: ['Outcome is accepted or no further action is needed.'],
+      recommendedSkills: [],
+    },
+  },
 ];
 
 /**

--- a/packages/projects-db/src/migrate-from-json.ts
+++ b/packages/projects-db/src/migrate-from-json.ts
@@ -42,6 +42,7 @@ interface JsonColumn {
   description?: string;
   maxConcurrent?: number;
   gate?: boolean;
+  workflow?: unknown;
 }
 
 interface JsonTicket {
@@ -231,6 +232,8 @@ return 0;
           description: col.description ?? null,
           sort_order: i,
           gate: col.gate ? 1 : 0,
+          max_concurrent: col.maxConcurrent ?? null,
+          workflow: col.workflow == null ? null : JSON.stringify(col.workflow),
         });
       }
     }

--- a/packages/projects-db/src/pg/pg-repo.ts
+++ b/packages/projects-db/src/pg/pg-repo.ts
@@ -136,7 +136,7 @@ export class PgProjectsRepo implements IProjectsRepo {
   // ---- Pipeline columns ----
 
   listColumns(projectId: string): Promise<ColumnRow[]> {
-    return this.rows<ColumnRow>('SELECT * FROM pipeline_columns WHERE project_id = $1 ORDER BY sort_order', [projectId]);
+    return this.rows<ColumnRow>('SELECT tenant_id, id, project_id, label, description, sort_order, gate, max_concurrent, workflow::text AS workflow FROM pipeline_columns WHERE project_id = $1 ORDER BY sort_order', [projectId]);
   }
 
   async upsertColumn(row: ColumnRow): Promise<void> {
@@ -145,12 +145,13 @@ export class PgProjectsRepo implements IProjectsRepo {
 
   private upsertColumnIn(c: PoolClient, row: ColumnRow): Promise<unknown> {
     return c.query(
-      `INSERT INTO pipeline_columns (tenant_id, id, project_id, label, description, sort_order, gate)
-       VALUES ($1,$2,$3,$4,$5,$6,$7)
+      `INSERT INTO pipeline_columns (tenant_id, id, project_id, label, description, sort_order, gate, max_concurrent, workflow)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb)
        ON CONFLICT (id) DO UPDATE SET
          label = EXCLUDED.label, description = EXCLUDED.description,
-         sort_order = EXCLUDED.sort_order, gate = EXCLUDED.gate`,
-      [this.tenantId, row.id, row.project_id, row.label, row.description, row.sort_order, row.gate]
+         sort_order = EXCLUDED.sort_order, gate = EXCLUDED.gate,
+         max_concurrent = EXCLUDED.max_concurrent, workflow = EXCLUDED.workflow`,
+      [this.tenantId, row.id, row.project_id, row.label, row.description, row.sort_order, row.gate, row.max_concurrent, row.workflow]
     );
   }
 
@@ -179,11 +180,13 @@ export class PgProjectsRepo implements IProjectsRepo {
       description: d.description ?? null,
       sort_order: i,
       gate: d.gate ? 1 : 0,
+      max_concurrent: d.maxConcurrent ?? null,
+      workflow: d.workflow == null ? null : JSON.stringify(d.workflow),
     }));
     const result: ColumnSyncResult = { inserted: [], removed: [], remappedTickets: [] };
 
     return this.tx(async (c) => {
-      const oldRows = (await c.query('SELECT * FROM pipeline_columns WHERE project_id = $1 ORDER BY sort_order', [projectId])).rows as ColumnRow[];
+      const oldRows = (await c.query('SELECT tenant_id, id, project_id, label, description, sort_order, gate, max_concurrent, workflow::text AS workflow FROM pipeline_columns WHERE project_id = $1 ORDER BY sort_order', [projectId])).rows as ColumnRow[];
       const oldById = new Map(oldRows.map((r) => [r.id, r]));
       const newById = new Map(newRows.map((r) => [r.id, r]));
       const newByLabelLower = new Map(newRows.map((r) => [r.label.toLowerCase(), r]));

--- a/packages/projects-db/src/pg/schema.ts
+++ b/packages/projects-db/src/pg/schema.ts
@@ -466,4 +466,12 @@ CREATE POLICY principal_isolation ON machines
   USING (principal_id = current_setting('app.current_principal', true));
 `,
   },
+  {
+    version: 11,
+    sql: `
+-- DB-backed workflow metadata for pipeline columns.
+ALTER TABLE pipeline_columns ADD COLUMN max_concurrent INTEGER;
+ALTER TABLE pipeline_columns ADD COLUMN workflow JSONB;
+`,
+  },
 ];

--- a/packages/projects-db/src/repo-interface.ts
+++ b/packages/projects-db/src/repo-interface.ts
@@ -44,6 +44,8 @@ export interface ColumnSyncInput {
   label: string;
   description?: string | null;
   gate?: boolean;
+  maxConcurrent?: number | null;
+  workflow?: unknown;
 }
 
 /**

--- a/packages/projects-db/src/repo.test.ts
+++ b/packages/projects-db/src/repo.test.ts
@@ -94,6 +94,35 @@ describe('syncColumnsForProject', () => {
     expect(review.gate).toBe(0);
   });
 
+  it('persists workflow metadata and max concurrency on synced columns', () => {
+    repo.syncColumnsForProject(PROJECT_ID, [
+      { logicalId: 'backlog', label: 'Backlog' },
+      {
+        logicalId: 'spec',
+        label: 'Spec',
+        description: 'Plan the work',
+        maxConcurrent: 2,
+        workflow: {
+          purpose: 'Plan the implementation',
+          definitionOfDone: ['Decision-complete plan exists'],
+          agentInstructions: 'Use the software-planning skill.',
+          recommendedSkills: ['software-planning'],
+        },
+      },
+      { logicalId: 'completed', label: 'Completed' },
+    ]);
+
+    const spec = repo.listColumns(PROJECT_ID).find((c) => c.id === defaultColumnId(PROJECT_ID, 'spec'))!;
+    expect(spec.description).toBe('Plan the work');
+    expect(spec.max_concurrent).toBe(2);
+    expect(JSON.parse(spec.workflow!)).toEqual({
+      purpose: 'Plan the implementation',
+      definitionOfDone: ['Decision-complete plan exists'],
+      agentInstructions: 'Use the software-planning skill.',
+      recommendedSkills: ['software-planning'],
+    });
+  });
+
   it('rebinds tickets to new IDs by label match when logical id changes', () => {
     const tid = seedTicket('implementation');
     const renamed: ColumnSyncInput[] = [

--- a/packages/projects-db/src/repo.ts
+++ b/packages/projects-db/src/repo.ts
@@ -134,7 +134,7 @@ export class ProjectsRepo {
 
   upsertColumn(row: ColumnRow): void {
     this.stmts.upsertColumn.run(
-      row.id, row.project_id, row.label, row.description, row.sort_order, row.gate,
+      row.id, row.project_id, row.label, row.description, row.sort_order, row.gate, row.max_concurrent, row.workflow,
     );
     this.bumpChangeSeq();
   }
@@ -149,7 +149,7 @@ export class ProjectsRepo {
       this.stmts.deleteColumnsForProject.run(projectId);
       for (const row of rows) {
         this.stmts.upsertColumn.run(
-          row.id, row.project_id, row.label, row.description, row.sort_order, row.gate,
+          row.id, row.project_id, row.label, row.description, row.sort_order, row.gate, row.max_concurrent, row.workflow,
         );
       }
       this.bumpChangeSeq();
@@ -186,6 +186,8 @@ export class ProjectsRepo {
       description: d.description ?? null,
       sort_order: i,
       gate: d.gate ? 1 : 0,
+      max_concurrent: d.maxConcurrent ?? null,
+      workflow: d.workflow == null ? null : JSON.stringify(d.workflow),
     }));
 
     const result: ColumnSyncResult = { inserted: [], removed: [], remappedTickets: [] };
@@ -219,7 +221,7 @@ export class ProjectsRepo {
           result.inserted.push(row.id);
         }
         this.stmts.upsertColumn.run(
-          row.id, row.project_id, row.label, row.description, row.sort_order, row.gate,
+          row.id, row.project_id, row.label, row.description, row.sort_order, row.gate, row.max_concurrent, row.workflow,
         );
       }
 
@@ -637,11 +639,12 @@ function prepareStatements(db: DatabaseSync) {
     // Pipeline columns
     listColumns: db.prepare('SELECT * FROM pipeline_columns WHERE project_id = ? ORDER BY sort_order'),
     upsertColumn: db.prepare(`
-      INSERT INTO pipeline_columns (id, project_id, label, description, sort_order, gate)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO pipeline_columns (id, project_id, label, description, sort_order, gate, max_concurrent, workflow)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         label = excluded.label, description = excluded.description,
-        sort_order = excluded.sort_order, gate = excluded.gate
+        sort_order = excluded.sort_order, gate = excluded.gate,
+        max_concurrent = excluded.max_concurrent, workflow = excluded.workflow
     `),
     deleteColumnsForProject: db.prepare('DELETE FROM pipeline_columns WHERE project_id = ?'),
     deleteColumnById: db.prepare('DELETE FROM pipeline_columns WHERE id = ?'),

--- a/packages/projects-db/src/schema.ts
+++ b/packages/projects-db/src/schema.ts
@@ -258,4 +258,13 @@ CREATE TABLE page_content (
 ALTER TABLE tickets ADD COLUMN assignee TEXT;
 `,
   },
+  {
+    version: 10,
+    sql: `
+-- DB-backed workflow metadata for pipeline columns. Existing columns keep
+-- working; runtime mapping supplies safe defaults when these are NULL.
+ALTER TABLE pipeline_columns ADD COLUMN max_concurrent INTEGER;
+ALTER TABLE pipeline_columns ADD COLUMN workflow TEXT;
+`,
+  },
 ];

--- a/packages/projects-db/src/types.ts
+++ b/packages/projects-db/src/types.ts
@@ -29,6 +29,8 @@ export type ColumnRow = {
   description: string | null;
   sort_order: number;
   gate: number;
+  max_concurrent: number | null;
+  workflow: string | null;
 };
 
 export type TicketRow = {

--- a/packages/projects-mcp/src/seed.ts
+++ b/packages/projects-mcp/src/seed.ts
@@ -64,9 +64,11 @@ export async function seedProject(
     id: defaultColumnId(id, col.logicalId),
     project_id: id,
     label: col.label,
-    description: null,
+    description: col.description ?? null,
     sort_order: i,
     gate: col.gate ? 1 : 0,
+    max_concurrent: col.maxConcurrent ?? null,
+    workflow: col.workflow == null ? null : JSON.stringify(col.workflow),
   }));
   await repo.replaceColumnsForProject(id, columns);
 

--- a/packages/projects-mcp/src/tools/pipeline.ts
+++ b/packages/projects-mcp/src/tools/pipeline.ts
@@ -5,17 +5,31 @@ import { z } from 'zod';
 const json = (data: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(data) }] });
 const err = (message: string) => ({ content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }], isError: true as const });
 
+const parseWorkflow = (raw: string | null): unknown | undefined => {
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 export function registerPipelineTools(server: McpServer, repo: IProjectsRepo): void {
   server.tool(
     'get_pipeline',
-    'Get the full pipeline definition for a project — columns with labels, descriptions, and gate status.',
+    'Get the full pipeline definition for a project — columns with labels, descriptions, workflow contracts, max concurrency, and gate status.',
     { project_id: z.string().describe('The project ID to get the pipeline for.') },
     async ({ project_id }) => {
       const cols = await repo.listColumns(project_id);
 
       if (cols.length === 0) {
         const exists = await repo.getProject(project_id);
-        if (!exists) return err(`Project not found: ${project_id}`);
+        if (!exists) {
+          return err(`Project not found: ${project_id}`);
+        }
       }
 
       return json({
@@ -24,6 +38,8 @@ export function registerPipelineTools(server: McpServer, repo: IProjectsRepo): v
           label: c.label,
           description: c.description,
           gate: !!c.gate,
+          maxConcurrent: c.max_concurrent ?? undefined,
+          workflow: parseWorkflow(c.workflow),
         })),
       });
     }

--- a/src/lib/project-files.ts
+++ b/src/lib/project-files.ts
@@ -185,6 +185,15 @@ const ColumnSchema = z.object({
   description: z.string().optional(),
   maxConcurrent: z.number().int().positive().optional(),
   gate: z.boolean().optional(),
+  workflow: z.object({
+    purpose: z.string().optional(),
+    entryCriteria: z.array(z.string()).optional(),
+    definitionOfDone: z.array(z.string()).optional(),
+    agentInstructions: z.string().optional(),
+    recommendedSkills: z.array(z.string()).optional(),
+    allowedTransitions: z.array(z.string()).optional(),
+    autoDispatch: z.boolean().optional(),
+  }).optional(),
 });
 
 const PipelineSchema: z.ZodType<Pipeline> = z.object({

--- a/src/lib/resolve-pipeline-defs.test.ts
+++ b/src/lib/resolve-pipeline-defs.test.ts
@@ -11,6 +11,11 @@ describe('resolvePipelineDefs', () => {
     expect(defs).not.toBeNull();
     expect(defs!.map((d) => d.logicalId)).toEqual(['backlog', 'spec', 'implementation', 'review', 'pr', 'completed']);
     expect(defs!.find((d) => d.logicalId === 'review')!.gate).toBe(true);
+    expect(defs!.find((d) => d.logicalId === 'spec')!.workflow).toMatchObject({
+      purpose: expect.stringContaining('decision-complete'),
+      definitionOfDone: expect.arrayContaining([expect.stringContaining('plan')]),
+      recommendedSkills: expect.arrayContaining(['software-planning']),
+    });
   });
 
   it('seeds SIMPLE_COLUMNS for sourceless projects when SQLite is empty', () => {

--- a/src/lib/resolve-pipeline-defs.ts
+++ b/src/lib/resolve-pipeline-defs.ts
@@ -27,5 +27,12 @@ export const resolvePipelineDefs = (
     return null;
   }
   const seed = input.hasSource ? DEFAULT_COLUMNS : SIMPLE_COLUMNS;
-  return seed.map((c) => ({ logicalId: c.logicalId, label: c.label, gate: c.gate }));
+  return seed.map((c) => ({
+    logicalId: c.logicalId,
+    label: c.label,
+    description: c.description,
+    gate: c.gate,
+    maxConcurrent: c.maxConcurrent,
+    workflow: c.workflow,
+  }));
 };

--- a/src/main/db-store-bridge.test.ts
+++ b/src/main/db-store-bridge.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { columnToRow, rowToColumn } from '@/main/db-store-bridge';
+
+import type { ColumnRow } from 'omni-projects-db';
+
+describe('pipeline column row mapping', () => {
+  const baseRow: ColumnRow = {
+    id: 'proj_1__spec',
+    project_id: 'proj_1',
+    label: 'Spec',
+    description: 'Plan the work',
+    sort_order: 1,
+    gate: 0,
+    max_concurrent: 2,
+    workflow: JSON.stringify({
+      purpose: 'Plan the implementation',
+      definitionOfDone: ['Decision-complete plan exists'],
+      agentInstructions: 'Use software-planning.',
+      recommendedSkills: ['software-planning'],
+    }),
+  };
+
+  it('maps workflow metadata and max concurrency from rows', () => {
+    expect(rowToColumn(baseRow)).toEqual({
+      id: 'proj_1__spec',
+      label: 'Spec',
+      description: 'Plan the work',
+      maxConcurrent: 2,
+      workflow: {
+        purpose: 'Plan the implementation',
+        definitionOfDone: ['Decision-complete plan exists'],
+        agentInstructions: 'Use software-planning.',
+        recommendedSkills: ['software-planning'],
+      },
+    });
+  });
+
+  it('ignores malformed workflow JSON safely', () => {
+    expect(rowToColumn({ ...baseRow, workflow: '{nope' }).workflow).toBeUndefined();
+  });
+
+  it('maps workflow metadata and max concurrency to rows', () => {
+    expect(columnToRow(rowToColumn(baseRow), 'proj_1', 1)).toMatchObject({
+      max_concurrent: 2,
+      workflow: baseRow.workflow,
+    });
+  });
+});

--- a/src/main/db-store-bridge.ts
+++ b/src/main/db-store-bridge.ts
@@ -11,22 +11,23 @@
  * by reading project data from SQLite and non-project data from electron-store.
  * This is what gets broadcast via `store:changed` to the renderer.
  */
-import type { ProjectsRepo } from 'omni-projects-db';
-import { fromIso, toIso } from 'omni-projects-db';
 import type {
-  ProjectRow,
   ColumnRow,
-  TicketRow,
   CommentRow,
+  InboxRow,
   MilestoneRow,
   PageRow,
-  InboxRow,
+  ProjectRow,
+  ProjectsRepo,
   TaskRow,
+  TicketRow,
 } from 'omni-projects-db';
+import { fromIso, toIso } from 'omni-projects-db';
 
 import type {
   Column,
   ColumnId,
+  ColumnWorkflowContract,
   InboxItem,
   InboxItemId,
   InboxPromotion,
@@ -66,6 +67,37 @@ function parseJsonOr<T>(s: string | null, fallback: T): T {
 
 function jsonStrOrNull(v: unknown): string | null {
   return v != null ? JSON.stringify(v) : null;
+}
+
+function parseWorkflow(s: string | null): ColumnWorkflowContract | undefined {
+  const parsed = parseJsonOr<unknown>(s, null);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const input = parsed as Record<string, unknown>;
+  const workflow: ColumnWorkflowContract = {};
+  if (typeof input.purpose === 'string' && input.purpose.trim()) {
+    workflow.purpose = input.purpose;
+  }
+  if (Array.isArray(input.entryCriteria)) {
+    workflow.entryCriteria = input.entryCriteria.filter((v): v is string => typeof v === 'string');
+  }
+  if (Array.isArray(input.definitionOfDone)) {
+    workflow.definitionOfDone = input.definitionOfDone.filter((v): v is string => typeof v === 'string');
+  }
+  if (typeof input.agentInstructions === 'string' && input.agentInstructions.trim()) {
+    workflow.agentInstructions = input.agentInstructions;
+  }
+  if (Array.isArray(input.recommendedSkills)) {
+    workflow.recommendedSkills = input.recommendedSkills.filter((v): v is string => typeof v === 'string');
+  }
+  if (Array.isArray(input.allowedTransitions)) {
+    workflow.allowedTransitions = input.allowedTransitions.filter((v): v is ColumnId => typeof v === 'string') as ColumnId[];
+  }
+  if (typeof input.autoDispatch === 'boolean') {
+    workflow.autoDispatch = input.autoDispatch;
+  }
+  return Object.keys(workflow).length > 0 ? workflow : undefined;
 }
 
 function isoOrNull(epochMs: number | undefined): string | null {
@@ -119,7 +151,10 @@ export function rowToColumn(row: ColumnRow): Column {
     label: row.label,
   };
   if (row.description) col.description = row.description;
+  if (row.max_concurrent) col.maxConcurrent = row.max_concurrent;
   if (row.gate) col.gate = true;
+  const workflow = parseWorkflow(row.workflow);
+  if (workflow) col.workflow = workflow;
   return col;
 }
 
@@ -302,6 +337,8 @@ export function columnToRow(col: Column, projectId: string, sortOrder: number): 
     description: col.description ?? null,
     sort_order: sortOrder,
     gate: col.gate ? 1 : 0,
+    max_concurrent: col.maxConcurrent ?? null,
+    workflow: jsonStrOrNull(col.workflow),
   };
 }
 

--- a/src/main/project-manager.ts
+++ b/src/main/project-manager.ts
@@ -24,6 +24,7 @@ import { type ArtifactStore, DockerArtifactStore, HostFsArtifactStore } from '@/
 import { DbChangeWatcher } from '@/main/db-change-watcher';
 import {
   commentToRow,
+  columnToRow,
   inboxItemToRow,
   milestoneToRow,
   pageToRow,
@@ -704,8 +705,18 @@ export class ProjectManager {
     if (patch.sources) {
       validateProjectSources(patch.sources);
     }
-    projects[index] = { ...projects[index]!, ...patch };
+    const { pipeline, ...projectPatch } = patch;
+    projects[index] = { ...projects[index]!, ...projectPatch };
     this.setProjects(projects);
+    if (this.repo && pipeline) {
+      const repo = this.repo;
+      const rows = pipeline.columns.map((col, sortOrder) => columnToRow(col, id, sortOrder));
+      this.cache.columns.set(id, rows);
+      this.enqueuePersist(async () => {
+        await repo.replaceColumnsForProject(id, rows);
+      });
+      this.noteLocalWriteAndBroadcast();
+    }
   };
 
   removeProject = async (id: ProjectId): Promise<void> => {
@@ -935,14 +946,7 @@ export class ProjectManager {
     if (this.repo) {
       const rows = this.cache.columns.get(projectId) ?? [];
       if (rows.length > 0) {
-        return {
-          columns: rows.map((r) => ({
-            id: r.id as ColumnId,
-            label: r.label,
-            ...(r.description ? { description: r.description } : {}),
-            ...(r.gate ? { gate: true } : {}),
-          })),
-        };
+        return rowsToPipeline(rows);
       }
     }
 

--- a/src/renderer/features/Tickets/PipelineSettingsDialog.tsx
+++ b/src/renderer/features/Tickets/PipelineSettingsDialog.tsx
@@ -13,6 +13,7 @@ import {
   IconButton,
   Input,
   Switch,
+  Textarea,
 } from '@/renderer/ds';
 import type { Column, ProjectId } from '@/shared/types';
 
@@ -73,7 +74,23 @@ const useStyles = makeStyles({
   flex1: {
     flex: '1 1 0',
   },
+  fieldColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
 });
+
+const linesToText = (values: string[] | undefined): string => values?.join('\n') ?? '';
+const textToLines = (value: string): string[] | undefined => {
+  const lines = value.split('\n').map((line) => line.trim()).filter(Boolean);
+  return lines.length > 0 ? lines : undefined;
+};
+const skillsToText = (values: string[] | undefined): string => values?.join(', ') ?? '';
+const textToSkills = (value: string): string[] | undefined => {
+  const skills = value.split(',').map((skill) => skill.trim()).filter(Boolean);
+  return skills.length > 0 ? skills : undefined;
+};
 
 const ColumnEditor = memo(
   ({
@@ -83,6 +100,7 @@ const ColumnEditor = memo(
     onMaxConcurrentChange,
     onGateChange,
     onDescriptionChange,
+    onWorkflowChange,
     onRename,
     onMoveUp,
     onMoveDown,
@@ -95,6 +113,7 @@ const ColumnEditor = memo(
     onMaxConcurrentChange: (columnId: string, value: number | undefined) => void;
     onGateChange: (columnId: string, checked: boolean) => void;
     onDescriptionChange: (columnId: string, value: string) => void;
+    onWorkflowChange: (columnId: string, patch: NonNullable<Column['workflow']>) => void;
     onRename: (columnId: string, label: string) => void;
     onMoveUp: (index: number) => void;
     onMoveDown: (index: number) => void;
@@ -140,6 +159,32 @@ const ColumnEditor = memo(
     const handleMoveUp = useCallback(() => onMoveUp(index), [index, onMoveUp]);
     const handleMoveDown = useCallback(() => onMoveDown(index), [index, onMoveDown]);
     const handleRemoveColumn = useCallback(() => onRemoveColumn(column.id), [column.id, onRemoveColumn]);
+    const handleLabelChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setEditLabel(e.target.value), []);
+    const handleGateCheckedChange = useCallback(
+      (checked: boolean) => onGateChange(column.id, checked),
+      [column.id, onGateChange]
+    );
+    const handleDescriptionInputChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => onDescriptionChange(column.id, e.target.value),
+      [column.id, onDescriptionChange]
+    );
+    const handlePurposeChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => onWorkflowChange(column.id, { purpose: e.target.value || undefined }),
+      [column.id, onWorkflowChange]
+    );
+    const handleDefinitionOfDoneChange = useCallback(
+      (e: React.ChangeEvent<HTMLTextAreaElement>) => onWorkflowChange(column.id, { definitionOfDone: textToLines(e.target.value) }),
+      [column.id, onWorkflowChange]
+    );
+    const handleAgentInstructionsChange = useCallback(
+      (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+        onWorkflowChange(column.id, { agentInstructions: e.target.value || undefined }),
+      [column.id, onWorkflowChange]
+    );
+    const handleRecommendedSkillsChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => onWorkflowChange(column.id, { recommendedSkills: textToSkills(e.target.value) }),
+      [column.id, onWorkflowChange]
+    );
 
     return (
       <div className={styles.columnCard}>
@@ -148,7 +193,7 @@ const ColumnEditor = memo(
             <Input
               size="sm"
               value={editLabel}
-              onChange={(e) => setEditLabel(e.target.value)}
+              onChange={handleLabelChange}
               onBlur={handleFinishRename}
               onKeyDown={handleRenameKeyDown}
               autoFocus
@@ -202,16 +247,52 @@ const ColumnEditor = memo(
         </div>
         <div className={styles.fieldRow}>
           <label className={styles.fieldLabel}>Gate</label>
-          <Switch checked={column.gate ?? false} onCheckedChange={(checked) => onGateChange(column.id, checked)} />
+          <Switch checked={column.gate ?? false} onCheckedChange={handleGateCheckedChange} />
         </div>
         <div className={styles.fieldRow}>
           <label className={styles.fieldLabel}>Description</label>
           <Input
             size="sm"
             value={column.description ?? ''}
-            onChange={(e) => onDescriptionChange(column.id, e.target.value)}
+            onChange={handleDescriptionInputChange}
             placeholder="What does this column mean?"
             className={styles.flex1}
+          />
+        </div>
+        <div className={styles.fieldColumn}>
+          <label className={styles.fieldLabel}>Purpose</label>
+          <Input
+            size="sm"
+            value={column.workflow?.purpose ?? ''}
+            onChange={handlePurposeChange}
+            placeholder="What should happen in this column?"
+          />
+        </div>
+        <div className={styles.fieldColumn}>
+          <label className={styles.fieldLabel}>Definition of done</label>
+          <Textarea
+            value={linesToText(column.workflow?.definitionOfDone)}
+            onChange={handleDefinitionOfDoneChange}
+            placeholder="One checklist item per line"
+            rows={4}
+          />
+        </div>
+        <div className={styles.fieldColumn}>
+          <label className={styles.fieldLabel}>Agent instructions</label>
+          <Textarea
+            value={column.workflow?.agentInstructions ?? ''}
+            onChange={handleAgentInstructionsChange}
+            placeholder="Column-specific instructions for agents"
+            rows={3}
+          />
+        </div>
+        <div className={styles.fieldColumn}>
+          <label className={styles.fieldLabel}>Recommended skills</label>
+          <Input
+            size="sm"
+            value={skillsToText(column.workflow?.recommendedSkills)}
+            onChange={handleRecommendedSkillsChange}
+            placeholder="software-planning, debug"
           />
         </div>
       </div>
@@ -282,6 +363,27 @@ return prev;
       });
     }, []);
 
+    const handleWorkflowChange = useCallback((columnId: string, patch: NonNullable<Column['workflow']>) => {
+      setEditColumns((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        return prev.map((col) => {
+          if (col.id !== columnId) {
+            return col;
+          }
+          const workflow = { ...(col.workflow ?? {}), ...patch };
+          for (const key of Object.keys(workflow) as (keyof typeof workflow)[]) {
+            const value = workflow[key];
+            if (value === undefined || value === '' || (Array.isArray(value) && value.length === 0)) {
+              delete workflow[key];
+            }
+          }
+          return { ...col, workflow: Object.keys(workflow).length > 0 ? workflow : undefined };
+        });
+      });
+    }, []);
+
     const handleRename = useCallback((columnId: string, label: string) => {
       setEditColumns((prev) => {
         if (!prev) {
@@ -323,6 +425,9 @@ return prev;
     }, []);
 
     const [newColumnLabel, setNewColumnLabel] = useState('');
+    const handleNewColumnLabelChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+      setNewColumnLabel(e.target.value);
+    }, []);
 
     const handleAddColumn = useCallback(() => {
       const trimmed = newColumnLabel.trim();
@@ -390,6 +495,7 @@ return prev;
                 onMaxConcurrentChange={handleMaxConcurrentChange}
                 onGateChange={handleGateChange}
                 onDescriptionChange={handleDescriptionChange}
+                onWorkflowChange={handleWorkflowChange}
                 onRename={handleRename}
                 onMoveUp={handleMoveUp}
                 onMoveDown={handleMoveDown}
@@ -401,7 +507,7 @@ return prev;
               <Input
                 size="sm"
                 value={newColumnLabel}
-                onChange={(e) => setNewColumnLabel(e.target.value)}
+                onChange={handleNewColumnLabelChange}
                 placeholder="Add column..."
                 onKeyDown={handleAddColumnKeyDown}
                 className={styles.flex1}

--- a/src/server/mcp-projects-smoke.test.ts
+++ b/src/server/mcp-projects-smoke.test.ts
@@ -75,6 +75,12 @@ describe('omni-projects MCP tools (async IProjectsRepo, SQLite)', () => {
 
   it('creates, moves, and lists a ticket', async () => {
     const pipeline = await call('get_pipeline', { project_id: projectId });
+    const spec = pipeline.columns.find((column: any) => column.label === 'Spec');
+    expect(spec.workflow).toMatchObject({
+      purpose: expect.stringContaining('decision-complete'),
+      definitionOfDone: expect.arrayContaining([expect.stringContaining('plan')]),
+      recommendedSkills: expect.arrayContaining(['software-planning']),
+    });
     const lastCol = pipeline.columns[pipeline.columns.length - 1].label;
 
     const created = await call('create_ticket', { project_id: projectId, title: 'Do the thing', priority: 'high' });

--- a/src/shared/pipeline-defaults.ts
+++ b/src/shared/pipeline-defaults.ts
@@ -6,7 +6,10 @@ const toPipeline = (cols: typeof DEFAULT_COLUMNS): Pipeline => ({
   columns: cols.map((c) => ({
     id: c.logicalId,
     label: c.label,
+    ...(c.description ? { description: c.description } : {}),
+    ...(c.maxConcurrent ? { maxConcurrent: c.maxConcurrent } : {}),
     ...(c.gate ? { gate: true } : {}),
+    ...(c.workflow ? { workflow: c.workflow } : {}),
   })),
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1260,6 +1260,18 @@ export type Column = {
   maxConcurrent?: number;
   /** When true, the supervisor is stopped on entry and only a human can move the ticket out. */
   gate?: boolean;
+  /** DB-backed workflow metadata used by humans, agents, and project tools. */
+  workflow?: ColumnWorkflowContract;
+};
+
+export type ColumnWorkflowContract = {
+  purpose?: string;
+  entryCriteria?: string[];
+  definitionOfDone?: string[];
+  agentInstructions?: string;
+  recommendedSkills?: string[];
+  allowedTransitions?: ColumnId[];
+  autoDispatch?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds DB-backed workflow contracts and `maxConcurrent` to project pipeline columns across shared types, SQLite/Postgres persistence, row mapping, and MCP output.
- Seeds software workflow defaults for `Backlog`, `Spec`, `Implementation`, `Review`, `PR`, and `Completed` without reintroducing FLEET.md/file-based workflow authority.
- Extends the existing Pipeline Settings dialog to edit purpose, definition of done, agent instructions, recommended skills, gate, and max concurrency.
- Adds coverage for DB sync/mapping, default seed contracts, and `get_pipeline` workflow exposure.

## Test plan

- [x] `npm run build:packages`
- [x] `npx eslint src/renderer/features/Tickets/PipelineSettingsDialog.tsx packages/projects-mcp/src/tools/pipeline.ts`
- [x] `npx vitest run packages/projects-db/src/repo.test.ts src/main/db-store-bridge.test.ts src/lib/resolve-pipeline-defs.test.ts src/server/mcp-projects-smoke.test.ts`

## Notes

- Repo-wide `npm run lint:tsc` still reports unrelated pre-existing type errors outside this change set.
