### PR TITLE
Make autopilot follow column workflow contracts

### DIFF
--- a/src/lib/project-manager-test-helpers.ts
+++ b/src/lib/project-manager-test-helpers.ts
@@ -312,7 +312,7 @@ export const seedStore = (args: SeedArgs = {}): IStore => {
         id: t.id,
         projectId,
         title: t.title ?? `Ticket ${t.id}`,
-        description: '',
+        description: t.description ?? '',
         priority: t.priority ?? 'medium',
         columnId: t.columnId ?? pipeline.columns[0]!.id,
         blockedBy: t.blockedBy ?? [],

--- a/src/lib/supervisor-orchestrator.test.ts
+++ b/src/lib/supervisor-orchestrator.test.ts
@@ -227,6 +227,34 @@ describe('SupervisorOrchestrator integration', () => {
 
       expect(startSpy).not.toHaveBeenCalled();
     });
+
+    it('autoDispatchTick respects the destination active column maxConcurrent after moving from backlog', async () => {
+      const ctx = makePm({
+        autoDispatch: true,
+        pipeline: {
+          columns: [
+            { id: 'backlog', label: 'Backlog' },
+            { id: 'in_progress', label: 'In Progress', maxConcurrent: 1 },
+            { id: 'review', label: 'Review' },
+            { id: 'done', label: 'Done' },
+          ],
+        },
+        tickets: [
+          { id: 'busy', columnId: 'in_progress' },
+          { id: 't-ready', columnId: 'backlog' },
+        ],
+      });
+      const busy = seedMachine(ctx, 'busy');
+      busy.phase = 'running';
+      const startSpy = vi.fn(async () => {});
+      (orch(ctx.pm) as unknown as { startSupervisor: typeof startSpy }).startSupervisor = startSpy;
+
+      await orch(ctx.pm).autoDispatchTick();
+
+      expect(startSpy).not.toHaveBeenCalled();
+      const readyTicket = ctx.store.get('tickets', []).find((t: Ticket) => t.id === 't-ready')!;
+      expect(readyTicket.columnId).toBe('backlog');
+    });
   });
 
   // handleClientToolCall moved out of main — tool dispatch now lives entirely
@@ -583,6 +611,57 @@ describe('SupervisorOrchestrator integration', () => {
       expect(ctx.bridge.ensureColumn).toHaveBeenCalledWith(
         expect.objectContaining({ ticketId: 't1', profileName: 'local:machine-1' })
       );
+    });
+
+    it('passes goal text as prompt and durable rules as additionalInstructions without duplicating the full prompt', async () => {
+      const ctx = makePm({
+        source: { kind: 'local', workspaceDir: '/tmp/fake' },
+        pipeline: {
+          columns: [
+            { id: 'backlog', label: 'Backlog' },
+            {
+              id: 'in_progress',
+              label: 'In Progress',
+              workflow: {
+                purpose: 'Implement the accepted ticket plan.',
+                definitionOfDone: ['Regression test demonstrates prompt channel separation'],
+                agentInstructions: 'Keep the launcher workflow source of truth in the database.',
+              },
+            },
+            { id: 'review', label: 'Review', gate: true },
+            { id: 'done', label: 'Done' },
+          ],
+        },
+        tickets: [
+          {
+            id: 't1',
+            columnId: 'in_progress',
+            title: 'Split autopilot prompt channels',
+            description: 'Send the ticket goal separately from durable runtime instructions.',
+          },
+        ],
+      });
+
+      await orch(ctx.pm).startSupervisor('t1' as TicketId);
+
+      const startGoalCall = ctx.bridge.startGoal.mock.calls[ctx.bridge.startGoal.mock.calls.length - 1];
+      const startGoalArg = startGoalCall?.[0] as {
+        prompt: string;
+        runOverrides?: { additionalInstructions?: string };
+      };
+      expect(startGoalArg.prompt).toContain('Title: Split autopilot prompt channels');
+      expect(startGoalArg.prompt).toContain('Send the ticket goal separately from durable runtime instructions.');
+      expect(startGoalArg.prompt).toContain('Implement the accepted ticket plan.');
+      expect(startGoalArg.prompt).toContain('Regression test demonstrates prompt channel separation');
+
+      const additionalInstructions = startGoalArg.runOverrides?.additionalInstructions;
+      expect(additionalInstructions).toEqual(expect.any(String));
+      expect(additionalInstructions).toContain('move_ticket');
+      expect(additionalInstructions).toContain('spawn_worker');
+      expect(additionalInstructions).not.toContain('Title: Split autopilot prompt channels');
+      expect(additionalInstructions).not.toContain('Send the ticket goal separately from durable runtime instructions.');
+      expect(additionalInstructions).not.toContain('Regression test demonstrates prompt channel separation');
+      expect(additionalInstructions).not.toBe(startGoalArg.prompt);
     });
   });
 

--- a/src/lib/supervisor-prompt.test.ts
+++ b/src/lib/supervisor-prompt.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildSupervisorPrompt } from '@/main/supervisor-prompt';
-import type { Pipeline, Project, Ticket } from '@/shared/types';
+import {
+  buildAutopilotAdditionalInstructions,
+  buildAutopilotGoalText,
+  buildSupervisorPrompt,
+} from '@/main/supervisor-prompt';
+import type { Column, Pipeline, Project, Ticket } from '@/shared/types';
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const makePipeline = (columns: { id: string; label: string }[]): Pipeline => ({
+const makePipeline = (columns: Column[]): Pipeline => ({
   columns: columns.map((c) => ({
     ...c,
   })),
@@ -40,6 +44,34 @@ const PIPELINE = makePipeline([
   { id: 'col-backlog', label: 'Backlog' },
   { id: 'col-spec', label: 'Spec' },
   { id: 'col-impl', label: 'Implementation' },
+  { id: 'col-done', label: 'Done' },
+]);
+
+const WORKFLOW_PIPELINE = makePipeline([
+  { id: 'col-backlog', label: 'Backlog' },
+  {
+    id: 'col-impl',
+    label: 'Implementation',
+    maxConcurrent: 2,
+    workflow: {
+      purpose: 'Turn the approved plan into a tested product change.',
+      entryCriteria: ['Spec is approved by a human reviewer', 'Dependencies are unblocked'],
+      definitionOfDone: ['Feature flag persists across restarts', 'Targeted Vitest coverage passes'],
+      agentInstructions: 'Keep implementation minimal and preserve public APIs.',
+      recommendedSkills: ['bugfix', 'typescript'],
+      allowedTransitions: ['col-review'],
+      autoDispatch: true,
+    },
+  },
+  {
+    id: 'col-review',
+    label: 'Review',
+    gate: true,
+    workflow: {
+      purpose: 'Human review gate.',
+      definitionOfDone: ['Reviewer has inspected the full PR diff'],
+    },
+  },
   { id: 'col-done', label: 'Done' },
 ]);
 
@@ -141,5 +173,60 @@ describe('buildSupervisorPrompt', () => {
 
   it('omits the artifacts section when no artifactsDir is provided', () => {
     expect(buildSupervisorPrompt(makeTicket(), makeProject(), PIPELINE)).not.toContain('## Output for the user');
+  });
+});
+
+describe('buildAutopilotGoalText', () => {
+  it('includes ticket details and the current column workflow contract', () => {
+    const goalText = buildAutopilotGoalText(makeTicket(), makeProject(), WORKFLOW_PIPELINE);
+
+    expect(goalText).toContain('Title: Add dark mode');
+    expect(goalText).toContain('Implement dark mode across the entire app.');
+    expect(goalText).toContain('Priority: high');
+    expect(goalText).toContain('Current Column: Implementation');
+    expect(goalText).toContain('Turn the approved plan into a tested product change.');
+    expect(goalText).toContain('Spec is approved by a human reviewer');
+    expect(goalText).toContain('Feature flag persists across restarts');
+    expect(goalText).toContain('Keep implementation minimal and preserve public APIs.');
+    expect(goalText).toContain('bugfix');
+    expect(goalText).toContain('col-review');
+    expect(goalText).toMatch(/auto.?dispatch/i);
+    expect(goalText).not.toContain('Reviewer has inspected the full PR diff');
+  });
+
+  it('preserves optional supervisor context in the goal text', () => {
+    const goalText = buildAutopilotGoalText(makeTicket(), makeProject(), WORKFLOW_PIPELINE, {
+      projectBrief: '# My Project\nBuilding a widget system.',
+      blockerTitles: ['Set up database'],
+      recentComments: [{ author: 'human', content: 'Please keep the API stable' }],
+    });
+
+    expect(goalText).toContain('Building a widget system');
+    expect(goalText).toContain('Set up database');
+    expect(goalText).toContain('[human]: Please keep the API stable');
+  });
+});
+
+describe('buildAutopilotAdditionalInstructions', () => {
+  it('contains durable tool, artifact, and gate rules', () => {
+    const additionalInstructions = buildAutopilotAdditionalInstructions(makeTicket(), makeProject(), WORKFLOW_PIPELINE, {
+      artifactsDir: '/workspace/.omni-artifacts/ticket-42',
+    });
+
+    expect(additionalInstructions).toContain('move_ticket');
+    expect(additionalInstructions).toContain('spawn_worker');
+    expect(additionalInstructions).toContain('/workspace/.omni-artifacts/ticket-42');
+    expect(additionalInstructions).toContain('/workspace/.omni-artifacts/ticket-42/pr/PR_TITLE.md');
+    expect(additionalInstructions).toContain('/workspace/.omni-artifacts/ticket-42/pr/PR_BODY.md');
+    expect(additionalInstructions).toMatch(/gate/i);
+  });
+
+  it('does not duplicate ticket-specific goal details or the full current column DoD', () => {
+    const additionalInstructions = buildAutopilotAdditionalInstructions(makeTicket(), makeProject(), WORKFLOW_PIPELINE);
+
+    expect(additionalInstructions).not.toContain('Title: Add dark mode');
+    expect(additionalInstructions).not.toContain('Implement dark mode across the entire app.');
+    expect(additionalInstructions).not.toContain('Feature flag persists across restarts');
+    expect(additionalInstructions).not.toContain('Targeted Vitest coverage passes');
   });
 });

--- a/src/main/supervisor-orchestrator.ts
+++ b/src/main/supervisor-orchestrator.ts
@@ -37,7 +37,11 @@ import { claimsCollide, decideWorktreeAction, resolveWorkspaceClaim } from '@/li
 import type { AppControlManager } from '@/main/app-control-manager';
 import type { ProcessManager } from '@/main/process-manager';
 import type { SupervisorBridge } from '@/main/supervisor-bridge';
-import { buildSupervisorPrompt, type SupervisorContext } from '@/main/supervisor-prompt';
+import {
+  buildAutopilotAdditionalInstructions,
+  buildAutopilotGoalText,
+  type SupervisorContext,
+} from '@/main/supervisor-prompt';
 import { SupervisorState } from '@/main/supervisor-state';
 import { getProjectPagesDir } from '@/main/util';
 import { createWorktree, generateWorktreeName, isWorktreeDirty, removeWorktree } from '@/main/worktree-ops';
@@ -761,17 +765,17 @@ export class SupervisorOrchestrator {
     // in session.variables (set via buildSessionVariables), so omni-code
     // tools can read structured ticket context without parsing this
     // prompt.
-    const supervisorPrompt = this.buildFullSupervisorPrompt(ticketId);
+    const { goalText, additionalInstructions } = this.buildAutopilotPrompts(ticketId);
 
     console.log(`[SupervisorOrchestrator] startMachineRun: bridge.startGoal for ${ticketId}`);
     state.transition('running' as TicketPhase);
     void this.deps.bridge
       .startGoal({
         ticketId,
-        prompt: supervisorPrompt,
+        prompt: goalText,
         maxTurns,
         runOverrides: {
-          additionalInstructions: supervisorPrompt,
+          additionalInstructions,
           safeToolOverrides: { safe_tool_patterns: ['.*'] },
         },
       })
@@ -1335,16 +1339,16 @@ export class SupervisorOrchestrator {
         continue;
       }
 
-      // Check global + per-column WIP limits
-      if (!this.canStartSupervisor(project.id, nextTicket.columnId)) {
-        continue;
-      }
-
-      // Move from first column to second column (first active column) to start work
       const pipeline = this.deps.host.getPipeline(project.id);
       const firstColumnId = pipeline.columns[0]?.id;
       const terminalColumnId = pipeline.columns[pipeline.columns.length - 1]?.id;
       const firstActiveColumn = pipeline.columns.find((c) => c.id !== firstColumnId && c.id !== terminalColumnId);
+      const dispatchColumnId = firstActiveColumn?.id ?? nextTicket.columnId;
+
+      if (!this.canStartSupervisor(project.id, dispatchColumnId)) {
+        continue;
+      }
+
       const originalColumnId = nextTicket.columnId;
       if (firstActiveColumn) {
         this.deps.host.moveTicketToColumn(nextTicket.id, firstActiveColumn.id);
@@ -1366,7 +1370,7 @@ export class SupervisorOrchestrator {
     }
   };
 
-  private buildFullSupervisorPrompt(ticketId: TicketId): string {
+  private buildAutopilotPrompts(ticketId: TicketId): { goalText: string; additionalInstructions: string } {
     const ticket = this.deps.host.getTicketById(ticketId)!;
     const project = this.deps.store.getProjects().find((p) => p.id === ticket.projectId)!;
     const pipeline = this.deps.host.getPipeline(ticket.projectId);
@@ -1422,7 +1426,10 @@ export class SupervisorOrchestrator {
       }
     }
 
-    return buildSupervisorPrompt(ticket, project, pipeline, context);
+    return {
+      goalText: buildAutopilotGoalText(ticket, project, pipeline, context),
+      additionalInstructions: buildAutopilotAdditionalInstructions(ticket, project, pipeline, context),
+    };
   }
 
   /** Release bridge subscription on shutdown. */

--- a/src/main/supervisor-prompt.ts
+++ b/src/main/supervisor-prompt.ts
@@ -1,4 +1,4 @@
-import type { Pipeline, Project, Ticket } from '@/shared/types';
+import type { Column, Pipeline, Project, Ticket } from '@/shared/types';
 
 export type SupervisorContext = {
   /** First ~500 chars of the project's root page content. */
@@ -47,11 +47,67 @@ const buildContextSection = (ctx?: SupervisorContext): string => {
   return parts.join('');
 };
 
+const listSection = (title: string, values?: string[]): string => {
+  if (!values || values.length === 0) {
+    return '';
+  }
+  return `\n${title}:\n${values.map((value) => `- ${value}`).join('\n')}`;
+};
+
+const workflowSection = (column?: Column): string => {
+  const workflow = column?.workflow;
+  if (!column || !workflow) {
+    return '';
+  }
+
+  const parts: string[] = ['\n## Column Contract'];
+  if (workflow.purpose) {
+    parts.push(`Purpose: ${workflow.purpose}`);
+  }
+  const entryCriteria = listSection('Entry criteria', workflow.entryCriteria);
+  if (entryCriteria) {
+    parts.push(entryCriteria);
+  }
+  const definitionOfDone = listSection('Definition of done', workflow.definitionOfDone);
+  if (definitionOfDone) {
+    parts.push(definitionOfDone);
+  }
+  if (workflow.agentInstructions) {
+    parts.push(`Column instructions:\n${workflow.agentInstructions}`);
+  }
+  const recommendedSkills = listSection('Recommended skills', workflow.recommendedSkills);
+  if (recommendedSkills) {
+    parts.push(recommendedSkills);
+  }
+  const allowedTransitions = listSection('Allowed transitions', workflow.allowedTransitions);
+  if (allowedTransitions) {
+    parts.push(allowedTransitions);
+  }
+  if (workflow.autoDispatch !== undefined) {
+    parts.push(`Auto-dispatch: ${workflow.autoDispatch ? 'enabled' : 'disabled'}`);
+  }
+  return parts.join('\n');
+};
+
+const nextTransitionText = (ticket: Ticket, pipeline: Pipeline): string => {
+  const currentIndex = pipeline.columns.findIndex((column) => column.id === ticket.columnId);
+  const currentColumn = currentIndex >= 0 ? pipeline.columns[currentIndex] : undefined;
+  const allowedTransitionIds = currentColumn?.workflow?.allowedTransitions;
+  const nextColumn = allowedTransitionIds?.length
+    ? pipeline.columns.find((column) => column.id === allowedTransitionIds[0])
+    : pipeline.columns[currentIndex + 1];
+  if (!nextColumn) {
+    return 'No next column is available; if the current definition of done is satisfied, call `goal_complete` and stop.';
+  }
+  const gateText = nextColumn.gate ? ' This destination is a human gate; move there and stop without advancing further.' : '';
+  return `When the current column definition of done is satisfied, move the ticket to \`${nextColumn.label}\` with \`move_ticket\`.${gateText}`;
+};
+
 /**
  * Build the system prompt for a supervisor agent session.
  * Single prompt replaces all per-column prompt templates.
  */
-export const buildSupervisorPrompt = (
+export const buildAutopilotGoalText = (
   ticket: Ticket,
   project: Project,
   pipeline: Pipeline,
@@ -83,8 +139,8 @@ Current Column: ${columnLabel}
 ## Pipeline
 ${columnNames}
 
-When your work for the current column is complete, use \`move_ticket\` to advance the ticket to the next column.
-Do not edit YAML files or configuration files to manage ticket state — use your project management tools instead.
+${nextTransitionText(ticket, pipeline)}
+Do not edit YAML files or configuration files to manage ticket state — use your project management tools instead.${workflowSection(currentColumn)}
 
 ## How to Work
 
@@ -94,3 +150,28 @@ Do not edit YAML files or configuration files to manage ticket state — use you
 4. **Verify** — Run tests, check linting, review changes.
 5. **Advance** — When work for the current column is complete, use \`move_ticket\` to advance the ticket.${buildContextSection(context)}`;
 };
+
+export const buildAutopilotAdditionalInstructions = (
+  _ticket: Ticket,
+  _project: Project,
+  _pipeline: Pipeline,
+  context?: SupervisorContext
+): string => {
+  const artifactText = context?.artifactsDir
+    ? `\n\n## Output for the user\nWrite persistent progress notes, research, and deliverables to \`${context.artifactsDir}\`. Keep the PR writeup current:\n- \`${context.artifactsDir}/pr/PR_TITLE.md\` — one short line (≤70 chars), no markdown.\n- \`${context.artifactsDir}/pr/PR_BODY.md\` — markdown with **Summary** and **Test plan** sections.`
+    : '';
+
+  return `You are working on an Omni project ticket.
+
+## Stable Rules
+
+- Use project tools such as \`move_ticket\` to mutate ticket state; never edit DB, YAML, or config files to manage ticket state.
+- Read ticket comments before starting and write a summary comment before ending.
+- Respect gates; never move past a \`gate: true\` column automatically.
+- Follow AGENTS.md for every source file you touch.
+- Use \`spawn_worker\` only for independent subtasks with clear file ownership and acceptance criteria.
+- Activate recommended skills when relevant, and follow activated skill requirements.
+- Use \`goal_complete\` to end the autopilot loop when achieved or truly blocked.${artifactText}`;
+};
+
+export const buildSupervisorPrompt = buildAutopilotGoalText;


### PR DESCRIPTION
## Summary

- Split autopilot `/goal` text from durable `additional_instructions`.
- Inject current column workflow contracts into the goal prompt, including purpose, entry criteria, definition of done, agent instructions, recommended skills, allowed transitions, and auto-dispatch metadata.
- Enforce auto-dispatch `maxConcurrent` against the destination active column after backlog promotion.

## Test plan

- [x] `npx vitest run src/lib/supervisor-prompt.test.ts src/lib/supervisor-orchestrator.test.ts`
- [ ] `npm run lint:tsc` — currently fails on unrelated existing repo-wide type errors outside this change.
