### PR TITLE
fix(agent): preserve theme in global agent panel

### DIFF
--- a/src/renderer/features/GlobalAgent/GlobalAgentPanel.tsx
+++ b/src/renderer/features/GlobalAgent/GlobalAgentPanel.tsx
@@ -76,9 +76,13 @@ export const GlobalAgentPanel = memo(() => {
       return null;
     }
     const url = new URL(status.data.uiUrl, serverOrigin());
+    const theme = store.theme ?? 'teams-light';
+    if (theme !== 'default') {
+      url.searchParams.set('theme', theme);
+    }
     url.searchParams.set('minimal', 'true');
     return url.toString();
-  }, [status]);
+  }, [status, store.theme]);
 
   if (!uiUrl) {
     return (


### PR DESCRIPTION
## Summary
- Passes the active launcher theme into the embedded global Agent UI.
- Keeps `html[data-theme]` from being cleared when opening Agent from Spaces.

## Why
Clicking `Agent` in the Spaces tab mounted the OmniAgents UI without a `theme` query param. `LauncherApp` interpreted that missing param as default behavior and cleared the document theme, causing colors across the app to shift unexpectedly.

## Validation
- `npm run lint:tsc` attempted locally, but failed because `tsc` is not installed in this checkout. Dependencies appear not to be installed.
