### PR TITLE
fix(voice): guard unavailable PWA microphone APIs

### DIFF
--- a/src/renderer/features/SettingsModal/SettingsModalAudioTab.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModalAudioTab.tsx
@@ -68,6 +68,21 @@ type DeviceOption = { deviceId: string; label: string };
 
 const NONE_OPTION = '__default__';
 
+function isStandalonePwa(): boolean {
+  return window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as Navigator & { standalone?: boolean }).standalone === true;
+}
+
+function microphoneUnavailableMessage(): string {
+  if (!window.isSecureContext) {
+    return 'Microphone access requires HTTPS or localhost on this device.';
+  }
+  if (isStandalonePwa()) {
+    return 'Microphone access is not available in this installed iPhone app. Open Omni in Safari to use voice input.';
+  }
+  return 'Microphone access is not available in this browser.';
+}
+
 function deviceLabel(d: MediaDeviceInfo, fallbackIndex: number): string {
   if (d.label) {
     return d.label;
@@ -92,10 +107,11 @@ export const SettingsModalAudioTab = memo(() => {
 
   const refresh = useCallback(async () => {
     if (!navigator.mediaDevices?.enumerateDevices) {
-      setError('Audio device enumeration is not supported in this environment.');
+      setError(microphoneUnavailableMessage());
       return;
     }
     try {
+      setError(null);
       const devices = await navigator.mediaDevices.enumerateDevices();
       let inIdx = 0;
       let outIdx = 0;
@@ -119,7 +135,8 @@ export const SettingsModalAudioTab = memo(() => {
       setOutputs(outs);
       setNeedsPermission(anyLabelMissing && ins.length > 0);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to enumerate audio devices');
+      setNeedsPermission(true);
+      setError(e instanceof Error ? e.message : 'Audio device enumeration requires microphone permission.');
     }
   }, []);
 
@@ -138,6 +155,10 @@ export const SettingsModalAudioTab = memo(() => {
   }, [refresh]);
 
   const grantPermission = useCallback(async () => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setError(microphoneUnavailableMessage());
+      return;
+    }
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       stream.getTracks().forEach((t) => t.stop());
@@ -282,7 +303,15 @@ function useInputLevelMeter(deviceId: string | null) {
   const start = useCallback(async () => {
     setError(null);
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({
+      const mediaDevices = navigator.mediaDevices;
+      if (!mediaDevices?.getUserMedia) {
+        throw new Error(microphoneUnavailableMessage());
+      }
+      const Ctx = window.AudioContext ?? (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!Ctx) {
+        throw new Error('Audio capture is not available in this browser.');
+      }
+      const stream = await mediaDevices.getUserMedia({
         audio: {
           deviceId: deviceId ? { exact: deviceId } : undefined,
           echoCancellation: false,
@@ -291,8 +320,8 @@ function useInputLevelMeter(deviceId: string | null) {
         } as MediaTrackConstraints,
       });
       streamRef.current = stream;
-      const Ctx = window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
       const ctx = new Ctx();
+      await ctx.resume().catch(() => {});
       ctxRef.current = ctx;
       const source = ctx.createMediaStreamSource(stream);
       const analyser = ctx.createAnalyser();

--- a/src/renderer/omniagents-ui/components/LocalVoiceButton.tsx
+++ b/src/renderer/omniagents-ui/components/LocalVoiceButton.tsx
@@ -50,7 +50,9 @@ return;
     // talks. The speak tool is already registered via the localVoiceEnabled
     // setting, so nothing else to toggle here.
     void getVoiceClient().start().catch(() => {});
-    await cap.start().catch(() => {});
+    await cap.start().catch((err) => {
+      console.error('[voice] failed to start local capture', err);
+    });
     if (pendingStopRef.current) {
       pendingStopRef.current = false;
       await stopAndSend();
@@ -93,14 +95,14 @@ return;
     });
   }, [scope]);
 
-  const label = cap.busy ? 'Transcribing…' : cap.recording ? 'Stop and send' : 'Voice input';
+  const label = cap.error ?? (cap.busy ? 'Transcribing…' : cap.recording ? 'Stop and send' : 'Voice input');
 
   return (
     <button
       type="button"
       onClick={onClick}
       className={`flex h-8 w-8 items-center justify-center rounded-2xl ${
-        cap.recording ? 'bg-destructive/15' : 'hover:bg-accent/50'
+        cap.error ? 'bg-destructive/15' : cap.recording ? 'bg-destructive/15' : 'hover:bg-accent/50'
       }`}
       aria-label={label}
       title={label}
@@ -110,7 +112,7 @@ return;
       ) : cap.recording ? (
         <SquareIcon size={20} className="text-destructive" />
       ) : (
-        <MicIcon size={20} className="text-foreground" />
+        <MicIcon size={20} className={cap.error ? 'text-destructive' : 'text-foreground'} />
       )}
     </button>
   );

--- a/src/renderer/services/use-voice-capture.ts
+++ b/src/renderer/services/use-voice-capture.ts
@@ -49,9 +49,15 @@ function toBase64(bytes: Uint8Array): string {
   return btoa(bin);
 }
 
+function isStandalonePwa(): boolean {
+  return window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as Navigator & { standalone?: boolean }).standalone === true;
+}
+
 export interface VoiceCapture {
   recording: boolean;
   busy: boolean;
+  error: string | null;
   /** Start mic capture. */
   start: () => Promise<void>;
   /** Stop capture, transcribe, and resolve with the recognized text. */
@@ -63,6 +69,7 @@ export interface VoiceCapture {
 export function useVoiceCapture(): VoiceCapture {
   const [recording, setRecording] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const ctxRef = useRef<AudioContext | null>(null);
   const nodeRef = useRef<AudioWorkletNode | ScriptProcessorNode | null>(null);
@@ -84,9 +91,30 @@ export function useVoiceCapture(): VoiceCapture {
   }, []);
 
   const start = useCallback(async () => {
+    setError(null);
     chunksRef.current = [];
     const audioPrefs = persistedStoreApi.$atom.get().audioSettings;
-    const stream = await navigator.mediaDevices.getUserMedia({
+    const mediaDevices = navigator.mediaDevices;
+    if (!window.isSecureContext) {
+      const message = 'Voice input requires HTTPS or localhost on this device.';
+      setError(message);
+      throw new Error(message);
+    }
+    if (!mediaDevices?.getUserMedia) {
+      const message = isStandalonePwa()
+        ? 'Microphone access is not available in this installed iPhone app. Open Omni in Safari to use voice input.'
+        : 'Microphone access is not available in this browser.';
+      setError(message);
+      throw new Error(message);
+    }
+    const AudioContextCtor = window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextCtor) {
+      const message = 'Audio capture is not available in this browser.';
+      setError(message);
+      throw new Error(message);
+    }
+    const stream = await mediaDevices.getUserMedia({
       audio: {
         deviceId: audioPrefs.inputDeviceId ? { exact: audioPrefs.inputDeviceId } : undefined,
         channelCount: 1,
@@ -96,8 +124,8 @@ export function useVoiceCapture(): VoiceCapture {
       },
     });
     streamRef.current = stream;
-    const ctx = new (window.AudioContext ||
-      (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
+    const ctx = new AudioContextCtor();
+    await ctx.resume().catch(() => {});
     ctxRef.current = ctx;
     const source = ctx.createMediaStreamSource(stream);
 
@@ -136,6 +164,7 @@ export function useVoiceCapture(): VoiceCapture {
   }, []);
 
   const stop = useCallback(async (): Promise<string> => {
+    setError(null);
     setRecording(false);
     const inRate = ctxRef.current?.sampleRate ?? 48000;
     const chunks = chunksRef.current;
@@ -162,10 +191,11 @@ export function useVoiceCapture(): VoiceCapture {
   }, [cleanup]);
 
   const cancel = useCallback(() => {
+    setError(null);
     setRecording(false);
     chunksRef.current = [];
     cleanup(); // stops stream + analyser + meter loop and resets the level
   }, [cleanup]);
 
-  return { recording, busy, start, stop, cancel };
+  return { recording, busy, error, start, stop, cancel };
 }


### PR DESCRIPTION
## Summary
- Adds guards for missing `navigator.mediaDevices`, `getUserMedia`, and `AudioContext` in local voice capture.
- Surfaces local voice start failures through the mic button label/title and console logging.
- Handles blocked or unavailable audio device enumeration in the Audio settings tab with clearer messages.

## Why
On iPhone, Omni works over HTTPS in Safari but the installed standalone PWA can expose `navigator.mediaDevices` as undefined. The previous voice paths assumed mic APIs were present, causing runtime errors such as `undefined is not an object evaluating navigator.mediaDevices.getUserMedia` and audio device enumeration failures.

## Validation
- `npm run lint:tsc` attempted locally, but failed because `tsc` is not installed in this checkout. Dependencies appear not to be installed.
