### PR TITLE
Prove pipeline workflow contracts end to end

### DIFF
--- a/src/lib/supervisor-orchestrator.test.ts
+++ b/src/lib/supervisor-orchestrator.test.ts
@@ -624,7 +624,7 @@ describe('SupervisorOrchestrator integration', () => {
               label: 'In Progress',
               workflow: {
                 purpose: 'Implement the accepted ticket plan.',
-                definitionOfDone: ['Regression test demonstrates prompt channel separation'],
+                definitionOfDone: ['Edited Implementation DoD reaches the agent goal text'],
                 agentInstructions: 'Keep the launcher workflow source of truth in the database.',
               },
             },
@@ -652,7 +652,9 @@ describe('SupervisorOrchestrator integration', () => {
       expect(startGoalArg.prompt).toContain('Title: Split autopilot prompt channels');
       expect(startGoalArg.prompt).toContain('Send the ticket goal separately from durable runtime instructions.');
       expect(startGoalArg.prompt).toContain('Implement the accepted ticket plan.');
-      expect(startGoalArg.prompt).toContain('Regression test demonstrates prompt channel separation');
+      expect(startGoalArg.prompt).toContain('Edited Implementation DoD reaches the agent goal text');
+      expect(startGoalArg.prompt).toContain('move the ticket to `Review`');
+      expect(startGoalArg.prompt).toContain('human gate; move there and stop');
 
       const additionalInstructions = startGoalArg.runOverrides?.additionalInstructions;
       expect(additionalInstructions).toEqual(expect.any(String));
@@ -660,7 +662,7 @@ describe('SupervisorOrchestrator integration', () => {
       expect(additionalInstructions).toContain('spawn_worker');
       expect(additionalInstructions).not.toContain('Title: Split autopilot prompt channels');
       expect(additionalInstructions).not.toContain('Send the ticket goal separately from durable runtime instructions.');
-      expect(additionalInstructions).not.toContain('Regression test demonstrates prompt channel separation');
+      expect(additionalInstructions).not.toContain('Edited Implementation DoD reaches the agent goal text');
       expect(additionalInstructions).not.toBe(startGoalArg.prompt);
     });
   });

--- a/src/renderer/features/Tickets/PipelineSettingsDialog.tsx
+++ b/src/renderer/features/Tickets/PipelineSettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, shorthands,tokens } from '@fluentui/react-components';
+import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import { Add20Regular, ArrowDown20Regular, ArrowUp20Regular, Delete20Filled } from '@fluentui/react-icons';
 import { useStore } from '@nanostores/react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -271,6 +271,7 @@ const ColumnEditor = memo(
         <div className={styles.fieldColumn}>
           <label className={styles.fieldLabel}>Definition of done</label>
           <Textarea
+            aria-label={`Definition of done for ${column.label}`}
             value={linesToText(column.workflow?.definitionOfDone)}
             onChange={handleDefinitionOfDoneChange}
             placeholder="One checklist item per line"
@@ -280,6 +281,7 @@ const ColumnEditor = memo(
         <div className={styles.fieldColumn}>
           <label className={styles.fieldLabel}>Agent instructions</label>
           <Textarea
+            aria-label={`Agent instructions for ${column.label}`}
             value={column.workflow?.agentInstructions ?? ''}
             onChange={handleAgentInstructionsChange}
             placeholder="Column-specific instructions for agents"

--- a/src/server/mcp-projects-smoke.test.ts
+++ b/src/server/mcp-projects-smoke.test.ts
@@ -18,6 +18,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 let dir: string;
 let db: ReturnType<typeof openDatabase>;
+let repo: SqliteProjectsRepo;
 let client: Client;
 
 /** Call a tool and parse its single JSON text payload. */
@@ -33,7 +34,7 @@ async function call(name: string, args: Record<string, unknown> = {}): Promise<a
 beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), 'omni-mcp-'));
   db = openDatabase(join(dir, 'projects.db'));
-  const repo = new SqliteProjectsRepo(new ProjectsRepo(db));
+  repo = new SqliteProjectsRepo(new ProjectsRepo(db));
   const server = createServer(repo);
 
   const [clientT, serverT] = InMemoryTransport.createLinkedPair();
@@ -95,6 +96,26 @@ describe('omni-projects MCP tools (async IProjectsRepo, SQLite)', () => {
 
     const filteredOut = await call('list_tickets', { project_id: projectId, priority: 'low' });
     expect(filteredOut.tickets.map((t: any) => t.id)).not.toContain(ticketId);
+  });
+
+  it('returns persisted column workflow edits from get_pipeline', async () => {
+    const editedDefinitionOfDone = 'Edited Implementation DoD is exposed through get_pipeline';
+    const columns = await repo.listColumns(projectId);
+    const implementation = columns.find((column) => column.label === 'Implementation');
+    expect(implementation).toBeTruthy();
+
+    const workflow = JSON.parse(implementation!.workflow ?? '{}') as { definitionOfDone?: string[] };
+    await repo.upsertColumn({
+      ...implementation!,
+      workflow: JSON.stringify({
+        ...workflow,
+        definitionOfDone: [editedDefinitionOfDone],
+      }),
+    });
+
+    const pipeline = await call('get_pipeline', { project_id: projectId });
+    const implementationFromTool = pipeline.columns.find((column: any) => column.label === 'Implementation');
+    expect(implementationFromTool.workflow.definitionOfDone).toEqual([editedDefinitionOfDone]);
   });
 
   it('updates a ticket and tracks blockers', async () => {

--- a/tests/e2e/specs/pipeline-settings.spec.ts
+++ b/tests/e2e/specs/pipeline-settings.spec.ts
@@ -1,0 +1,55 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { addGitSource, createProject, openPipelineSettings, openProject } from 'tests/e2e/support/app';
+
+async function ensureImplementationColumn(page: Page): Promise<void> {
+  await openPipelineSettings(page);
+  const dialog = page.getByRole('dialog', { name: 'Pipeline Settings' });
+  if ((await dialog.getByRole('button', { name: 'Implementation' }).count()) === 0) {
+    await dialog.getByPlaceholder('Add column...').fill('Implementation');
+    await dialog.getByRole('button', { name: 'Add column' }).click();
+    await dialog.getByRole('button', { name: /Save/ }).click();
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+    return;
+  }
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+}
+
+async function setImplementationDefinitionOfDone(page: Page, text: string): Promise<void> {
+  await openPipelineSettings(page);
+  const dialog = page.getByRole('dialog', { name: 'Pipeline Settings' });
+  await dialog.getByLabel('Definition of done for Implementation').fill(text);
+  await dialog.getByRole('button', { name: /Save/ }).click();
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+}
+
+async function expectImplementationDefinitionOfDone(page: Page, text: string): Promise<void> {
+  await openPipelineSettings(page);
+  const dialog = page.getByRole('dialog', { name: 'Pipeline Settings' });
+  await expect(dialog.getByLabel('Definition of done for Implementation')).toHaveValue(text);
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+}
+
+test.describe('pipeline settings', () => {
+  test('persists the Implementation definition of done edited in settings', async ({ app }) => {
+    const projectName = `E2E Pipeline Project ${Date.now()}`;
+    const mountName = `e2e-pipeline-source-${Date.now()}`;
+    const definitionOfDone = `Implementation verifies DB-backed workflow contracts ${Date.now()}.`;
+
+    await createProject(app.page, projectName);
+    await openProject(app.page, projectName);
+    await addGitSource(app.page, 'https://github.com/example/e2e-pipeline-source.git', mountName);
+    await ensureImplementationColumn(app.page);
+
+    await setImplementationDefinitionOfDone(app.page, definitionOfDone);
+    await expectImplementationDefinitionOfDone(app.page, definitionOfDone);
+
+    const restarted = await app.restart();
+    await openProject(restarted, projectName);
+    await expectImplementationDefinitionOfDone(restarted, definitionOfDone);
+  });
+});

--- a/tests/e2e/support/app.ts
+++ b/tests/e2e/support/app.ts
@@ -69,6 +69,12 @@ export async function openAddSourceDialog(page: Page): Promise<void> {
   await expect(page.getByRole('dialog').filter({ hasText: 'Add source' })).toBeVisible();
 }
 
+export async function openPipelineSettings(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Project actions' }).last().click();
+  await page.getByRole('menuitem', { name: 'Pipeline settings' }).click();
+  await expect(page.getByRole('dialog', { name: 'Pipeline Settings' })).toBeVisible();
+}
+
 export async function addGitSource(page: Page, repoUrl: string, mountName: string): Promise<void> {
   await openAddSourceDialog(page);
   await page.getByRole('combobox', { name: 'Source type' }).selectOption('url');


### PR DESCRIPTION
## Summary

- Adds user-facing Playwright coverage for editing the `Implementation` column definition of done in Pipeline Settings and verifying it persists after reopen and restart.
- Exposes stable accessible labels for per-column workflow textareas so E2E can target the intended column and users get clearer control names.
- Extends integration coverage proving edited workflow metadata is returned by `get_pipeline`, reaches autopilot goal text, and Review remains a gate-stop destination.

## Test plan

- `npm run build:packages && npx vitest run src/lib/supervisor-orchestrator.test.ts src/server/mcp-projects-smoke.test.ts` — passed, 71 tests.
- `npx playwright test --project=server-local tests/e2e/specs/pipeline-settings.spec.ts` — passed, 1 test.
- `VISUAL_PROOF=1 npx playwright test --project=server-local tests/e2e/specs/pipeline-settings.spec.ts` — passed, 1 test; proof artifacts in `artifacts/playwright-proof-report/` and `artifacts/playwright-proof-results/`.
- `npm run lint:tsc` — failed on existing unrelated repo-wide TypeScript errors outside this change.
