### PR TITLE
fix(browser): harden server-mode proxy browser

### DIFF
--- a/docs/browser-server-proxy-overhaul-plan.md
+++ b/docs/browser-server-proxy-overhaul-plan.md
@@ -1,0 +1,479 @@
+# Browser/Server Built-In Browser Proxy Overhaul Plan
+
+## Problem
+
+Browser/server mode uses an iframe plus the launcher server's `/proxy` routes to emulate the built-in browser. This differs from Electron mode, where Omni uses Electron's real `<webview>` guest browser. The iframe/proxy approach is still the right near-term architecture for browser/server mode, but the current implementation mixes user-facing browser state with internal proxy transport state and does not yet define a strong security or compatibility contract.
+
+The visible failure is that a browser tab can end up with `/proxy/...` as its URL after flows such as clicking a PR badge in the code deck. When that happens, users see an implementation URL instead of the real destination, retries and history become confusing, and the iframe can fail to load. More broadly, common link, form, redirect, cookie, WebSocket, and runtime fetch flows can break because the proxy only rewrites a narrow set of static HTML attributes.
+
+The overhaul should keep the current iframe/proxy model, but make it explicit, scoped, secure, and testable. The proxy should support a safe useful subset of browsing in browser/server mode, especially first-party/local/sandbox surfaces and common external documentation/PR workflows. It should not promise perfect parity with Electron's real browser engine.
+
+## Goals
+
+- Keep canonical user-facing URLs out of `/proxy` transport details.
+- Make proxy registration reliable, scoped, and safe.
+- Support common same-upstream browser operations through the proxy.
+- Prevent proxied pages from becoming an open-proxy, SSRF, or same-origin attack surface.
+- Add tests that define the proxy's supported behavior and security boundaries.
+- Preserve Electron mode behavior.
+
+## Non-Goals
+
+- Do not replace Electron `<webview>` behavior.
+- Do not turn the iframe proxy into a fully transparent general-purpose browser.
+- Do not support every arbitrary public website feature such as WebAuthn/passkeys, DRM, extension APIs, camera/mic permissions, or anti-bot-protected flows.
+- Do not broaden runtime shims until security isolation and session scoping tests exist.
+
+## Current Context
+
+### Electron Mode
+
+Relevant files:
+
+- `src/renderer/common/Webview.tsx`
+- `src/main/app-control-manager.ts`
+- `src/main/browser-manager.ts`
+
+Electron mode renders `<webview>` and receives browser-native navigation, title, favicon, console, context menu, load, and failure events. It does not need `/proxy` for arbitrary external web pages.
+
+### Browser/Server Mode
+
+Relevant files:
+
+- `src/renderer/common/Webview.tsx`
+- `src/renderer/services/proxy-resolver.ts`
+- `src/server/proxy-rewriter.ts`
+- `src/renderer/features/Browser/BrowserView.tsx`
+- `src/renderer/features/Tickets/preview-bridge.ts`
+
+Browser/server mode renders an iframe. External iframe URLs are resolved through `/proxy/<name>/...` so the launcher server can strip `X-Frame-Options` and CSP `frame-ancestors`, rewrite same-upstream URLs, and inject lightweight scripts for navigation, title, console, and WebSocket handling.
+
+### Existing Tests
+
+Relevant files:
+
+- `src/server/proxy-rewriter.test.ts`
+- `tests/e2e/specs/*`
+
+Phase 0 contract doc:
+
+- `docs/proxy-security-contract.md`
+
+Current proxy tests cover pure string rewriting for static HTML attributes, CSP meta stripping, and status URL rewriting. There is no dedicated e2e spec proving browser/server proxy behavior for real interactions such as link clicks, forms, redirects, cookies, streaming responses, runtime fetches, or PR badge navigation.
+
+## Capability Contract
+
+### Supported
+
+The proxy should reliably support:
+
+- Localhost and sandbox app surfaces exposed through browser/server mode.
+- Code-server, noVNC, dashboards, notebooks, and internal app panes that are expected to run behind `/proxy`.
+- GitHub PR and documentation browsing enough for common read/review workflows.
+- Static same-upstream assets.
+- Same-upstream links, forms, redirects, cookies, fetch/XHR, EventSource, WebSocket, and Workers where allowed by the security model.
+- Clear fallback UI when a page cannot be proxied safely.
+
+### Best Effort
+
+The proxy may work but should not guarantee full support for:
+
+- Complex public SPAs.
+- OAuth redirect flows.
+- File downloads and uploads.
+- Cross-origin embedded widgets.
+- Aggressive CSP/COOP/COEP pages.
+- Sites that detect or reject embedding/proxying.
+
+### Unsupported Or Fallback
+
+The proxy should explicitly fail or offer fallback for:
+
+- WebAuthn/passkeys.
+- DRM/protected media.
+- Browser extension APIs.
+- Camera/microphone permissions inside proxied arbitrary pages.
+- Service worker registration by proxied arbitrary pages.
+- Anti-bot or high-security flows that require a real browser context.
+
+## Security Model
+
+Security must be defined before expanding compatibility shims. The proxy currently collapses many upstreams under the launcher origin at `/proxy/...`, and the iframe currently allows scripts and same-origin behavior in `src/renderer/common/Webview.tsx`. That makes isolation the highest-risk part of the overhaul.
+
+### Required Security Decisions
+
+- Proxy registrations are scoped to the authenticated user/session and browser tab or tabset.
+- Proxy names are server-minted opaque capabilities, not renderer-controlled names.
+- A proxied page cannot call launcher APIs such as `/api/*`, `/ws`, `/proxy/_register`, or unrelated `/proxy` names.
+- A proxied page cannot access parent DOM, launcher storage, IPC bridges, or app state.
+- A proxied page cannot register a service worker under the launcher origin.
+- Cookie and storage behavior is isolated by proxy session/profile, or explicitly documented as unsupported for server-mode profiles.
+- Sensitive query strings and tokens are redacted from proxy logs and UI diagnostics.
+- Console capture for arbitrary proxied pages is disabled by default or clearly scoped to trusted/local app surfaces.
+
+### SSRF And Open Proxy Controls
+
+`/proxy/_register` must not become an authenticated SSRF/open-proxy primitive.
+
+Rules:
+
+- Accept only `http:` and `https:` upstreams for HTTP proxying.
+- Reject empty, malformed, overlong, or renderer-chosen proxy names.
+- Deny link-local, metadata, and private network ranges by default for arbitrary external browsing.
+- Allow loopback/private upstreams only for trusted local/sandbox surfaces and existing configured trusted-network flows.
+- Keep `OMNI_TRUSTED_CIDRS` support, but treat it as an operator-level allowance, not a substitute for session scoping.
+- Add CSRF protection or same-session capability checks to registration and proxy access.
+
+## Proposed Implementation
+
+### Phase 0: Contract, Isolation, And Current-State Tests
+
+Before broadening proxy behavior, codify the contract and prove current security boundaries.
+
+Implementation work:
+
+- Add a proxy capability/security section to developer docs or this plan's implementation ticket.
+- Add current-state tests for `/proxy/_register` trust gating.
+- Add hostile-page e2e tests that attempt to access launcher APIs, parent DOM, storage, service workers, and unrelated proxy names.
+- Decide whether browser/server profile isolation is supported. If not, label it explicitly in UI/docs.
+
+Phase 0 current-state coverage is intentionally narrow and executable without full browser/server app bootstrapping. See `docs/proxy-security-contract.md` for the supported/best-effort/unsupported contract, security invariants, and known gaps captured by `src/server/proxy-rewriter.test.ts`.
+
+Acceptance criteria:
+
+- The team can state exactly which page classes the proxy supports.
+- Security tests exist before compatibility shims are expanded.
+- Unsupported features fail clearly instead of silently breaking.
+
+### Phase 1: Canonical URL State And Registration Reliability
+
+Separate browser state from iframe transport state.
+
+Relevant files:
+
+- `src/renderer/services/proxy-resolver.ts`
+- `src/renderer/common/Webview.tsx`
+- `src/renderer/features/Browser/BrowserView.tsx`
+- `src/renderer/features/Tickets/preview-bridge.ts`
+- `src/main/browser-manager.ts`
+
+Implementation work:
+
+- Change `resolveProxiedSrc` to return a typed result instead of a raw string.
+- Check `/proxy/_register` with `res.ok`; never cache failed registrations.
+- Keep browser tab state, omnibox, history, app-control registration, and error displays canonical.
+- Use `/proxy/...` only for iframe `src`.
+- Remove PR/preview-specific pre-proxying from `preview-bridge.ts` so PR badge opens follow the same URL path as any other browser navigation.
+- Normalize legacy persisted `/proxy/...` tab/history entries where possible using known registration state; otherwise show the safest canonical fallback or clear broken entries.
+
+Recommended interface:
+
+```ts
+type ProxiedSrcResult =
+  | {
+      ok: true;
+      canonicalUrl: string;
+      iframeSrc: string;
+      proxyName?: string;
+    }
+  | {
+      ok: false;
+      canonicalUrl: string;
+      reason: string;
+      status?: number;
+    };
+
+export const resolveProxiedSrc = async (rawSrc: string): Promise<ProxiedSrcResult>;
+```
+
+Acceptance criteria:
+
+- `/proxy/...` never appears in omnibox/history for external pages.
+- PR badge clicks store and display canonical GitHub PR URLs.
+- Registration failures show a clear fallback instead of a dead proxy page.
+
+### Phase 2: Session-Scoped Proxy Registration
+
+Replace global proxy registration semantics with scoped capabilities.
+
+Relevant files:
+
+- `src/server/proxy-rewriter.ts`
+- `src/renderer/services/proxy-resolver.ts`
+- `src/server/ws-handler.ts`
+- `src/server/managers.ts`
+
+Implementation work:
+
+- Replace renderer-supplied proxy names with server-minted IDs.
+- Scope proxy entries to user/session/tabset, depending on the server-mode identity model available at request time.
+- Store upstream metadata with owner, created time, last-used time, allowed path prefix, and site class.
+- Enforce owner/capability checks on `/proxy/:proxyName/*` and `/proxy/_register`.
+- Add expiry and cleanup for unused dynamic proxy entries.
+- Validate upstream protocol and network range before registration.
+
+Acceptance criteria:
+
+- One session cannot overwrite, guess, or use another session's proxy registration.
+- Two tabs/users can proxy the same upstream without cookie/proxy-name collisions.
+- Dynamic registration cannot be used to reach denied internal targets.
+
+### Phase 3: HTTP Proxy Semantics
+
+Harden request/response handling before adding broad runtime shims.
+
+Relevant file:
+
+- `src/server/proxy-rewriter.ts`
+
+Implementation work:
+
+- Preserve method, query string, body, and content type for non-GET requests.
+- Normalize upstream-facing `Host`, `Origin`, and `Referer` for same-upstream proxied requests.
+- Continue dropping hop-by-hop headers.
+- Use streaming for non-HTML bodies instead of buffering everything into memory.
+- Use manual redirect handling so `Location` can be rewritten intentionally.
+- Rewrite same-upstream `Location` headers to `/proxy/<name>/...`.
+- Define and test cross-origin redirect behavior.
+- Rewrite `Set-Cookie` headers safely for proxy paths, preserving valid `HttpOnly`, `Secure`, and `SameSite` attributes.
+- Redact sensitive query parameters from logs.
+
+Suggested helper exports:
+
+```ts
+export function rewriteLocationHeader(location: string, upstream: string, proxyName: string): string;
+export function rewriteSetCookieHeader(cookie: string, proxyName: string): string;
+export function redactProxyUrlForLog(url: string): string;
+```
+
+Acceptance criteria:
+
+- Large files and SSE responses are streamed.
+- Cookie-backed same-upstream flows work in the supported test harness.
+- Redirect chains preserve canonical browser state and do not leak `/proxy` to UI state.
+
+### Phase 4: Static HTML And CSS Rewriting
+
+Expand static rewriting using safer helper boundaries.
+
+Relevant file:
+
+- `src/server/proxy-rewriter.ts`
+
+Implementation work:
+
+- Expand URL-bearing HTML attribute support:
+  - `href`
+  - `src`
+  - `action`
+  - `formaction`
+  - `poster`
+  - `data`
+  - `srcset`
+  - `iframe[src]`
+  - `source[src]`
+  - `track[src]`
+  - preload/prefetch/modulepreload links
+- Rewrite `meta[http-equiv=refresh]` URLs.
+- Add CSS `url(...)` rewriting for same-upstream and root-relative assets.
+- Preserve the current rule that inline JavaScript and JSON literals are not rewritten by static regex replacement.
+
+Suggested helper exports:
+
+```ts
+export function rewriteHtmlUrls(html: string, upstream: string, proxyName: string): string;
+export function rewriteCssUrls(css: string, upstream: string, proxyName: string): string;
+export function rewriteMetaRefresh(html: string, upstream: string, proxyName: string): string;
+```
+
+Acceptance criteria:
+
+- Common static assets load for supported pages.
+- Third-party absolute URLs are not rewritten unless explicitly registered.
+- Existing CSP and XFO stripping behavior remains intact for proxied HTML.
+
+### Phase 5: Runtime Compatibility Shims Behind A Flag
+
+Only after Phase 0 security tests and Phase 2 scoping land, broaden injected runtime support.
+
+Relevant file:
+
+- `src/server/proxy-rewriter.ts`
+
+Implementation work:
+
+- Replace the current minimal navigation/WebSocket injection with a versioned runtime shim.
+- Gate expanded shims behind a feature flag or per-site-class allowlist.
+- Rewrite same-upstream or root-relative runtime URLs for:
+  - anchor clicks
+  - `target=_blank`
+  - `window.open`
+  - form submissions
+  - `fetch`
+  - `XMLHttpRequest`
+  - `EventSource`
+  - `WebSocket`
+  - `Worker`
+- Use `new URL(input, location.href)` for all runtime URL parsing.
+- Block or no-op service worker registration for arbitrary proxied pages unless explicitly trusted.
+- Keep navigation/title postMessage reporting canonical.
+
+Acceptance criteria:
+
+- Runtime shims do not allow access to launcher APIs or unrelated proxy entries.
+- Same-upstream runtime calls work in the synthetic e2e harness.
+- The shim can be disabled quickly if it breaks pages.
+
+### Phase 6: User-Facing Fallback And Diagnostics
+
+Make failures explicit and recoverable.
+
+Relevant files:
+
+- `src/renderer/common/Webview.tsx`
+- `src/renderer/features/Browser/BrowserView.tsx`
+
+Implementation work:
+
+- Add a browser/server proxy failure panel.
+- Show canonical URL, short reason, retry, copy URL, and browser-native open/copy instructions.
+- Avoid showing `/proxy/...` except in a details/debug section.
+- Include specific messages for registration forbidden, denied upstream, DNS/TLS failure, timeout, redirect loop, and unsupported browser feature.
+
+Acceptance criteria:
+
+- Users never get stranded on an opaque `/proxy/...` error page.
+- Failure states are actionable and include canonical URLs.
+
+## Test Plan
+
+### Unit Tests
+
+Expand `src/server/proxy-rewriter.test.ts`.
+
+Add coverage for:
+
+- `iframe[src]`, `source[src]`, `track[src]`.
+- `modulepreload`, `preload`, and `prefetch` links.
+- `meta refresh` rewriting.
+- CSS `url(...)` rewriting.
+- Multiple-value `srcset` rewriting.
+- Same-upstream and cross-origin `Location` handling.
+- `Set-Cookie` domain/path rewriting.
+- URL redaction in logs.
+- Relative WebSocket URL handling with `new URL(input, location.href)`.
+- Service worker blocking shim behavior.
+
+Add renderer unit tests for:
+
+- `resolveProxiedSrc` non-OK registration failures.
+- `resolveProxiedSrc` success result shape.
+- `unproxyUrl` query/hash preservation.
+- Unknown proxy names staying safe.
+- Legacy `/proxy/...` normalization behavior.
+
+### Integration Tests
+
+Add a Fastify proxy integration harness with a synthetic upstream server.
+
+Coverage:
+
+- GET with query strings.
+- POST/PUT/PATCH/DELETE body forwarding.
+- Header normalization.
+- CSP/XFO stripping.
+- HTML and CSS rewriting.
+- Same-upstream redirects.
+- Cross-origin redirect behavior.
+- Cookie set and replay.
+- SSE streaming.
+- Large binary streaming without buffering entire response.
+- WebSocket echo, including binary frames.
+- Forbidden, invalid, and denied `/proxy/_register` calls.
+- Session-scoped proxy name isolation.
+
+### Browser E2E Tests
+
+Add a dedicated server-mode spec:
+
+- `tests/e2e/specs/proxy-browser.spec.ts`
+
+Use a synthetic upstream torture page with controls for:
+
+- normal links
+- absolute same-upstream links
+- root-relative links
+- `target=_blank`
+- `window.open`
+- forms
+- `fetch('/api/data')`
+- `XMLHttpRequest('/api/data')`
+- `EventSource('/events')`
+- `new WebSocket('/ws')`
+- cookies
+- redirects
+- SPA `pushState` and `replaceState`
+- file upload input where supported
+- download response where supported
+
+Assertions:
+
+- iframe `src` uses `/proxy/...`.
+- omnibox/history/app-control state uses canonical URLs.
+- page content updates as expected.
+- unsupported operations show fallback or documented failure.
+
+### Security E2E Tests
+
+Add hostile-page tests for browser/server mode.
+
+Assertions:
+
+- Proxied page cannot read parent DOM.
+- Proxied page cannot read launcher localStorage/sessionStorage used by the app.
+- Proxied page cannot call `/api/*` launcher endpoints.
+- Proxied page cannot open `/ws` launcher WebSocket.
+- Proxied page cannot call `/proxy/_register`.
+- Proxied page cannot access unrelated proxy names.
+- Proxied page cannot register a service worker under launcher origin.
+- Two sessions/tabs cannot share proxy registrations or cookies unless explicitly expected.
+
+### Regression Tests
+
+Add PR badge regression coverage.
+
+Coverage:
+
+- Click a PR badge in a code deck column.
+- Browser tab state stores canonical GitHub PR URL.
+- Iframe transport uses `/proxy/...` internally.
+- Omnibox/history never show `/proxy/...`.
+- Failed proxy registration shows the fallback panel with the canonical GitHub URL.
+
+## Acceptance Criteria
+
+- Browser/server proxy has a documented capability and security contract.
+- Proxy registrations are scoped, server-minted, validated, and expiring.
+- Browser state and app-control state use canonical URLs.
+- `/proxy/...` is confined to iframe transport and debug details.
+- PR badge navigation no longer leaks proxy URLs.
+- Common same-upstream operations work in unit, integration, and e2e tests.
+- Hostile-page tests prove proxied pages cannot access launcher APIs/storage or register new proxies.
+- Unsupported features fail with clear user-facing fallback.
+- Electron behavior remains unchanged.
+
+## Rollout Strategy
+
+- Land Phase 0 and Phase 1 first to fix user-visible URL leakage without broadening proxy power.
+- Land Phase 2 before cookie, redirect, and runtime compatibility changes.
+- Land Phase 3 and Phase 4 with integration tests and security tests in place.
+- Land Phase 5 behind a feature flag or allowlist.
+- Land Phase 6 fallback UX before enabling expanded proxy behavior broadly.
+
+## Assumptions
+
+- Browser/server mode remains iframe/proxy-based for this overhaul.
+- The proxy is intended to support a safe useful subset, not full Electron parity.
+- Browser/server profile isolation must be either implemented or explicitly documented as unsupported.
+- The implementation should prioritize local/sandbox/app surfaces and GitHub PR/documentation workflows before arbitrary external sites.
+- Runtime shims are considered higher risk and should only be expanded after scoping and isolation are proven by tests.

--- a/docs/proxy-security-contract.md
+++ b/docs/proxy-security-contract.md
@@ -1,0 +1,72 @@
+# Browser/Server Proxy Security Contract
+
+This contract covers the browser/server-mode iframe proxy served from `/proxy`. It is the Phase 0 safety baseline for the browser/server proxy overhaul and should be updated before any compatibility shim expands proxy power.
+
+## Supported Page Classes
+
+- Localhost and sandbox surfaces launched by Omni, including chat UI, code-server, noVNC, notebooks, dashboards, and other app panes that are expected to run behind the launcher proxy.
+- Static same-upstream HTML assets whose URLs appear in supported attributes such as `href`, `src`, `action`, `formaction`, `poster`, `data`, and `srcset`.
+- Server-minted dynamic registration for browser/server surfaces where the caller is already allowed by the same network policy used for `/api/ws-token`.
+- Basic GitHub documentation and PR reading flows as a target outcome of the overhaul, once later phases separate canonical browser state from proxy transport state.
+
+## Best-Effort Page Classes
+
+- Complex public SPAs that rely on runtime URL construction, aggressive CSP/COOP/COEP, cross-origin widgets, or anti-embedding behavior.
+- OAuth and other redirect-heavy workflows until redirect handling and fallback UI are explicitly implemented.
+- Downloads, uploads, and cookies until later phases add scoped tests and behavior. EventSource, WebSocket, Workers, and same-upstream runtime fetch/XHR are supported only where Phase 5 runtime policy enables expanded shims.
+
+## Unsupported Or Fallback Page Classes
+
+- WebAuthn/passkeys, DRM/protected media, browser extension APIs, camera/microphone permissions in arbitrary proxied pages, and anti-bot/high-security flows.
+- Service worker registration by arbitrary proxied pages unless a future trusted-site allowlist explicitly permits it.
+- Cross-tab cookie/storage isolation for browser/server profiles. Dynamic proxy names are now opaque and expiring, but full browser profile isolation remains unsupported.
+
+## Security Invariants
+
+- `/proxy/_register` must be denied for callers outside the trusted network unless the operator explicitly sets `OMNI_ALLOW_EXTERNAL_REGISTER=1`.
+- Dynamic proxy registration is server-minted, expiring, owner-checked when EasyAuth identity is present, and restricted to `http:` and `https:` upstreams.
+- Proxied pages must not be able to call launcher APIs such as `/api/*`, `/ws`, `/proxy/_register`, or unrelated `/proxy` names as launcher-origin capabilities.
+- Proxied pages must not access parent DOM, launcher localStorage/sessionStorage, IPC bridges, or app state.
+- Static root-relative links and forms in proxied HTML should stay under that page's proxy prefix instead of targeting launcher-origin routes directly.
+- Sensitive query strings and tokens must not be logged or surfaced in diagnostics without redaction.
+
+## Phase 0 Executable Baseline
+
+The Phase 0 Vitest coverage in `src/server/proxy-rewriter.test.ts` establishes the current safety foundation without changing runtime proxy behavior:
+
+- `/proxy/_register` rejects untrusted callers.
+- `/proxy/_register` accepts trusted HTTP registrations and preserves the initial path/query in the returned proxy path.
+- `OMNI_ALLOW_EXTERNAL_REGISTER=1` remains a current operator escape hatch.
+- Static hostile-page links to launcher-looking paths are rewritten under the active proxy prefix where the current attribute rewriter supports them.
+- Inline hostile scripts are not rewritten by static HTML rewriting, documenting the current launcher API and service-worker exposure gap.
+
+## Phase 2 Baseline
+
+- `/proxy/_register` ignores renderer-supplied names and returns the actual opaque `proxyName` and `proxyPath` minted by the server.
+- Dynamic registrations carry owner metadata. In EasyAuth mode, proxy access requires the same authenticated principal header that created the registration.
+- In non-EasyAuth server mode, every request belongs to the local single tenant. Dynamic proxy names are unguessable expiring capabilities, but there is no stronger per-browser-session HTTP identity available yet.
+- Internal status rewrites from `rewriteStatusUrls` / `registerAndRewrite` remain trusted, process-local registrations with stable names so existing chat/code-server/noVNC surfaces keep working.
+- Expired dynamic registrations are removed deterministically by the proxy cleanup path during registration/access and by the exported cleanup helper used in tests.
+
+## Phase 5 Baseline
+
+- Proxied HTML receives a versioned runtime shim that always reports navigation/title messages using canonical upstream URLs.
+- Expanded runtime URL rewriting defaults on for trusted-internal entries and off for dynamic entries unless an operator explicitly sets `OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS=1`.
+- Setting `OMNI_PROXY_RUNTIME_SHIMS=0` disables expanded runtime URL rewriting quickly while leaving the canonical reporting and service-worker guard in place.
+- Runtime rewriting keeps same-upstream and launcher-origin root-relative requests under the active proxy prefix, including `/api/*`, `/ws`, `/proxy/_register`, and unrelated `/proxy/...` paths.
+- Service worker registration is blocked for dynamic proxied pages. Trusted-internal entries do not receive that block by default.
+
+## Current Known Gaps
+
+- Dynamic registrations are not yet scoped to a specific browser tab/tabset; EasyAuth scopes to principal, while single-tenant mode relies on unguessable expiring names.
+- The proxy still relies on trusted-network gating plus minted capabilities rather than a dedicated CSRF token for `/proxy/_register`.
+- Static links or forms that already point at `/proxy/...`, including `/proxy/_register`, are not double-proxied by the static rewriter; Phase 5 runtime shims cover user/runtime flows when expanded rewriting is enabled.
+- Proxied HTML can still run scripts in the launcher origin iframe sandbox configuration, so Phase 5 relies on the injected runtime guard for supported fetch/XHR/EventSource/WebSocket/Worker/service-worker APIs rather than full origin isolation.
+- Console capture posts arbitrary proxied-page console output to the parent by default; later phases should scope or disable it for untrusted pages.
+- Cookie and storage isolation for browser/server profiles is not implemented as a supported feature.
+
+## Phase 1 Handoff
+
+- Keep `/proxy/...` as iframe transport only; browser tab state, history, omnibox, and app-control state should use canonical upstream URLs.
+- Check `/proxy/_register` responses before caching or navigating to proxy paths, and surface a clear fallback for non-OK registration.
+- Do not broaden runtime fetch/XHR/WebSocket/Worker shims until Phase 2 session-scoped capabilities and hostile-page tests are in place.

--- a/src/lib/url.test.ts
+++ b/src/lib/url.test.ts
@@ -16,6 +16,10 @@ describe('normalizeAddress', () => {
     expect(normalizeAddress('view-source:https://a.b')).toBe('view-source:https://a.b');
   });
 
+  it('does not treat relative proxy transport paths as navigable browser URLs', () => {
+    expect(normalizeAddress('/proxy/ext-https-github-com/acme/repo/pull/42')).toBe(BROWSER_START_URL);
+  });
+
   it('treats whitespace as a search query', () => {
     expect(normalizeAddress('hello world')).toBe('https://duckduckgo.com/?q=hello%20world');
     expect(normalizeAddress('foo bar.com')).toContain('duckduckgo.com/?q=');

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -15,6 +15,14 @@ const IPV6_BRACKETED_PATTERN = /^\[[0-9a-fA-F:]+\](:\d+)?(\/.*)?$/;
 const HOST_PORT_PATTERN = /^[\w-]+(\.[\w-]+)*:\d+(\/.*)?$/;
 const DOTTED_HOST_PATTERN = /^[\w-]+(\.[\w-]+)+(\/.*)?$/;
 
+export function isProxyTransportPath(input: string): boolean {
+  return input.trim().startsWith('/proxy/');
+}
+
+export function normalizeBrowserStateUrl(input: string): string {
+  return isProxyTransportPath(input) ? BROWSER_START_URL : input;
+}
+
 /**
  * Coerce a typed address into a loadable URL.
  *
@@ -33,34 +41,38 @@ const DOTTED_HOST_PATTERN = /^[\w-]+(\.[\w-]+)+(\/.*)?$/;
 export function normalizeAddress(input: string): string {
   const trimmed = input.trim();
   if (!trimmed) {
-return BROWSER_START_URL;
-}
+    return BROWSER_START_URL;
+  }
+
+  if (isProxyTransportPath(trimmed)) {
+    return BROWSER_START_URL;
+  }
 
   if (SCHEME_PATTERNS.some((re) => re.test(trimmed))) {
-return trimmed;
-}
+    return trimmed;
+  }
 
   // Any whitespace → query. Runs before host heuristics so "foo bar.com" is a
   // search, not an attempt at "bar.com".
   if (/\s/.test(trimmed)) {
-return `${DEFAULT_SEARCH}${encodeURIComponent(trimmed)}`;
-}
+    return `${DEFAULT_SEARCH}${encodeURIComponent(trimmed)}`;
+  }
 
   if (LOCALHOST_PATTERN.test(trimmed)) {
-return `http://${trimmed}`;
-}
+    return `http://${trimmed}`;
+  }
   if (IPV4_PATTERN.test(trimmed)) {
-return `http://${trimmed}`;
-}
+    return `http://${trimmed}`;
+  }
   if (IPV6_BRACKETED_PATTERN.test(trimmed)) {
-return `http://${trimmed}`;
-}
+    return `http://${trimmed}`;
+  }
   if (HOST_PORT_PATTERN.test(trimmed)) {
-return `http://${trimmed}`;
-}
+    return `http://${trimmed}`;
+  }
   if (DOTTED_HOST_PATTERN.test(trimmed)) {
-return `https://${trimmed}`;
-}
+    return `https://${trimmed}`;
+  }
 
   return `${DEFAULT_SEARCH}${encodeURIComponent(trimmed)}`;
 }
@@ -86,7 +98,7 @@ export function parseOrigin(url: string): { scheme: string; host: string; secure
 export function fallbackTitle(url: string): string {
   const origin = parseOrigin(url);
   if (origin) {
-return origin.host || url;
-}
+    return origin.host || url;
+  }
   return url;
 }

--- a/src/main/browser-manager.test.ts
+++ b/src/main/browser-manager.test.ts
@@ -1,13 +1,25 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import { BROWSER_START_URL } from '@/lib/url';
 import { BrowserManager, type BrowserStoreSurface, DEFAULT_PROFILE_ID } from '@/main/browser-manager';
-import type { BrowserBookmark, BrowserHistoryEntry, BrowserProfile, BrowserTabset, BrowserTabsetId } from '@/shared/types';
+import type {
+  BrowserBookmark,
+  BrowserHistoryEntry,
+  BrowserProfile,
+  BrowserTabset,
+  BrowserTabsetId,
+} from '@/shared/types';
 
-function makeStore(): BrowserStoreSurface {
-  let profiles: BrowserProfile[] = [];
-  let tabsets: Record<BrowserTabsetId, BrowserTabset> = {};
-  let history: BrowserHistoryEntry[] = [];
-  let bookmarks: BrowserBookmark[] = [];
+function makeStore(initial?: {
+  profiles?: BrowserProfile[];
+  tabsets?: Record<BrowserTabsetId, BrowserTabset>;
+  history?: BrowserHistoryEntry[];
+  bookmarks?: BrowserBookmark[];
+}): BrowserStoreSurface {
+  let profiles: BrowserProfile[] = initial?.profiles ?? [];
+  let tabsets: Record<BrowserTabsetId, BrowserTabset> = initial?.tabsets ?? {};
+  let history: BrowserHistoryEntry[] = initial?.history ?? [];
+  let bookmarks: BrowserBookmark[] = initial?.bookmarks ?? [];
   return {
     getProfiles: () => profiles,
     setProfiles: (p) => {
@@ -109,6 +121,46 @@ describe('BrowserManager', () => {
     mgr.navigateTab('nav', activeTabId!, 'localhost:3000');
     const ts = mgr.getSnapshot().tabsets.nav!;
     expect(ts.tabs[0]!.url).toBe('http://localhost:3000');
+  });
+
+  it('does not store relative proxy transport paths on create, update, or history', () => {
+    mgr.ensureTabset('nav');
+    const created = mgr.createTab('nav', { url: '/proxy/ext-https-github-com/acme/repo/pull/42', activate: true });
+    expect(created.url).toBe(BROWSER_START_URL);
+
+    mgr.updateTabMeta('nav', created.id, { url: '/proxy/ext-https-example-com/docs' });
+    expect(mgr.getSnapshot().tabsets.nav!.tabs.find((tab) => tab.id === created.id)!.url).toBe(BROWSER_START_URL);
+
+    mgr.recordHistory({ url: '/proxy/ext-https-example-com/docs', profileId: DEFAULT_PROFILE_ID });
+    expect(mgr.listHistory()).toHaveLength(0);
+  });
+
+  it('normalizes legacy persisted relative proxy transport state', () => {
+    const store = makeStore({
+      tabsets: {
+        legacy: {
+          id: 'legacy',
+          profileId: DEFAULT_PROFILE_ID,
+          activeTabId: 'tab-1',
+          createdAt: 1,
+          updatedAt: 1,
+          tabs: [{ id: 'tab-1', url: '/proxy/ext-https-github-com/acme/repo/pull/42', createdAt: 1, lastActiveAt: 1 }],
+        },
+      },
+      history: [
+        {
+          id: 'h-1',
+          url: '/proxy/ext-https-github-com/acme/repo/pull/42',
+          profileId: DEFAULT_PROFILE_ID,
+          visitedAt: 1,
+        },
+        { id: 'h-2', url: 'https://github.com/acme/repo/pull/42', profileId: DEFAULT_PROFILE_ID, visitedAt: 2 },
+      ],
+    });
+    const manager = new BrowserManager({ store, newId: () => 'id', now: () => 10 });
+
+    expect(manager.getSnapshot().tabsets.legacy!.tabs[0]!.url).toBe(BROWSER_START_URL);
+    expect(manager.listHistory().map((entry) => entry.url)).toEqual(['https://github.com/acme/repo/pull/42']);
   });
 
   it('removeTabset drops the entry', () => {

--- a/src/main/browser-manager.ts
+++ b/src/main/browser-manager.ts
@@ -9,7 +9,7 @@
  * narrow store interface so it can be exercised in tests without a live
  * electron-store instance.
  */
-import { BROWSER_START_URL, normalizeAddress } from '@/lib/url';
+import { BROWSER_START_URL, isProxyTransportPath, normalizeAddress, normalizeBrowserStateUrl } from '@/lib/url';
 import type { IIpcListener } from '@/shared/ipc-listener';
 import type {
   BrowserBookmark,
@@ -68,6 +68,7 @@ export class BrowserManager {
 
   constructor(private readonly deps: BrowserManagerDeps) {
     this.ensureDefaultProfile();
+    this.normalizePersistedBrowserState();
   }
 
   // ---------------------------------------------------------------------------
@@ -94,8 +95,8 @@ export class BrowserManager {
     const profiles = this.deps.store.getProfiles();
     const existing = profiles.find((p) => p.id === DEFAULT_PROFILE_ID);
     if (existing) {
-return existing;
-}
+      return existing;
+    }
     const profile: BrowserProfile = {
       id: DEFAULT_PROFILE_ID,
       label: 'Default',
@@ -141,23 +142,20 @@ return existing;
       }
     }
     if (mutated) {
-this.deps.store.setTabsets(next);
-}
+      this.deps.store.setTabsets(next);
+    }
   }
 
   // ---------------------------------------------------------------------------
   // Tabsets
   // ---------------------------------------------------------------------------
 
-  ensureTabset(
-    id: BrowserTabsetId,
-    opts?: { profileId?: BrowserProfileId; initialUrl?: string }
-  ): BrowserTabset {
+  ensureTabset(id: BrowserTabsetId, opts?: { profileId?: BrowserProfileId; initialUrl?: string }): BrowserTabset {
     const tabsets = this.deps.store.getTabsets();
     const existing = tabsets[id];
     if (existing) {
-return existing;
-}
+      return existing;
+    }
     const now = this.deps.now();
     const initialUrl = opts?.initialUrl ?? BROWSER_START_URL;
     const firstTab: BrowserTab = {
@@ -190,8 +188,8 @@ return existing;
   removeTabset(id: BrowserTabsetId): void {
     const tabsets = this.deps.store.getTabsets();
     if (!tabsets[id]) {
-return;
-}
+      return;
+    }
     const { [id]: _removed, ...rest } = tabsets;
     this.deps.store.setTabsets(rest);
   }
@@ -208,7 +206,7 @@ return;
       const now = this.deps.now();
       const tab: BrowserTab = {
         id: this.deps.newId(),
-        url: opts?.url ?? BROWSER_START_URL,
+        url: opts?.url ? normalizeBrowserStateUrl(opts.url) : BROWSER_START_URL,
         createdAt: now,
         lastActiveAt: now,
         ...(opts?.profileId ? { profileId: opts.profileId } : {}),
@@ -229,8 +227,8 @@ return;
     this.mutateTabset(tabsetId, (ts) => {
       const idx = ts.tabs.findIndex((t) => t.id === tabId);
       if (idx < 0) {
-throw new BrowserTabNotFoundError(tabsetId, tabId);
-}
+        throw new BrowserTabNotFoundError(tabsetId, tabId);
+      }
       // Remember the closed tab (minus any blank start-page tabs) so
       // Cmd+Shift+T can resurrect it.
       const closed = ts.tabs[idx]!;
@@ -301,8 +299,8 @@ throw new BrowserTabNotFoundError(tabsetId, tabId);
     this.mutateTabset(tabsetId, (ts) => {
       const tab = ts.tabs.find((t) => t.id === tabId);
       if (!tab) {
-throw new BrowserTabNotFoundError(tabsetId, tabId);
-}
+        throw new BrowserTabNotFoundError(tabsetId, tabId);
+      }
       const now = this.deps.now();
       const tabs = ts.tabs.map((t) =>
         t.id === tabId ? { ...t, url, lastActiveAt: now, title: undefined, favicon: undefined } : t
@@ -319,9 +317,10 @@ throw new BrowserTabNotFoundError(tabsetId, tabId);
     this.mutateTabset(tabsetId, (ts) => {
       const tab = ts.tabs.find((t) => t.id === tabId);
       if (!tab) {
-throw new BrowserTabNotFoundError(tabsetId, tabId);
-}
-      const tabs = ts.tabs.map((t) => (t.id === tabId ? { ...t, ...patch } : t));
+        throw new BrowserTabNotFoundError(tabsetId, tabId);
+      }
+      const normalizedPatch = patch.url ? { ...patch, url: normalizeBrowserStateUrl(patch.url) } : patch;
+      const tabs = ts.tabs.map((t) => (t.id === tabId ? { ...t, ...normalizedPatch } : t));
       return { next: { ...ts, tabs } };
     });
   }
@@ -339,8 +338,8 @@ throw new BrowserTabNotFoundError(tabsetId, tabId);
       }
       // Anything the caller omitted goes to the end (defensive).
       for (const t of byId.values()) {
-ordered.push(t);
-}
+        ordered.push(t);
+      }
       return { next: { ...ts, tabs: ordered } };
     });
   }
@@ -349,8 +348,8 @@ ordered.push(t);
     this.mutateTabset(tabsetId, (ts) => {
       const tab = ts.tabs.find((t) => t.id === tabId);
       if (!tab) {
-throw new BrowserTabNotFoundError(tabsetId, tabId);
-}
+        throw new BrowserTabNotFoundError(tabsetId, tabId);
+      }
       const tabs = ts.tabs.map((t) => (t.id === tabId ? { ...t, pinned } : t));
       return { next: { ...ts, tabs } };
     });
@@ -360,8 +359,8 @@ throw new BrowserTabNotFoundError(tabsetId, tabId);
     return this.mutateTabset(tabsetId, (ts) => {
       const src = ts.tabs.find((t) => t.id === tabId);
       if (!src) {
-throw new BrowserTabNotFoundError(tabsetId, tabId);
-}
+        throw new BrowserTabNotFoundError(tabsetId, tabId);
+      }
       const now = this.deps.now();
       const clone: BrowserTab = {
         ...src,
@@ -380,9 +379,9 @@ throw new BrowserTabNotFoundError(tabsetId, tabId);
   // ---------------------------------------------------------------------------
 
   recordHistory(entry: { url: string; title?: string; profileId: BrowserProfileId }): void {
-    if (!entry.url || entry.url === 'about:blank') {
-return;
-}
+    if (!entry.url || entry.url === 'about:blank' || isProxyTransportPath(entry.url)) {
+      return;
+    }
     const history = this.deps.store.getHistory();
     const last = history[0];
     // Dedupe consecutive visits to the same URL within the same profile.
@@ -404,21 +403,15 @@ return;
     this.deps.store.setHistory(next);
   }
 
-  listHistory(opts?: {
-    query?: string;
-    limit?: number;
-    profileId?: BrowserProfileId;
-  }): BrowserHistoryEntry[] {
+  listHistory(opts?: { query?: string; limit?: number; profileId?: BrowserProfileId }): BrowserHistoryEntry[] {
     const q = (opts?.query ?? '').trim().toLowerCase();
     const limit = opts?.limit ?? 100;
     let entries = this.deps.store.getHistory();
     if (opts?.profileId) {
-entries = entries.filter((e) => e.profileId === opts.profileId);
-}
+      entries = entries.filter((e) => e.profileId === opts.profileId);
+    }
     if (q) {
-      entries = entries.filter(
-        (e) => e.url.toLowerCase().includes(q) || (e.title?.toLowerCase().includes(q) ?? false)
-      );
+      entries = entries.filter((e) => e.url.toLowerCase().includes(q) || (e.title?.toLowerCase().includes(q) ?? false));
     }
     return entries.slice(0, limit);
   }
@@ -456,15 +449,12 @@ entries = entries.filter((e) => e.profileId === opts.profileId);
   // Suggestions
   // ---------------------------------------------------------------------------
 
-  suggest(
-    query: string,
-    opts?: { limit?: number; profileId?: BrowserProfileId }
-  ): BrowserSuggestion[] {
+  suggest(query: string, opts?: { limit?: number; profileId?: BrowserProfileId }): BrowserSuggestion[] {
     const q = query.trim();
     const limit = opts?.limit ?? 8;
     if (!q) {
-return [];
-}
+      return [];
+    }
 
     const qLower = q.toLowerCase();
     const now = this.deps.now();
@@ -474,8 +464,8 @@ return [];
     for (const b of this.deps.store.getBookmarks()) {
       const hay = `${b.title} ${b.url}`.toLowerCase();
       if (!hay.includes(qLower)) {
-continue;
-}
+        continue;
+      }
       out.push({ kind: 'bookmark', url: b.url, title: b.title, score: 100 + hay.indexOf(qLower) * -1 });
     }
 
@@ -484,15 +474,15 @@ continue;
     const seen = new Set<string>(out.map((o) => o.url));
     for (const h of history) {
       if (opts?.profileId && h.profileId !== opts.profileId) {
-continue;
-}
+        continue;
+      }
       if (seen.has(h.url)) {
-continue;
-}
+        continue;
+      }
       const hay = `${h.title ?? ''} ${h.url}`.toLowerCase();
       if (!hay.includes(qLower)) {
-continue;
-}
+        continue;
+      }
       // Decay: last 24h ≈ +30, last week ≈ +15, older ≈ +5
       const ageHours = Math.max(0, (now - h.visitedAt) / 3_600_000);
       const recency = ageHours < 24 ? 30 : ageHours < 24 * 7 ? 15 : 5;
@@ -524,12 +514,40 @@ continue;
     const tabsets = this.deps.store.getTabsets();
     const ts = tabsets[tabsetId];
     if (!ts) {
-throw new BrowserTabsetNotFoundError(tabsetId);
-}
+      throw new BrowserTabsetNotFoundError(tabsetId);
+    }
     const { next, result } = mutator(ts);
     const stamped: BrowserTabset = { ...next, updatedAt: this.deps.now() };
     this.deps.store.setTabsets({ ...tabsets, [tabsetId]: stamped });
     return result as R;
+  }
+
+  private normalizePersistedBrowserState(): void {
+    const tabsets = this.deps.store.getTabsets();
+    let tabsetsChanged = false;
+    const nextTabsets: Record<BrowserTabsetId, BrowserTabset> = {};
+    for (const [id, tabset] of Object.entries(tabsets)) {
+      let tabsetChanged = false;
+      const tabs = tabset.tabs.map((tab) => {
+        const url = normalizeBrowserStateUrl(tab.url);
+        if (url !== tab.url) {
+          tabsetsChanged = true;
+          tabsetChanged = true;
+          return { ...tab, url };
+        }
+        return tab;
+      });
+      nextTabsets[id] = tabsetChanged ? { ...tabset, tabs } : tabset;
+    }
+    if (tabsetsChanged) {
+      this.deps.store.setTabsets(nextTabsets);
+    }
+
+    const history = this.deps.store.getHistory();
+    const nextHistory = history.filter((entry) => !isProxyTransportPath(entry.url));
+    if (nextHistory.length !== history.length) {
+      this.deps.store.setHistory(nextHistory);
+    }
   }
 }
 
@@ -538,9 +556,7 @@ throw new BrowserTabsetNotFoundError(tabsetId);
 // ---------------------------------------------------------------------------
 
 type ElectronStoreLike = {
-  get<K extends 'browserProfiles' | 'browserTabsets' | 'browserHistory' | 'browserBookmarks'>(
-    key: K
-  ): unknown;
+  get<K extends 'browserProfiles' | 'browserTabsets' | 'browserHistory' | 'browserBookmarks'>(key: K): unknown;
   set(key: string, value: unknown): void;
 };
 

--- a/src/renderer/common/Webview.tsx
+++ b/src/renderer/common/Webview.tsx
@@ -8,6 +8,11 @@ import {
   isAbortErrorCode,
   shouldRetryInitialLoad,
 } from '@/lib/webview-navigation';
+import {
+  getWebviewFallbackDiagnostics,
+  openInBrowserTab,
+  type WebviewLoadError,
+} from '@/renderer/common/webview-fallback';
 import { registerApp, unregisterApp, updateApp } from '@/renderer/features/AppControl/live-registry';
 import { resolveProxiedSrc, unproxyUrl } from '@/renderer/services/proxy-resolver';
 import type { AppHandleId, AppRegistrationPayload } from '@/shared/app-control-types';
@@ -103,667 +108,779 @@ export type ContextMenuParams = {
   };
 };
 
-export const Webview = forwardRef<WebviewHandle, {
-  src?: string;
-  onReady?: () => void;
-  onConsoleMessage?: (msg: ConsoleMessage) => void;
-  onNavigate?: (url: string) => void;
-  onLoadingChange?: (loading: boolean) => void;
-  onTitleChange?: (title: string) => void;
-  onFaviconChange?: (favicon: string) => void;
-  onFoundInPage?: (result: FoundInPageResult) => void;
-  onContextMenu?: (params: ContextMenuParams) => void;
-  onError?: (error: { code: number; description: string; url: string }) => void;
-  maxInitialRetries?: number;
-  retryBaseDelayMs?: number;
-  retryMaxDelayMs?: number;
-  showUnavailable?: boolean;
-  /** If provided, this webview registers itself with the app-control registry. */
-  registry?: WebviewRegistryProps;
-  /**
-   * Electron `<webview partition="…">`. Scopes cookies / localStorage / cache
-   * to the given profile. Names starting with `persist:` persist to disk; any
-   * other name is in-memory only (incognito). No-op in browser/iframe mode.
-   */
-  partition?: string;
-}>(({
-  src,
-  onReady,
-  onConsoleMessage,
-  onNavigate,
-  onLoadingChange,
-  onTitleChange,
-  onFaviconChange,
-  onFoundInPage,
-  onContextMenu,
-  onError,
-  maxInitialRetries = DEFAULT_WEBVIEW_MAX_INITIAL_RETRIES,
-  retryBaseDelayMs = DEFAULT_WEBVIEW_RETRY_BASE_DELAY_MS,
-  retryMaxDelayMs = DEFAULT_WEBVIEW_RETRY_MAX_DELAY_MS,
-  showUnavailable = true,
-  registry,
-  partition,
-}, handleRef) => {
-  const elementRef = useRef<HTMLElement | null>(null);
-  const cleanupRef = useRef<(() => void) | null>(null);
-  const onReadyRef = useRef(onReady);
-  const onConsoleRef = useRef(onConsoleMessage);
-  const onNavigateRef = useRef(onNavigate);
-  const onLoadingRef = useRef(onLoadingChange);
-  const onTitleRef = useRef(onTitleChange);
-  const onFaviconRef = useRef(onFaviconChange);
-  const onFoundInPageRef = useRef(onFoundInPage);
-  const onContextMenuRef = useRef(onContextMenu);
-  const onErrorRef = useRef(onError);
-  const srcRef = useRef(src);
-  const registryRef = useRef(registry);
-  const readyEmittedRef = useRef(false);
-  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const retryAttemptRef = useRef(0);
-  const maxInitialRetriesRef = useRef(maxInitialRetries);
-  const retryBaseDelayMsRef = useRef(retryBaseDelayMs);
-  const retryMaxDelayMsRef = useRef(retryMaxDelayMs);
-  const registeredHandleRef = useRef<AppHandleId | null>(null);
-  const [internalError, setInternalError] = useState<{ code: number; description: string; url: string } | null>(null);
-  const [reloadNonce, setReloadNonce] = useState(0);
-  // Resolved src for the <iframe> in browser/server mode. External http(s)
-  // URLs are routed through `/proxy/<name>/…` so `frame-ancestors` /
-  // `X-Frame-Options` don't block embedding. No-op in Electron `<webview>`.
-  const [iframeSrc, setIframeSrc] = useState<string | undefined>(isElectron ? src : undefined);
+export const Webview = forwardRef<
+  WebviewHandle,
+  {
+    src?: string;
+    onReady?: () => void;
+    onConsoleMessage?: (msg: ConsoleMessage) => void;
+    onNavigate?: (url: string) => void;
+    onLoadingChange?: (loading: boolean) => void;
+    onTitleChange?: (title: string) => void;
+    onFaviconChange?: (favicon: string) => void;
+    onFoundInPage?: (result: FoundInPageResult) => void;
+    onContextMenu?: (params: ContextMenuParams) => void;
+    onError?: (error: WebviewLoadError) => void;
+    maxInitialRetries?: number;
+    retryBaseDelayMs?: number;
+    retryMaxDelayMs?: number;
+    showUnavailable?: boolean;
+    /** If provided, this webview registers itself with the app-control registry. */
+    registry?: WebviewRegistryProps;
+    /**
+     * Electron `<webview partition="…">`. Scopes cookies / localStorage / cache
+     * to the given profile. Names starting with `persist:` persist to disk; any
+     * other name is in-memory only (incognito). No-op in browser/iframe mode.
+     */
+    partition?: string;
+  }
+>(
+  (
+    {
+      src,
+      onReady,
+      onConsoleMessage,
+      onNavigate,
+      onLoadingChange,
+      onTitleChange,
+      onFaviconChange,
+      onFoundInPage,
+      onContextMenu,
+      onError,
+      maxInitialRetries = DEFAULT_WEBVIEW_MAX_INITIAL_RETRIES,
+      retryBaseDelayMs = DEFAULT_WEBVIEW_RETRY_BASE_DELAY_MS,
+      retryMaxDelayMs = DEFAULT_WEBVIEW_RETRY_MAX_DELAY_MS,
+      showUnavailable = true,
+      registry,
+      partition,
+    },
+    handleRef
+  ) => {
+    const elementRef = useRef<HTMLElement | null>(null);
+    const cleanupRef = useRef<(() => void) | null>(null);
+    const onReadyRef = useRef(onReady);
+    const onConsoleRef = useRef(onConsoleMessage);
+    const onNavigateRef = useRef(onNavigate);
+    const onLoadingRef = useRef(onLoadingChange);
+    const onTitleRef = useRef(onTitleChange);
+    const onFaviconRef = useRef(onFaviconChange);
+    const onFoundInPageRef = useRef(onFoundInPage);
+    const onContextMenuRef = useRef(onContextMenu);
+    const onErrorRef = useRef(onError);
+    const srcRef = useRef(src);
+    const registryRef = useRef(registry);
+    const readyEmittedRef = useRef(false);
+    const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const retryAttemptRef = useRef(0);
+    const maxInitialRetriesRef = useRef(maxInitialRetries);
+    const retryBaseDelayMsRef = useRef(retryBaseDelayMs);
+    const retryMaxDelayMsRef = useRef(retryMaxDelayMs);
+    const registeredHandleRef = useRef<AppHandleId | null>(null);
+    const [internalError, setInternalError] = useState<WebviewLoadError | null>(null);
+    const [reloadNonce, setReloadNonce] = useState(0);
+    // Resolved src for the <iframe> in browser/server mode. External http(s)
+    // URLs are routed through `/proxy/<name>/…` so `frame-ancestors` /
+    // `X-Frame-Options` don't block embedding. No-op in Electron `<webview>`.
+    const [iframeSrc, setIframeSrc] = useState<string | undefined>(isElectron ? src : undefined);
 
-  useEffect(() => {
- onReadyRef.current = onReady; 
-}, [onReady]);
-  useEffect(() => {
- onConsoleRef.current = onConsoleMessage; 
-}, [onConsoleMessage]);
-  useEffect(() => {
- onNavigateRef.current = onNavigate; 
-}, [onNavigate]);
-  useEffect(() => {
- onLoadingRef.current = onLoadingChange; 
-}, [onLoadingChange]);
-  useEffect(() => {
- onTitleRef.current = onTitleChange;
-}, [onTitleChange]);
-  useEffect(() => {
- onFaviconRef.current = onFaviconChange;
-}, [onFaviconChange]);
-  useEffect(() => {
- onFoundInPageRef.current = onFoundInPage;
-}, [onFoundInPage]);
-  useEffect(() => {
- onContextMenuRef.current = onContextMenu;
-}, [onContextMenu]);
-  useEffect(() => {
- onErrorRef.current = onError;
-}, [onError]);
-  useEffect(() => {
-    srcRef.current = src;
-    retryAttemptRef.current = 0;
-    setInternalError(null);
-  }, [src]);
-  // Resolve external URLs through the server's /proxy reverse-proxy so the
-  // iframe doesn't get killed by X-Frame-Options / frame-ancestors.
-  useEffect(() => {
-    if (isElectron) {
-      setIframeSrc(src);
-      return;
-    }
-    if (!src) {
-      setIframeSrc(undefined);
-      return;
-    }
-    let cancelled = false;
-    void resolveProxiedSrc(src).then((resolved) => {
-      if (!cancelled) {
-        setIframeSrc(resolved);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [src]);
-  useEffect(() => {
-    registryRef.current = registry;
-  }, [registry]);
-  useEffect(() => {
-    maxInitialRetriesRef.current = maxInitialRetries;
-  }, [maxInitialRetries]);
-  useEffect(() => {
-    retryBaseDelayMsRef.current = retryBaseDelayMs;
-  }, [retryBaseDelayMs]);
-  useEffect(() => {
-    retryMaxDelayMsRef.current = retryMaxDelayMs;
-  }, [retryMaxDelayMs]);
-  useEffect(() => {
-    const currentRegistry = registry;
-    const currentSrc = src;
-    if (!currentRegistry || !currentSrc || !elementRef.current) {
-      return;
-    }
-    const webContentsId = (() => {
-      if (!isElectron) {
-        return undefined;
-      }
-      try {
-        return (elementRef.current as unknown as Electron.WebviewTag).getWebContentsId?.();
-      } catch {
-        return undefined;
-      }
-    })();
-    if (registeredHandleRef.current && registeredHandleRef.current !== currentRegistry.handleId) {
-      unregisterApp(registeredHandleRef.current);
-      registeredHandleRef.current = null;
-    }
-    if (registeredHandleRef.current === currentRegistry.handleId) {
-      updateApp(currentRegistry.handleId, { url: currentSrc, ...(webContentsId !== undefined ? { webContentsId } : {}) });
-      return;
-    }
-    registerApp({
-      handleId: currentRegistry.handleId,
-      appId: currentRegistry.appId,
-      kind: currentRegistry.kind,
-      scope: currentRegistry.scope,
-      tabId: currentRegistry.tabId,
-      label: currentRegistry.label,
-      url: currentSrc,
-      controllable: isControllableKind(currentRegistry.kind),
-      ...(webContentsId !== undefined ? { webContentsId } : {}),
-      ...(currentRegistry.browserTabsetId ? { browserTabsetId: currentRegistry.browserTabsetId } : {}),
-    });
-    registeredHandleRef.current = currentRegistry.handleId;
-  }, [registry, src]);
-
-  useImperativeHandle(handleRef, () => ({
-    reload: () => {
-      const el = elementRef.current;
-      if (!el) {
-return;
-}
-      if (isElectron) {
-        (el as unknown as Electron.WebviewTag).reload();
-      } else {
-        (el as HTMLIFrameElement).src = (el as HTMLIFrameElement).src;
-      }
-    },
-    goBack: () => {
-      const el = elementRef.current;
-      if (!el) {
-return;
-}
-      if (isElectron) {
-        (el as unknown as Electron.WebviewTag).goBack();
-      } else {
-        try {
- (el as HTMLIFrameElement).contentWindow?.history.back(); 
-} catch { /* cross-origin */ }
-      }
-    },
-    goForward: () => {
-      const el = elementRef.current;
-      if (!el) {
-return;
-}
-      if (isElectron) {
-        (el as unknown as Electron.WebviewTag).goForward();
-      } else {
-        try {
- (el as HTMLIFrameElement).contentWindow?.history.forward(); 
-} catch { /* cross-origin */ }
-      }
-    },
-    stop: () => {
-      const el = elementRef.current;
-      if (!el) {
-return;
-}
-      if (isElectron) {
-        (el as unknown as Electron.WebviewTag).stop();
-      } else {
-        try {
- (el as HTMLIFrameElement).contentWindow?.stop(); 
-} catch { /* cross-origin */ }
-      }
-    },
-    executeScript: async (code: string): Promise<unknown> => {
-      const el = elementRef.current;
-      if (!el) {
-return undefined;
-}
-      if (isElectron) {
-        return (el as unknown as Electron.WebviewTag).executeJavaScript(code);
-      }
-      try {
-        const win = (el as HTMLIFrameElement).contentWindow as (Window & { eval: (code: string) => unknown }) | null;
-        if (!win) {
-return undefined;
-}
-        return win.eval(code);
-      } catch (e) {
-        return String(e);
-      }
-    },
-    insertCSS: async (css: string): Promise<string | null> => {
-      const el = elementRef.current;
-      if (!el || !isElectron) {
-return null;
-}
-      try {
-        return await (el as unknown as Electron.WebviewTag).insertCSS(css);
-      } catch {
-        return null;
-      }
-    },
-    removeInsertedCSS: async (key: string): Promise<void> => {
-      const el = elementRef.current;
-      if (!el || !isElectron) {
-return;
-}
-      try {
-        await (el as unknown as Electron.WebviewTag).removeInsertedCSS(key);
-      } catch {
-        // ignore — webview may have navigated away
-      }
-    },
-    findInPage: (text, options) => {
-      const el = elementRef.current;
-      if (!el || !isElectron || !text) {
-        return;
-      }
-      try {
-        (el as unknown as Electron.WebviewTag).findInPage(text, options);
-      } catch {
-        // webview not ready — safe to ignore; caller will retry on next keystroke
-      }
-    },
-    stopFindInPage: (action = 'clearSelection') => {
-      const el = elementRef.current;
-      if (!el || !isElectron) {
-        return;
-      }
-      try {
-        (el as unknown as Electron.WebviewTag).stopFindInPage(action);
-      } catch {
-        // ignore
-      }
-    },
-    openDevTools: () => {
-      const el = elementRef.current;
-      if (!el || !isElectron) return;
-      try {
-        (el as unknown as Electron.WebviewTag).openDevTools();
-      } catch {
-        // ignore
-      }
-    },
-  }), []);
-
-  const clearRetryTimer = useCallback(() => {
-    if (!retryTimerRef.current) {
-      return;
-    }
-    clearTimeout(retryTimerRef.current);
-    retryTimerRef.current = null;
-  }, []);
-
-  const emitError = useCallback((error: { code: number; description: string; url: string }) => {
-    if (onErrorRef.current) {
-      onErrorRef.current(error);
-    } else {
-      setInternalError(error);
-    }
-  }, []);
-
-  const scheduleRetry = useCallback(() => {
-    const el = elementRef.current;
-    if (!el) {
-      return;
-    }
-    clearRetryTimer();
-
-    const attempt = retryAttemptRef.current++;
-    const delay = getRetryDelayMs({
-      attempt,
-      baseDelayMs: retryBaseDelayMsRef.current,
-      maxDelayMs: retryMaxDelayMsRef.current,
-    });
-    retryTimerRef.current = setTimeout(() => {
-      if (isElectron) {
-        (el as unknown as Electron.WebviewTag).reload();
-      } else {
-        // Reload iframe by resetting src
-        (el as HTMLIFrameElement).src = (el as HTMLIFrameElement).src;
-      }
-    }, delay);
-  }, [clearRetryTimer]);
-
-  const callbackRef = useCallback(
-    (node: HTMLElement | null) => {
-      cleanupRef.current?.();
-      cleanupRef.current = null;
-      elementRef.current = null;
-      clearRetryTimer();
+    useEffect(() => {
+      onReadyRef.current = onReady;
+    }, [onReady]);
+    useEffect(() => {
+      onConsoleRef.current = onConsoleMessage;
+    }, [onConsoleMessage]);
+    useEffect(() => {
+      onNavigateRef.current = onNavigate;
+    }, [onNavigate]);
+    useEffect(() => {
+      onLoadingRef.current = onLoadingChange;
+    }, [onLoadingChange]);
+    useEffect(() => {
+      onTitleRef.current = onTitleChange;
+    }, [onTitleChange]);
+    useEffect(() => {
+      onFaviconRef.current = onFaviconChange;
+    }, [onFaviconChange]);
+    useEffect(() => {
+      onFoundInPageRef.current = onFoundInPage;
+    }, [onFoundInPage]);
+    useEffect(() => {
+      onContextMenuRef.current = onContextMenu;
+    }, [onContextMenu]);
+    useEffect(() => {
+      onErrorRef.current = onError;
+    }, [onError]);
+    useEffect(() => {
+      srcRef.current = src;
       retryAttemptRef.current = 0;
-      readyEmittedRef.current = false;
-
-      const currentSrc = srcRef.current;
-      if (!node || !currentSrc) {
+      setInternalError(null);
+    }, [src]);
+    // Resolve external URLs through the server's /proxy reverse-proxy so the
+    // iframe doesn't get killed by X-Frame-Options / frame-ancestors.
+    useEffect(() => {
+      if (isElectron) {
+        setIframeSrc(src);
         return;
       }
+      if (!src) {
+        setIframeSrc(undefined);
+        return;
+      }
+      let cancelled = false;
+      void resolveProxiedSrc(src).then((resolved) => {
+        if (!cancelled) {
+          if (!resolved.ok) {
+            setIframeSrc(undefined);
+            emitError({ code: resolved.status ?? -1, description: resolved.reason, url: resolved.canonicalUrl });
+            return;
+          }
+          setIframeSrc(resolved.iframeSrc);
+          if (resolved.canonicalUrl !== src) {
+            onNavigateRef.current?.(resolved.canonicalUrl);
+            const currentRegistry = registryRef.current;
+            if (currentRegistry) {
+              updateApp(currentRegistry.handleId, { url: resolved.canonicalUrl });
+            }
+          }
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, [src]);
+    useEffect(() => {
+      registryRef.current = registry;
+    }, [registry]);
+    useEffect(() => {
+      maxInitialRetriesRef.current = maxInitialRetries;
+    }, [maxInitialRetries]);
+    useEffect(() => {
+      retryBaseDelayMsRef.current = retryBaseDelayMs;
+    }, [retryBaseDelayMs]);
+    useEffect(() => {
+      retryMaxDelayMsRef.current = retryMaxDelayMs;
+    }, [retryMaxDelayMs]);
+    useEffect(() => {
+      const currentRegistry = registry;
+      const currentSrc = src;
+      if (!currentRegistry || !currentSrc || !elementRef.current) {
+        return;
+      }
+      const webContentsId = (() => {
+        if (!isElectron) {
+          return undefined;
+        }
+        try {
+          return (elementRef.current as unknown as Electron.WebviewTag).getWebContentsId?.();
+        } catch {
+          return undefined;
+        }
+      })();
+      if (registeredHandleRef.current && registeredHandleRef.current !== currentRegistry.handleId) {
+        unregisterApp(registeredHandleRef.current);
+        registeredHandleRef.current = null;
+      }
+      if (registeredHandleRef.current === currentRegistry.handleId) {
+        updateApp(currentRegistry.handleId, {
+          url: currentSrc,
+          ...(webContentsId !== undefined ? { webContentsId } : {}),
+        });
+        return;
+      }
+      registerApp({
+        handleId: currentRegistry.handleId,
+        appId: currentRegistry.appId,
+        kind: currentRegistry.kind,
+        scope: currentRegistry.scope,
+        tabId: currentRegistry.tabId,
+        label: currentRegistry.label,
+        url: currentSrc,
+        controllable: isControllableKind(currentRegistry.kind),
+        ...(webContentsId !== undefined ? { webContentsId } : {}),
+        ...(currentRegistry.browserTabsetId ? { browserTabsetId: currentRegistry.browserTabsetId } : {}),
+      });
+      registeredHandleRef.current = currentRegistry.handleId;
+    }, [registry, src]);
 
-      elementRef.current = node;
+    useImperativeHandle(
+      handleRef,
+      () => ({
+        reload: () => {
+          const el = elementRef.current;
+          if (!el) {
+            return;
+          }
+          if (isElectron) {
+            (el as unknown as Electron.WebviewTag).reload();
+          } else {
+            (el as HTMLIFrameElement).src = (el as HTMLIFrameElement).src;
+          }
+        },
+        goBack: () => {
+          const el = elementRef.current;
+          if (!el) {
+            return;
+          }
+          if (isElectron) {
+            (el as unknown as Electron.WebviewTag).goBack();
+          } else {
+            try {
+              (el as HTMLIFrameElement).contentWindow?.history.back();
+            } catch {
+              /* cross-origin */
+            }
+          }
+        },
+        goForward: () => {
+          const el = elementRef.current;
+          if (!el) {
+            return;
+          }
+          if (isElectron) {
+            (el as unknown as Electron.WebviewTag).goForward();
+          } else {
+            try {
+              (el as HTMLIFrameElement).contentWindow?.history.forward();
+            } catch {
+              /* cross-origin */
+            }
+          }
+        },
+        stop: () => {
+          const el = elementRef.current;
+          if (!el) {
+            return;
+          }
+          if (isElectron) {
+            (el as unknown as Electron.WebviewTag).stop();
+          } else {
+            try {
+              (el as HTMLIFrameElement).contentWindow?.stop();
+            } catch {
+              /* cross-origin */
+            }
+          }
+        },
+        executeScript: async (code: string): Promise<unknown> => {
+          const el = elementRef.current;
+          if (!el) {
+            return undefined;
+          }
+          if (isElectron) {
+            return (el as unknown as Electron.WebviewTag).executeJavaScript(code);
+          }
+          try {
+            const win = (el as HTMLIFrameElement).contentWindow as
+              | (Window & { eval: (code: string) => unknown })
+              | null;
+            if (!win) {
+              return undefined;
+            }
+            return win.eval(code);
+          } catch (e) {
+            return String(e);
+          }
+        },
+        insertCSS: async (css: string): Promise<string | null> => {
+          const el = elementRef.current;
+          if (!el || !isElectron) {
+            return null;
+          }
+          try {
+            return await (el as unknown as Electron.WebviewTag).insertCSS(css);
+          } catch {
+            return null;
+          }
+        },
+        removeInsertedCSS: async (key: string): Promise<void> => {
+          const el = elementRef.current;
+          if (!el || !isElectron) {
+            return;
+          }
+          try {
+            await (el as unknown as Electron.WebviewTag).removeInsertedCSS(key);
+          } catch {
+            // ignore — webview may have navigated away
+          }
+        },
+        findInPage: (text, options) => {
+          const el = elementRef.current;
+          if (!el || !isElectron || !text) {
+            return;
+          }
+          try {
+            (el as unknown as Electron.WebviewTag).findInPage(text, options);
+          } catch {
+            // webview not ready — safe to ignore; caller will retry on next keystroke
+          }
+        },
+        stopFindInPage: (action = 'clearSelection') => {
+          const el = elementRef.current;
+          if (!el || !isElectron) {
+            return;
+          }
+          try {
+            (el as unknown as Electron.WebviewTag).stopFindInPage(action);
+          } catch {
+            // ignore
+          }
+        },
+        openDevTools: () => {
+          const el = elementRef.current;
+          if (!el || !isElectron) return;
+          try {
+            (el as unknown as Electron.WebviewTag).openDevTools();
+          } catch {
+            // ignore
+          }
+        },
+      }),
+      []
+    );
 
-      if (isElectron) {
-        const el = node as unknown as Electron.WebviewTag;
-        const currentRegistry = registryRef.current;
+    const clearRetryTimer = useCallback(() => {
+      if (!retryTimerRef.current) {
+        return;
+      }
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }, []);
 
-        // Register with the app-control registry as early as possible so
-        // list_apps sees the handle even before first load. webContentsId
-        // fills in on the first did-finish-load below.
-        if (currentRegistry) {
-          registerApp({
-            handleId: currentRegistry.handleId,
-            appId: currentRegistry.appId,
-            kind: currentRegistry.kind,
-            scope: currentRegistry.scope,
-            tabId: currentRegistry.tabId,
-            label: currentRegistry.label,
-            url: currentSrc,
-            controllable: isControllableKind(currentRegistry.kind),
-            ...(currentRegistry.browserTabsetId ? { browserTabsetId: currentRegistry.browserTabsetId } : {}),
-          });
-          registeredHandleRef.current = currentRegistry.handleId;
+    const emitError = useCallback((error: WebviewLoadError) => {
+      if (onErrorRef.current) {
+        onErrorRef.current(error);
+      } else {
+        setInternalError(error);
+      }
+    }, []);
+
+    const scheduleRetry = useCallback(() => {
+      const el = elementRef.current;
+      if (!el) {
+        return;
+      }
+      clearRetryTimer();
+
+      const attempt = retryAttemptRef.current++;
+      const delay = getRetryDelayMs({
+        attempt,
+        baseDelayMs: retryBaseDelayMsRef.current,
+        maxDelayMs: retryMaxDelayMsRef.current,
+      });
+      retryTimerRef.current = setTimeout(() => {
+        if (isElectron) {
+          (el as unknown as Electron.WebviewTag).reload();
+        } else {
+          // Reload iframe by resetting src
+          (el as HTMLIFrameElement).src = (el as HTMLIFrameElement).src;
+        }
+      }, delay);
+    }, [clearRetryTimer]);
+
+    const callbackRef = useCallback(
+      (node: HTMLElement | null) => {
+        cleanupRef.current?.();
+        cleanupRef.current = null;
+        elementRef.current = null;
+        clearRetryTimer();
+        retryAttemptRef.current = 0;
+        readyEmittedRef.current = false;
+
+        const currentSrc = srcRef.current;
+        if (!node || !currentSrc) {
+          return;
         }
 
-        const onStartLoad = () => {
-          onLoadingRef.current?.(true);
-        };
+        elementRef.current = node;
 
-        const onLoad = () => {
-          clearRetryTimer();
-          retryAttemptRef.current = 0;
-          onLoadingRef.current?.(false);
+        if (isElectron) {
+          const el = node as unknown as Electron.WebviewTag;
+          const currentRegistry = registryRef.current;
 
-          if (!readyEmittedRef.current) {
-            readyEmittedRef.current = true;
-            onReadyRef.current?.();
+          // Register with the app-control registry as early as possible so
+          // list_apps sees the handle even before first load. webContentsId
+          // fills in on the first did-finish-load below.
+          if (currentRegistry) {
+            registerApp({
+              handleId: currentRegistry.handleId,
+              appId: currentRegistry.appId,
+              kind: currentRegistry.kind,
+              scope: currentRegistry.scope,
+              tabId: currentRegistry.tabId,
+              label: currentRegistry.label,
+              url: currentSrc,
+              controllable: isControllableKind(currentRegistry.kind),
+              ...(currentRegistry.browserTabsetId ? { browserTabsetId: currentRegistry.browserTabsetId } : {}),
+            });
+            registeredHandleRef.current = currentRegistry.handleId;
           }
 
-          const currentRegistry = registryRef.current;
-          if (currentRegistry) {
-            const webContentsId = (() => {
-              try {
-                return el.getWebContentsId?.();
-              } catch {
-                return undefined;
-              }
-            })();
-            updateApp(currentRegistry.handleId, {
-              webContentsId,
-              url: (() => {
+          const onStartLoad = () => {
+            onLoadingRef.current?.(true);
+          };
+
+          const onLoad = () => {
+            clearRetryTimer();
+            retryAttemptRef.current = 0;
+            onLoadingRef.current?.(false);
+
+            if (!readyEmittedRef.current) {
+              readyEmittedRef.current = true;
+              onReadyRef.current?.();
+            }
+
+            const currentRegistry = registryRef.current;
+            if (currentRegistry) {
+              const webContentsId = (() => {
                 try {
-                  return el.getURL?.();
+                  return el.getWebContentsId?.();
                 } catch {
                   return undefined;
                 }
-              })(),
-            });
-          }
-
-          // Read page title
-          el.getTitle?.()
-            ? onTitleRef.current?.(el.getTitle())
-            : void el.executeJavaScript?.('document.title').then((t: string) => onTitleRef.current?.(t)).catch(() => {});
-        };
-
-        const onFailLoad = (event: unknown) => {
-          const e = event as { errorCode?: number; errorDescription?: string; validatedURL?: string; isMainFrame?: boolean };
-          const errorCode = e.errorCode ?? null;
-          const isMainFrame = e.isMainFrame ?? true;
-
-          if (!isMainFrame) {
-return;
-}
-          if (isAbortErrorCode(errorCode)) {
-return;
-} // ERR_ABORTED
-          onLoadingRef.current?.(false);
-
-          if (readyEmittedRef.current) {
-            emitError({ code: errorCode ?? -1, description: e.errorDescription ?? 'Load failed', url: e.validatedURL ?? '' });
-            return;
-          }
-          if (!shouldRetryInitialLoad({
-            errorCode,
-            ready: readyEmittedRef.current,
-            attempt: retryAttemptRef.current,
-            maxAttempts: maxInitialRetriesRef.current,
-          })) {
-            emitError({ code: errorCode ?? -1, description: e.errorDescription ?? 'Load failed', url: e.validatedURL ?? srcRef.current ?? '' });
-            return;
-          }
-          scheduleRetry();
-        };
-
-        const onConsole = (event: unknown) => {
-          const e = event as { level?: number; message?: string };
-          const level = e.level === 2 ? 'error' : e.level === 1 ? 'warn' : 'log';
-          onConsoleRef.current?.({ level, message: e.message ?? '' });
-        };
-
-        const onNavigateEvent = (event: unknown) => {
-          const e = event as { url?: string; isMainFrame?: boolean };
-          if (e.isMainFrame === false) {
-return;
-}
-          if (e.url) {
-onNavigateRef.current?.(e.url);
-            const currentRegistry = registryRef.current;
-            if (currentRegistry) {
-              updateApp(currentRegistry.handleId, { url: e.url });
+              })();
+              updateApp(currentRegistry.handleId, {
+                webContentsId,
+                url: (() => {
+                  try {
+                    return el.getURL?.();
+                  } catch {
+                    return undefined;
+                  }
+                })(),
+              });
             }
-          }
-        };
 
-        const onTitleUpdate = (event: unknown) => {
-          const e = event as { title?: string };
-          if (e.title) {
-onTitleRef.current?.(e.title);
-            const currentRegistry = registryRef.current;
-            if (currentRegistry) {
-              updateApp(currentRegistry.handleId, { title: e.title });
+            // Read page title
+            el.getTitle?.()
+              ? onTitleRef.current?.(el.getTitle())
+              : void el
+                  .executeJavaScript?.('document.title')
+                  .then((t: string) => onTitleRef.current?.(t))
+                  .catch(() => {});
+          };
+
+          const onFailLoad = (event: unknown) => {
+            const e = event as {
+              errorCode?: number;
+              errorDescription?: string;
+              validatedURL?: string;
+              isMainFrame?: boolean;
+            };
+            const errorCode = e.errorCode ?? null;
+            const isMainFrame = e.isMainFrame ?? true;
+
+            if (!isMainFrame) {
+              return;
             }
-          }
-        };
+            if (isAbortErrorCode(errorCode)) {
+              return;
+            } // ERR_ABORTED
+            onLoadingRef.current?.(false);
 
-        const onFavicon = (event: unknown) => {
-          const e = event as { favicons?: string[] };
-          const favicon = e.favicons?.[0];
-          if (favicon) {
-            onFaviconRef.current?.(favicon);
-          }
-        };
-
-        const onFoundInPage = (event: unknown) => {
-          const e = event as { result?: FoundInPageResult };
-          if (e.result) {
-            onFoundInPageRef.current?.(e.result);
-          }
-        };
-
-        const onContextMenuEvent = (event: unknown) => {
-          const e = event as { params?: ContextMenuParams };
-          if (e.params) {
-            onContextMenuRef.current?.(e.params);
-          }
-        };
-
-        el.addEventListener('did-start-loading', onStartLoad);
-        el.addEventListener('did-finish-load', onLoad);
-        el.addEventListener('did-fail-load', onFailLoad);
-        el.addEventListener('console-message', onConsole);
-        el.addEventListener('did-navigate', onNavigateEvent);
-        el.addEventListener('did-navigate-in-page', onNavigateEvent);
-        el.addEventListener('page-title-updated', onTitleUpdate);
-        el.addEventListener('page-favicon-updated', onFavicon);
-        el.addEventListener('found-in-page', onFoundInPage);
-        el.addEventListener('context-menu', onContextMenuEvent);
-
-        cleanupRef.current = () => {
-          el.removeEventListener('did-start-loading', onStartLoad);
-          el.removeEventListener('did-finish-load', onLoad);
-          el.removeEventListener('did-fail-load', onFailLoad);
-          el.removeEventListener('console-message', onConsole);
-          el.removeEventListener('did-navigate', onNavigateEvent);
-          el.removeEventListener('did-navigate-in-page', onNavigateEvent);
-          el.removeEventListener('page-title-updated', onTitleUpdate);
-          el.removeEventListener('page-favicon-updated', onFavicon);
-          el.removeEventListener('found-in-page', onFoundInPage);
-          el.removeEventListener('context-menu', onContextMenuEvent);
-          if (registeredHandleRef.current) {
-            unregisterApp(registeredHandleRef.current);
-            registeredHandleRef.current = null;
-          }
-        };
-      } else {
-        // Browser mode: use iframe events
-        const iframe = node as HTMLIFrameElement;
-
-        onLoadingRef.current?.(true);
-
-        const onLoad = () => {
-          clearRetryTimer();
-          retryAttemptRef.current = 0;
-          onLoadingRef.current?.(false);
-
-          if (!readyEmittedRef.current) {
-            readyEmittedRef.current = true;
-            onReadyRef.current?.();
-          }
-
-          // Report the navigated URL and title back
-          try {
-            const href = iframe.contentWindow?.location.href;
-            if (href && href !== 'about:blank') {
-              onNavigateRef.current?.(unproxyUrl(href));
+            if (readyEmittedRef.current) {
+              emitError({
+                code: errorCode ?? -1,
+                description: e.errorDescription ?? 'Load failed',
+                url: e.validatedURL ?? '',
+              });
+              return;
             }
-            const title = iframe.contentDocument?.title;
-            if (title) {
-onTitleRef.current?.(title);
-}
-          } catch { /* cross-origin */ }
-        };
+            if (
+              !shouldRetryInitialLoad({
+                errorCode,
+                ready: readyEmittedRef.current,
+                attempt: retryAttemptRef.current,
+                maxAttempts: maxInitialRetriesRef.current,
+              })
+            ) {
+              emitError({
+                code: errorCode ?? -1,
+                description: e.errorDescription ?? 'Load failed',
+                url: e.validatedURL ?? srcRef.current ?? '',
+              });
+              return;
+            }
+            scheduleRetry();
+          };
 
-        const onIframeError = () => {
-          onLoadingRef.current?.(false);
-          if (readyEmittedRef.current) {
-            emitError({ code: -1, description: 'Failed to load page', url: iframe.src });
-            return;
-          }
-          if (!shouldRetryInitialLoad({
-            errorCode: -1,
-            ready: readyEmittedRef.current,
-            attempt: retryAttemptRef.current,
-            maxAttempts: maxInitialRetriesRef.current,
-          })) {
-            emitError({ code: -1, description: 'Failed to load page', url: iframe.src });
-            return;
-          }
-          scheduleRetry();
-        };
+          const onConsole = (event: unknown) => {
+            const e = event as { level?: number; message?: string };
+            const level = e.level === 2 ? 'error' : e.level === 1 ? 'warn' : 'log';
+            onConsoleRef.current?.({ level, message: e.message ?? '' });
+          };
 
-        const onMessage = (event: MessageEvent) => {
-          if (event.source !== iframe.contentWindow) {
-return;
-}
-          const data = event.data as { type?: string; level?: string; message?: string; url?: string; title?: string } | null;
-          if (data?.type === '__preview_console__') {
-            const level = data.level === 'error' ? 'error' : data.level === 'warn' ? 'warn' : 'log';
-            onConsoleRef.current?.({ level, message: data.message ?? '' });
-          } else if (data?.type === '__preview_navigate__' && data.url) {
-            onNavigateRef.current?.(unproxyUrl(data.url));
-          } else if (data?.type === '__preview_title__' && data.title) {
-            onTitleRef.current?.(data.title);
-          }
-        };
+          const onNavigateEvent = (event: unknown) => {
+            const e = event as { url?: string; isMainFrame?: boolean };
+            if (e.isMainFrame === false) {
+              return;
+            }
+            if (e.url) {
+              onNavigateRef.current?.(e.url);
+              const currentRegistry = registryRef.current;
+              if (currentRegistry) {
+                updateApp(currentRegistry.handleId, { url: e.url });
+              }
+            }
+          };
 
-        iframe.addEventListener('load', onLoad);
-        iframe.addEventListener('error', onIframeError);
-        window.addEventListener('message', onMessage);
+          const onTitleUpdate = (event: unknown) => {
+            const e = event as { title?: string };
+            if (e.title) {
+              onTitleRef.current?.(e.title);
+              const currentRegistry = registryRef.current;
+              if (currentRegistry) {
+                updateApp(currentRegistry.handleId, { title: e.title });
+              }
+            }
+          };
 
-        cleanupRef.current = () => {
-          iframe.removeEventListener('load', onLoad);
-          iframe.removeEventListener('error', onIframeError);
-          window.removeEventListener('message', onMessage);
-        };
-      }
-    },
-    [clearRetryTimer, emitError, scheduleRetry]
-  );
+          const onFavicon = (event: unknown) => {
+            const e = event as { favicons?: string[] };
+            const favicon = e.favicons?.[0];
+            if (favicon) {
+              onFaviconRef.current?.(favicon);
+            }
+          };
 
-  if (!src) {
-    if (!showUnavailable) {
-      return null;
-    }
-    return (
-      <div className="flex items-center justify-center w-full h-full border border-surface-border rounded-lg">
-        <span className="text-fg-muted">Not available</span>
-      </div>
+          const onFoundInPage = (event: unknown) => {
+            const e = event as { result?: FoundInPageResult };
+            if (e.result) {
+              onFoundInPageRef.current?.(e.result);
+            }
+          };
+
+          const onContextMenuEvent = (event: unknown) => {
+            const e = event as { params?: ContextMenuParams };
+            if (e.params) {
+              onContextMenuRef.current?.(e.params);
+            }
+          };
+
+          el.addEventListener('did-start-loading', onStartLoad);
+          el.addEventListener('did-finish-load', onLoad);
+          el.addEventListener('did-fail-load', onFailLoad);
+          el.addEventListener('console-message', onConsole);
+          el.addEventListener('did-navigate', onNavigateEvent);
+          el.addEventListener('did-navigate-in-page', onNavigateEvent);
+          el.addEventListener('page-title-updated', onTitleUpdate);
+          el.addEventListener('page-favicon-updated', onFavicon);
+          el.addEventListener('found-in-page', onFoundInPage);
+          el.addEventListener('context-menu', onContextMenuEvent);
+
+          cleanupRef.current = () => {
+            el.removeEventListener('did-start-loading', onStartLoad);
+            el.removeEventListener('did-finish-load', onLoad);
+            el.removeEventListener('did-fail-load', onFailLoad);
+            el.removeEventListener('console-message', onConsole);
+            el.removeEventListener('did-navigate', onNavigateEvent);
+            el.removeEventListener('did-navigate-in-page', onNavigateEvent);
+            el.removeEventListener('page-title-updated', onTitleUpdate);
+            el.removeEventListener('page-favicon-updated', onFavicon);
+            el.removeEventListener('found-in-page', onFoundInPage);
+            el.removeEventListener('context-menu', onContextMenuEvent);
+            if (registeredHandleRef.current) {
+              unregisterApp(registeredHandleRef.current);
+              registeredHandleRef.current = null;
+            }
+          };
+        } else {
+          // Browser mode: use iframe events
+          const iframe = node as HTMLIFrameElement;
+
+          onLoadingRef.current?.(true);
+
+          const onLoad = () => {
+            clearRetryTimer();
+            retryAttemptRef.current = 0;
+            onLoadingRef.current?.(false);
+
+            if (!readyEmittedRef.current) {
+              readyEmittedRef.current = true;
+              onReadyRef.current?.();
+            }
+
+            // Report the navigated URL and title back
+            try {
+              const href = iframe.contentWindow?.location.href;
+              if (href && href !== 'about:blank') {
+                const canonicalUrl = unproxyUrl(href);
+                onNavigateRef.current?.(canonicalUrl);
+                const currentRegistry = registryRef.current;
+                if (currentRegistry) {
+                  updateApp(currentRegistry.handleId, { url: canonicalUrl });
+                }
+              }
+              const title = iframe.contentDocument?.title;
+              if (title) {
+                onTitleRef.current?.(title);
+              }
+            } catch {
+              /* cross-origin */
+            }
+          };
+
+          const onIframeError = () => {
+            onLoadingRef.current?.(false);
+            const transportUrl = iframe.src;
+            const unproxiedUrl = unproxyUrl(transportUrl);
+            const errorUrl =
+              unproxiedUrl && unproxiedUrl !== transportUrl ? unproxiedUrl : srcRef.current || unproxiedUrl || '';
+            const error = {
+              code: -1,
+              description: 'Failed to load page',
+              url: errorUrl,
+              ...(transportUrl && transportUrl !== errorUrl ? { transportUrl } : {}),
+            };
+            if (readyEmittedRef.current) {
+              emitError(error);
+              return;
+            }
+            if (
+              !shouldRetryInitialLoad({
+                errorCode: -1,
+                ready: readyEmittedRef.current,
+                attempt: retryAttemptRef.current,
+                maxAttempts: maxInitialRetriesRef.current,
+              })
+            ) {
+              emitError(error);
+              return;
+            }
+            scheduleRetry();
+          };
+
+          const onMessage = (event: MessageEvent) => {
+            if (event.source !== iframe.contentWindow) {
+              return;
+            }
+            const data = event.data as {
+              type?: string;
+              level?: string;
+              message?: string;
+              url?: string;
+              title?: string;
+            } | null;
+            if (data?.type === '__preview_console__') {
+              const level = data.level === 'error' ? 'error' : data.level === 'warn' ? 'warn' : 'log';
+              onConsoleRef.current?.({ level, message: data.message ?? '' });
+            } else if (data?.type === '__preview_navigate__' && data.url) {
+              const canonicalUrl = unproxyUrl(data.url);
+              onNavigateRef.current?.(canonicalUrl);
+              const currentRegistry = registryRef.current;
+              if (currentRegistry) {
+                updateApp(currentRegistry.handleId, { url: canonicalUrl });
+              }
+            } else if (data?.type === '__preview_title__' && data.title) {
+              onTitleRef.current?.(data.title);
+            }
+          };
+
+          iframe.addEventListener('load', onLoad);
+          iframe.addEventListener('error', onIframeError);
+          window.addEventListener('message', onMessage);
+
+          cleanupRef.current = () => {
+            iframe.removeEventListener('load', onLoad);
+            iframe.removeEventListener('error', onIframeError);
+            window.removeEventListener('message', onMessage);
+          };
+        }
+      },
+      [clearRetryTimer, emitError, scheduleRetry]
     );
-  }
 
-  if (internalError) {
-    return (
-      <div style={{ display: 'flex', height: '100%', width: '100%', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
-        <div style={{ display: 'flex', maxWidth: 520, flexDirection: 'column', gap: 12, textAlign: 'center' }}>
-          <div style={{ fontSize: 16, fontWeight: 600 }}>This app did not load</div>
-          <div style={{ opacity: 0.75 }}>{internalError.description || 'The embedded page failed to load.'}</div>
-          <div style={{ wordBreak: 'break-all', opacity: 0.6, fontSize: 12 }}>{internalError.url || src}</div>
-          <div style={{ display: 'flex', justifyContent: 'center', gap: 8 }}>
-            <button
-              type="button"
-              onClick={() => {
-                retryAttemptRef.current = 0;
-                setInternalError(null);
-                setReloadNonce((n) => n + 1);
-              }}
-            >
-              Retry
-            </button>
-            <button type="button" onClick={() => void navigator.clipboard.writeText(internalError.url || src).catch(() => {})}>
-              Copy URL
-            </button>
+    if (!src) {
+      if (!showUnavailable) {
+        return null;
+      }
+      return (
+        <div className="flex items-center justify-center w-full h-full border border-surface-border rounded-lg">
+          <span className="text-fg-muted">Not available</span>
+        </div>
+      );
+    }
+
+    if (internalError) {
+      const diagnostics = getWebviewFallbackDiagnostics(internalError, src);
+      return (
+        <div
+          style={{
+            display: 'flex',
+            height: '100%',
+            width: '100%',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 24,
+          }}
+        >
+          <div style={{ display: 'flex', maxWidth: 580, flexDirection: 'column', gap: 12, textAlign: 'center' }}>
+            <div style={{ fontSize: 16, fontWeight: 600 }}>{diagnostics.title}</div>
+            <div style={{ opacity: 0.78 }}>{diagnostics.reason}</div>
+            <div>
+              <div style={{ marginBottom: 4, fontSize: 12, fontWeight: 600, opacity: 0.7 }}>Canonical URL</div>
+              <div style={{ wordBreak: 'break-all', opacity: 0.7, fontSize: 12 }}>{diagnostics.displayUrl}</div>
+            </div>
+            <div style={{ opacity: 0.7, fontSize: 12 }}>{diagnostics.instructions}</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 8 }}>
+              <button
+                type="button"
+                onClick={() => {
+                  retryAttemptRef.current = 0;
+                  setInternalError(null);
+                  setReloadNonce((n) => n + 1);
+                }}
+              >
+                Retry
+              </button>
+              <button
+                type="button"
+                onClick={() => void navigator.clipboard.writeText(diagnostics.canonicalUrl).catch(() => {})}
+              >
+                Copy URL
+              </button>
+              <button type="button" onClick={() => openInBrowserTab(diagnostics.canonicalUrl)}>
+                Open in Browser
+              </button>
+            </div>
+            {(diagnostics.transportUrl || diagnostics.debugDescription) && (
+              <details style={{ marginTop: 4, textAlign: 'left', fontSize: 11, opacity: 0.65 }}>
+                <summary style={{ cursor: 'pointer', textAlign: 'center' }}>Details</summary>
+                {diagnostics.debugDescription && <div>Reason: {diagnostics.debugDescription}</div>}
+                {diagnostics.transportUrl && (
+                  <div style={{ wordBreak: 'break-all' }}>Proxy transport: {diagnostics.transportUrl}</div>
+                )}
+              </details>
+            )}
           </div>
         </div>
-      </div>
-    );
-  }
+      );
+    }
 
-  if (isElectron) {
-    // `partition` must be set BEFORE the <webview> is inserted into the DOM;
-    // Electron ignores later changes. Keying on partition forces a remount so
-    // switching profiles actually takes effect.
+    if (isElectron) {
+      // `partition` must be set BEFORE the <webview> is inserted into the DOM;
+      // Electron ignores later changes. Keying on partition forces a remount so
+      // switching profiles actually takes effect.
+      return (
+        <webview
+          key={`${partition ?? 'default'}:${reloadNonce}`}
+          ref={callbackRef}
+          src={src}
+          useragent={embeddedUserAgent}
+          {...(partition ? { partition } : {})}
+          style={{ width: '100%', height: '100%' }}
+        />
+      );
+    }
+
     return (
-      <webview
-        key={`${partition ?? 'default'}:${reloadNonce}`}
-        ref={callbackRef}
-        src={src}
-        useragent={embeddedUserAgent}
-        {...(partition ? { partition } : {})}
-        style={{ width: '100%', height: '100%' }}
+      <iframe
+        key={reloadNonce}
+        ref={callbackRef as React.RefCallback<HTMLIFrameElement>}
+        src={iframeSrc}
+        style={{ width: '100%', height: '100%', border: 'none' }}
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
       />
     );
   }
-
-  return (
-    <iframe
-      key={reloadNonce}
-      ref={callbackRef as React.RefCallback<HTMLIFrameElement>}
-      src={iframeSrc}
-      style={{ width: '100%', height: '100%', border: 'none' }}
-      sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
-    />
-  );
-});
+);
 Webview.displayName = 'Webview';

--- a/src/renderer/common/webview-fallback.test.ts
+++ b/src/renderer/common/webview-fallback.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getWebviewFallbackDiagnostics,
+  isProxyTransportUrl,
+  redactUrlForDiagnostics,
+} from '@/renderer/common/webview-fallback';
+
+describe('webview fallback diagnostics', () => {
+  it('maps forbidden proxy registration failures to an actionable browser/server message', () => {
+    const diagnostics = getWebviewFallbackDiagnostics(
+      {
+        code: 403,
+        description: 'Proxy registration failed (403): Forbidden: caller not in trusted network',
+        url: 'https://github.com/acme/repo/pull/42?tab=files',
+      },
+      'https://github.com/acme/repo/pull/42?tab=files'
+    );
+
+    expect(diagnostics).toMatchObject({
+      title: 'Proxy registration was blocked',
+      reason: 'Omni was not allowed to register this site with the browser/server proxy.',
+      canonicalUrl: 'https://github.com/acme/repo/pull/42?tab=files',
+      displayUrl: 'https://github.com/acme/repo/pull/42?tab=files',
+    });
+  });
+
+  it('recognizes denied upstream, DNS, TLS, timeout, redirect loop, and unsupported feature hints', () => {
+    expect(
+      getWebviewFallbackDiagnostics(
+        { code: 400, description: 'Invalid upstream URL: expected http(s)', url: 'ftp://example.test/file' },
+        'ftp://example.test/file'
+      ).title
+    ).toBe('This address cannot be proxied');
+    expect(
+      getWebviewFallbackDiagnostics(
+        { code: -105, description: 'ERR_NAME_NOT_RESOLVED', url: 'https://missing.example.test/' },
+        'https://missing.example.test/'
+      ).title
+    ).toBe('DNS lookup failed');
+    expect(
+      getWebviewFallbackDiagnostics(
+        { code: -202, description: 'ERR_CERT_AUTHORITY_INVALID', url: 'https://tls.example.test/' },
+        'https://tls.example.test/'
+      ).title
+    ).toBe('Secure connection failed');
+    expect(
+      getWebviewFallbackDiagnostics(
+        { code: -118, description: 'ERR_CONNECTION_TIMED_OUT', url: 'https://slow.example.test/' },
+        'https://slow.example.test/'
+      ).title
+    ).toBe('The site took too long to respond');
+    expect(
+      getWebviewFallbackDiagnostics(
+        { code: -310, description: 'ERR_TOO_MANY_REDIRECTS', url: 'https://loop.example.test/' },
+        'https://loop.example.test/'
+      ).title
+    ).toBe('Redirect loop detected');
+    expect(
+      getWebviewFallbackDiagnostics(
+        {
+          code: -1,
+          description: 'Unsupported browser feature: service worker registration',
+          url: 'https://app.example.test/',
+        },
+        'https://app.example.test/'
+      ).title
+    ).toBe('Browser feature not supported here');
+  });
+
+  it('keeps proxy transport URLs out of primary diagnostics but exposes redacted debug details', () => {
+    const diagnostics = getWebviewFallbackDiagnostics(
+      {
+        code: -1,
+        description: 'Failed to load page',
+        url: 'https://docs.example.test/private?token=secret#access_token=abc',
+        transportUrl: '/proxy/dyn-docs/private?token=secret#access_token=abc',
+      },
+      'https://docs.example.test/private?token=secret#access_token=abc'
+    );
+
+    expect(diagnostics.canonicalUrl).toBe('https://docs.example.test/private?token=secret#access_token=abc');
+    expect(diagnostics.displayUrl).toBe('https://docs.example.test/private?token=%5Bredacted%5D#[redacted]');
+    expect(diagnostics.transportUrl).toBe('/proxy/dyn-docs/private?token=%5Bredacted%5D#[redacted]');
+    expect(isProxyTransportUrl(diagnostics.displayUrl)).toBe(false);
+    expect(isProxyTransportUrl('/proxy/dyn-docs/private')).toBe(true);
+  });
+
+  it('redacts sensitive query and hash values without changing non-sensitive URLs', () => {
+    expect(redactUrlForDiagnostics('https://example.test/path?code=abc&tab=files#token=secret')).toBe(
+      'https://example.test/path?code=%5Bredacted%5D&tab=files#[redacted]'
+    );
+    expect(redactUrlForDiagnostics('https://example.test/path?tab=files#section')).toBe(
+      'https://example.test/path?tab=files#section'
+    );
+  });
+});

--- a/src/renderer/common/webview-fallback.ts
+++ b/src/renderer/common/webview-fallback.ts
@@ -1,0 +1,145 @@
+export type WebviewLoadError = {
+  code: number;
+  description: string;
+  url: string;
+  transportUrl?: string;
+};
+
+export type WebviewFallbackDiagnostics = {
+  title: string;
+  reason: string;
+  canonicalUrl: string;
+  displayUrl: string;
+  transportUrl?: string;
+  instructions: string;
+  debugDescription?: string;
+};
+
+const SENSITIVE_QUERY_KEYS =
+  /(?:^|_)(?:access_token|auth|authorization|code|credential|id_token|key|password|secret|session|sig|signature|token)(?:_|$)/i;
+
+const normalizeUrlForParsing = (url: string): URL | null => {
+  try {
+    return new URL(url, typeof window !== 'undefined' ? window.location.origin : 'http://localhost');
+  } catch {
+    return null;
+  }
+};
+
+export const isProxyTransportUrl = (url: string): boolean => {
+  const parsed = normalizeUrlForParsing(url);
+  return Boolean(parsed?.pathname.startsWith('/proxy/'));
+};
+
+export const redactUrlForDiagnostics = (url: string): string => {
+  const parsed = normalizeUrlForParsing(url);
+  if (!parsed) {
+    return url;
+  }
+
+  let changed = false;
+  for (const key of Array.from(parsed.searchParams.keys())) {
+    if (SENSITIVE_QUERY_KEYS.test(key)) {
+      parsed.searchParams.set(key, '[redacted]');
+      changed = true;
+    }
+  }
+
+  if (
+    /access_token|auth|authorization|code|credential|id_token|key|password|secret|session|sig|signature|token/i.test(
+      parsed.hash
+    )
+  ) {
+    parsed.hash = '#[redacted]';
+    changed = true;
+  }
+
+  if (!changed) {
+    return url;
+  }
+
+  if (/^[a-z][a-z\d+.-]*:/i.test(url)) {
+    return parsed.href;
+  }
+  return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+};
+
+const normalizeDescription = (description: string): string => description.toLowerCase();
+
+export const getWebviewFallbackDiagnostics = (
+  error: WebviewLoadError,
+  fallbackUrl: string
+): WebviewFallbackDiagnostics => {
+  const rawUrl = error.url || fallbackUrl;
+  const transportUrl = error.transportUrl || (isProxyTransportUrl(rawUrl) ? rawUrl : undefined);
+  const canonicalUrl = transportUrl && rawUrl === transportUrl ? fallbackUrl : rawUrl;
+  const hasDisplayableCanonicalUrl = Boolean(canonicalUrl && !isProxyTransportUrl(canonicalUrl));
+  const description = error.description || '';
+  const lowerDescription = normalizeDescription(description);
+  const status = error.code;
+
+  let title = 'This page didn’t load';
+  let reason = 'The embedded browser could not load this page through Omni.';
+
+  if (status === 401 || status === 403 || /forbidden|unauthorized|not allowed|trusted network/.test(lowerDescription)) {
+    title = 'Proxy registration was blocked';
+    reason = 'Omni was not allowed to register this site with the browser/server proxy.';
+  } else if (
+    status === 400 ||
+    status === 422 ||
+    /denied|invalid upstream|expected http\(s\)|private network|link-local|metadata|ssrf/.test(lowerDescription)
+  ) {
+    title = 'This address cannot be proxied';
+    reason = 'Omni only proxies allowed http(s) sites and blocked this upstream.';
+  } else if (
+    /dns|enotfound|getaddrinfo|name_not_resolved|err_name_not_resolved/.test(lowerDescription) ||
+    status === -105
+  ) {
+    title = 'DNS lookup failed';
+    reason = 'The proxy could not resolve the site’s hostname.';
+  } else if (
+    /tls|ssl|certificate|cert_|err_cert|err_ssl/.test(lowerDescription) ||
+    (status <= -200 && status >= -299)
+  ) {
+    title = 'Secure connection failed';
+    reason = 'The proxy could not establish a trusted TLS connection to this site.';
+  } else if (/timeout|timed out|etimedout|err_timed_out/.test(lowerDescription) || status === -7 || status === -118) {
+    title = 'The site took too long to respond';
+    reason = 'The proxy timed out while waiting for the page.';
+  } else if (/redirect loop|too many redirects|err_too_many_redirects/.test(lowerDescription) || status === -310) {
+    title = 'Redirect loop detected';
+    reason = 'The page redirected too many times before Omni could embed it.';
+  } else if (/unsupported|service worker|webauthn|passkey|drm|protected media|browser feature/.test(lowerDescription)) {
+    title = 'Browser feature not supported here';
+    reason = 'This page needs a browser feature that the server-mode embedded browser does not support.';
+  } else if (
+    /proxy request failed|bad gateway|no upstream/.test(lowerDescription) ||
+    status === 502 ||
+    status === 503 ||
+    status === 504
+  ) {
+    title = 'The proxy could not reach this site';
+    reason = 'Omni’s browser/server proxy failed while contacting the upstream page.';
+  } else if (/proxy registration failed|registration response/.test(lowerDescription)) {
+    title = 'Proxy registration failed';
+    reason = 'Omni could not prepare this site for embedding in browser/server mode.';
+  }
+
+  return {
+    title,
+    reason,
+    canonicalUrl,
+    displayUrl: hasDisplayableCanonicalUrl ? redactUrlForDiagnostics(canonicalUrl) : 'Original page URL unavailable',
+    ...(transportUrl && transportUrl !== canonicalUrl ? { transportUrl: redactUrlForDiagnostics(transportUrl) } : {}),
+    instructions:
+      'Open the URL in a regular browser tab, or copy it and paste it into your browser if embedding keeps failing.',
+    ...(description ? { debugDescription: description } : {}),
+  };
+};
+
+export const openInBrowserTab = (url: string): void => {
+  const opened = window.open(url, '_blank', 'noopener,noreferrer');
+  if (opened) {
+    opened.opener = null;
+  }
+};

--- a/src/renderer/features/Browser/BrowserView.tsx
+++ b/src/renderer/features/Browser/BrowserView.tsx
@@ -24,6 +24,11 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { fallbackTitle, normalizeAddress, parseOrigin } from '@/lib/url';
 import type { ConsoleMessage, ContextMenuParams, FoundInPageResult, WebviewHandle } from '@/renderer/common/Webview';
 import { Webview } from '@/renderer/common/Webview';
+import {
+  getWebviewFallbackDiagnostics,
+  openInBrowserTab,
+  type WebviewLoadError,
+} from '@/renderer/common/webview-fallback';
 import { BookmarksBar } from '@/renderer/features/Browser/BookmarksBar';
 import { DevtoolsPanel } from '@/renderer/features/Browser/Devtools/DevtoolsPanel';
 import { DownloadsTray } from '@/renderer/features/Browser/DownloadsTray';
@@ -123,9 +128,19 @@ const useStyles = makeStyles({
     textAlign: 'center',
     color: tokens.colorNeutralForeground2,
   },
-  errorTitle: { fontSize: tokens.fontSizeBase400, fontWeight: tokens.fontWeightSemibold, color: tokens.colorNeutralForeground1 },
+  errorTitle: {
+    fontSize: tokens.fontSizeBase400,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
+  },
   errorUrl: { fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3, wordBreak: 'break-all' },
-  errorActions: { display: 'flex', gap: tokens.spacingHorizontalS },
+  errorLabel: {
+    fontSize: tokens.fontSizeBase100,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground3,
+  },
+  errorInstructions: { maxWidth: '560px', fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3 },
+  errorActions: { display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: tokens.spacingHorizontalS },
   errorButton: {
     paddingLeft: tokens.spacingHorizontalM,
     paddingRight: tokens.spacingHorizontalM,
@@ -148,11 +163,21 @@ const useStyles = makeStyles({
     cursor: 'pointer',
     ':hover': { backgroundColor: tokens.colorSubtleBackgroundHover },
   },
+  errorDetails: {
+    maxWidth: '640px',
+    fontSize: tokens.fontSizeBase100,
+    color: tokens.colorNeutralForeground3,
+    textAlign: 'left',
+  },
+  errorDetailsSummary: {
+    cursor: 'pointer',
+    textAlign: 'center',
+  },
 });
 
 type PreviewState = {
   loading: boolean;
-  error: { code: number; description: string; url: string } | null;
+  error: WebviewLoadError | null;
 };
 
 /** Cmd (⌘) on macOS, Ctrl elsewhere. Used in button tooltips. */
@@ -230,8 +255,8 @@ export const BrowserView = memo(
     // this partition so the tray + prompt banner pick up items from it.
     useEffect(() => {
       if (!partition) {
-return;
-}
+        return;
+      }
       void emitter.invoke('browser:downloads-watch-partition', partition).catch(() => {});
       void emitter.invoke('browser:permissions-watch-partition', partition).catch(() => {});
     }, [partition]);
@@ -254,8 +279,8 @@ return;
     const activeUrl = activeTab?.url;
     useEffect(() => {
       if (activeUrl) {
-onUrlChange?.(activeUrl);
-}
+        onUrlChange?.(activeUrl);
+      }
     }, [activeUrl, onUrlChange]);
 
     // External navigation: if parent passes a new `src`, nav the active tab.
@@ -264,11 +289,11 @@ onUrlChange?.(activeUrl);
     const lastExternalSrcRef = useRef<string | undefined>(undefined);
     useEffect(() => {
       if (!src || !activeTab) {
-return;
-}
+        return;
+      }
       if (src === lastExternalSrcRef.current) {
-return;
-}
+        return;
+      }
       const normalizedSrc = normalizeAddress(src);
       lastExternalSrcRef.current = src;
       if (activeTab.url !== normalizedSrc) {
@@ -281,8 +306,8 @@ return;
     const handleNavigate = useCallback(
       (url: string) => {
         if (!activeTab) {
-return;
-}
+          return;
+        }
         void browserApi.updateTabMeta(tabsetId, activeTab.id, { url });
         void browserApi.recordHistory({
           url,
@@ -296,8 +321,8 @@ return;
     const handleTitle = useCallback(
       (title: string) => {
         if (!activeTab) {
-return;
-}
+          return;
+        }
         void browserApi.updateTabMeta(tabsetId, activeTab.id, { title });
       },
       [activeTab, tabsetId]
@@ -306,8 +331,8 @@ return;
     const handleFavicon = useCallback(
       (favicon: string) => {
         if (!activeTab) {
-return;
-}
+          return;
+        }
         void browserApi.updateTabMeta(tabsetId, activeTab.id, { favicon });
       },
       [activeTab, tabsetId]
@@ -317,7 +342,7 @@ return;
       setPreviewState((s) => ({ ...s, loading, error: loading ? null : s.error }));
     }, []);
 
-    const handleError = useCallback((error: { code: number; description: string; url: string }) => {
+    const handleError = useCallback((error: WebviewLoadError) => {
       setPreviewState({ loading: false, error });
     }, []);
 
@@ -336,8 +361,8 @@ return;
         reload: () => webviewRef.current?.reload(),
         navigate: (url: string) => {
           if (activeTab) {
-void browserApi.navigateTab(tabsetId, activeTab.id, url);
-}
+            void browserApi.navigateTab(tabsetId, activeTab.id, url);
+          }
         },
         openInNewTab: (url: string) => {
           void browserApi.createTab(tabsetId, { url, activate: true, profileId: resolvedProfileId });
@@ -350,8 +375,12 @@ void browserApi.navigateTab(tabsetId, activeTab.id, url);
         },
         viewSource: () => {
           if (activeTab) {
-void browserApi.createTab(tabsetId, { url: `view-source:${activeTab.url}`, activate: true, profileId: resolvedProfileId });
-}
+            void browserApi.createTab(tabsetId, {
+              url: `view-source:${activeTab.url}`,
+              activate: true,
+              profileId: resolvedProfileId,
+            });
+          }
         },
         inspect: (_x: number, _y: number) => {
           webviewRef.current?.openDevTools();
@@ -368,8 +397,8 @@ void browserApi.createTab(tabsetId, { url: `view-source:${activeTab.url}`, activ
     // Close find on tab switch / error — stale results are worse than empty.
     useEffect(() => {
       if (findOpen) {
-closeFind();
-}
+        closeFind();
+      }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeTabId]);
 
@@ -379,8 +408,8 @@ closeFind();
     const navigateActive = useCallback(
       (url: string) => {
         if (!activeTab) {
-return;
-}
+          return;
+        }
         void browserApi.navigateTab(tabsetId, activeTab.id, url);
       },
       [activeTab, tabsetId]
@@ -389,8 +418,8 @@ return;
     const handleOmniboxSubmit = useCallback(
       (url: string) => {
         if (!activeTab) {
-return;
-}
+          return;
+        }
         void browserApi.navigateTab(tabsetId, activeTab.id, url);
       },
       [activeTab, tabsetId]
@@ -406,9 +435,10 @@ return;
       (next: number) => {
         const clamped = Math.max(0.25, Math.min(5, next));
         setZoom(clamped);
-        const handleId = registryScope === 'column' && registryTabId
-          ? makeAppHandleId('column', 'browser', registryTabId)
-          : makeAppHandleId('global', 'browser');
+        const handleId =
+          registryScope === 'column' && registryTabId
+            ? makeAppHandleId('column', 'browser', registryTabId)
+            : makeAppHandleId('global', 'browser');
         // Tolerate races: if the webview hasn't registered yet we silently
         // skip — zoom will apply on next keystroke once it has.
         void emitter.invoke('app:set-zoom', handleId, clamped).catch(() => {});
@@ -423,8 +453,8 @@ return;
 
     const handleBookmarkToggle = useCallback(() => {
       if (!activeTab) {
-return;
-}
+        return;
+      }
       const existing = state.bookmarks.find((b) => b.url === activeTab.url);
       if (existing) {
         void browserApi.removeBookmark(existing.id);
@@ -439,8 +469,7 @@ return;
       const handler = (event: KeyboardEvent) => {
         const target = event.target as HTMLElement | null;
         const tag = target?.tagName?.toLowerCase();
-        const isEditable =
-          target?.isContentEditable || tag === 'input' || tag === 'textarea' || tag === 'select';
+        const isEditable = target?.isContentEditable || tag === 'input' || tag === 'textarea' || tag === 'select';
         const mod = event.metaKey || event.ctrlKey;
 
         // F12 toggles our devtools panel — no modifier, but we still want
@@ -452,14 +481,14 @@ return;
         }
 
         if (!mod && event.key !== 'Escape') {
-return;
-}
+          return;
+        }
         // Escape is always allowed (to stop a load); other shortcuts skip
         // when focus is in an editable element except for Cmd+L which is
         // specifically about re-focusing the omnibox.
         if (isEditable && event.key !== 'Escape' && event.key.toLowerCase() !== 'l') {
-return;
-}
+          return;
+        }
 
         const key = event.key.toLowerCase();
         if (key === 't') {
@@ -468,8 +497,8 @@ return;
         } else if (key === 'w') {
           event.preventDefault();
           if (activeTabId) {
-void browserApi.closeTab(tabsetId, activeTabId);
-}
+            void browserApi.closeTab(tabsetId, activeTabId);
+          }
         } else if (key === 'l') {
           event.preventDefault();
           omniRef.current?.focus();
@@ -506,8 +535,8 @@ void browserApi.closeTab(tabsetId, activeTabId);
           webviewRef.current?.goForward();
         } else if (event.key === 'Escape') {
           if (previewState.loading) {
-webviewRef.current?.stop();
-}
+            webviewRef.current?.stop();
+          }
         }
       };
       window.addEventListener('keydown', handler);
@@ -518,8 +547,8 @@ webviewRef.current?.stop();
 
     const registryProps = useMemo(() => {
       if (!activeTab) {
-return undefined;
-}
+        return undefined;
+      }
       return {
         handleId: makeAppHandleId(registryScope, 'browser', registryScope === 'column' ? registryTabId : undefined),
         appId: 'browser' as const,
@@ -541,6 +570,9 @@ return undefined;
 
     const bookmarked = state.bookmarks.some((b) => b.url === activeTab.url);
     const origin = parseOrigin(activeTab.url);
+    const fallbackDiagnostics = previewState.error
+      ? getWebviewFallbackDiagnostics(previewState.error, activeTab.url)
+      : null;
 
     return (
       <div className={mergeClasses(styles.root, isGlass && styles.rootGlass)}>
@@ -624,12 +656,16 @@ return undefined;
         <PermissionsBar partition={partition} />
         <div className={styles.body}>
           {previewState.loading && <div className={styles.loadingBar} />}
-          {previewState.error ? (
+          {fallbackDiagnostics ? (
             <div className={styles.errorPane}>
               <Globe20Regular style={{ width: 40, height: 40, opacity: 0.5 }} />
-              <div className={styles.errorTitle}>This page didn’t load</div>
-              <div>{previewState.error.description || 'Something went wrong.'}</div>
-              <div className={styles.errorUrl}>{previewState.error.url || activeTab.url}</div>
+              <div className={styles.errorTitle}>{fallbackDiagnostics.title}</div>
+              <div>{fallbackDiagnostics.reason}</div>
+              <div>
+                <div className={styles.errorLabel}>Canonical URL</div>
+                <div className={styles.errorUrl}>{fallbackDiagnostics.displayUrl}</div>
+              </div>
+              <div className={styles.errorInstructions}>{fallbackDiagnostics.instructions}</div>
               <div className={styles.errorActions}>
                 <button
                   type="button"
@@ -645,12 +681,26 @@ return undefined;
                   type="button"
                   className={styles.errorButtonGhost}
                   onClick={() => {
-                    void navigator.clipboard.writeText(activeTab.url).catch(() => {});
+                    void navigator.clipboard.writeText(fallbackDiagnostics.canonicalUrl).catch(() => {});
                   }}
                 >
                   Copy URL
                 </button>
+                <button
+                  type="button"
+                  className={styles.errorButtonGhost}
+                  onClick={() => openInBrowserTab(fallbackDiagnostics.canonicalUrl)}
+                >
+                  Open in Browser
+                </button>
               </div>
+              {(fallbackDiagnostics.transportUrl || fallbackDiagnostics.debugDescription) && (
+                <details className={styles.errorDetails}>
+                  <summary className={styles.errorDetailsSummary}>Details</summary>
+                  {fallbackDiagnostics.debugDescription && <div>Reason: {fallbackDiagnostics.debugDescription}</div>}
+                  {fallbackDiagnostics.transportUrl && <div>Proxy transport: {fallbackDiagnostics.transportUrl}</div>}
+                </details>
+              )}
             </div>
           ) : (
             <Webview
@@ -684,11 +734,7 @@ return undefined;
             />
           )}
           {isGlobal && historyOpen && (
-            <HistoryPanel
-              profileId={resolvedProfileId}
-              onOpen={navigateActive}
-              onClose={() => setHistoryOpen(false)}
-            />
+            <HistoryPanel profileId={resolvedProfileId} onOpen={navigateActive} onClose={() => setHistoryOpen(false)} />
           )}
           {origin && false /* hidden placeholder; kept for future origin badge */}
         </div>

--- a/src/renderer/features/Tickets/preview-bridge.test.ts
+++ b/src/renderer/features/Tickets/preview-bridge.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadBridge() {
+  vi.resetModules();
+  return import('@/renderer/features/Tickets/preview-bridge');
+}
+
+describe('preview-bridge', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('keeps preview URLs canonical and does not pre-register proxy paths', async () => {
+    const { resolvePreviewUrl } = await loadBridge();
+    const url = 'https://github.com/acme/repo/pull/42';
+
+    await expect(resolvePreviewUrl(url, 'tab-1')).resolves.toBe(url);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('stores PR preview requests with canonical URLs', async () => {
+    const { $previewRequest, requestPreviewOpen } = await loadBridge();
+    const url = 'https://github.com/acme/repo/pull/42';
+
+    requestPreviewOpen(url, 'tab-1');
+    await Promise.resolve();
+
+    expect($previewRequest.get()).toEqual({ id: 'preview-1', url, tabId: 'tab-1' });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/features/Tickets/preview-bridge.ts
+++ b/src/renderer/features/Tickets/preview-bridge.ts
@@ -5,40 +5,14 @@
  * The React side (CodeDeck) subscribes and opens the preview overlay.
  * Unlike the plan bridge, this does NOT block — the tool returns immediately.
  *
- * In browser/server mode, URLs are routed through the proxy so the browser
- * can reach localhost services on the server machine.
+ * Preview requests always carry the canonical URL. Browser/server iframe
+ * transport proxying is handled inside `<Webview>`.
  */
 import { atom } from 'nanostores';
 
-const isElectron = typeof window !== 'undefined' && 'electron' in window;
-
-/** Map from proxy name to upstream origin for reverse-mapping proxy URLs back to original URLs. */
-const proxyToUpstream = new Map<string, string>();
-
-/**
- * Convert a proxy URL (e.g. `/proxy/preview-default/search?q=foo`) back to
- * the original upstream URL (e.g. `https://www.google.com/search?q=foo`).
- * Returns the input unchanged if it's not a recognized proxy path.
- */
+/** Legacy compatibility shim; preview URLs are now canonical before storage. */
 export function reverseProxyUrl(url: string): string {
-  try {
-    const parsed = new URL(url, window.location.origin);
-    const pathMatch = parsed.pathname.match(/^\/proxy\/([^/]+)(\/.*)?$/);
-    if (!pathMatch) {
-return url;
-}
-
-    const proxyName = pathMatch[1] as string;
-    const remainder = pathMatch[2] ?? '/';
-    const upstream = proxyToUpstream.get(proxyName);
-    if (!upstream) {
-return url;
-}
-
-    return upstream + remainder + parsed.search + parsed.hash;
-  } catch {
-    return url;
-  }
+  return url;
 }
 
 export type PreviewRequest = {
@@ -55,35 +29,11 @@ const latestRequestByTab = new Map<string, string>();
 export const $previewRequest = atom<PreviewRequest | null>(null);
 
 /**
- * In browser mode, register the URL with the proxy and return the proxied path.
- * In Electron mode, return the URL as-is (webview can reach localhost directly).
+ * Preview requests stay canonical. Browser/server mode resolves iframe
+ * transport internally in `<Webview>` so tab state and PR badges never receive
+ * `/proxy/...` paths.
  */
-export async function resolvePreviewUrl(url: string, tabId?: string): Promise<string> {
-  if (isElectron) {
-return url;
-}
-
-  try {
-    const proxyName = `preview-${tabId ?? 'default'}`;
-    const res = await fetch('/proxy/_register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: proxyName, upstream: url }),
-    });
-    if (res.ok) {
-      const data = (await res.json()) as { proxyPath?: string };
-      if (data.proxyPath) {
-        // Store the reverse mapping so we can convert proxy URLs back to upstream URLs
-        try {
-          const parsed = new URL(url);
-          proxyToUpstream.set(proxyName, `${parsed.protocol}//${parsed.host}`);
-        } catch { /* ignore */ }
-        return data.proxyPath;
-      }
-    }
-  } catch {
-    // Fall through to raw URL
-  }
+export async function resolvePreviewUrl(url: string, _tabId?: string): Promise<string> {
   return url;
 }
 
@@ -92,7 +42,7 @@ export function requestPreviewOpen(url: string, tabId?: string): void {
   const id = `preview-${++nextId}`;
   const key = tabId ?? 'default';
   latestRequestByTab.set(key, id);
-  // Fire and forget — resolve the proxy URL, then set the atom
+  // Fire and forget — preserve the async shape used by callers.
   void resolvePreviewUrl(url, tabId).then((resolvedUrl) => {
     if (latestRequestByTab.get(key) !== id) {
       return;

--- a/src/renderer/services/proxy-resolver.test.ts
+++ b/src/renderer/services/proxy-resolver.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadResolver() {
+  vi.resetModules();
+  vi.doMock('@/renderer/services/ipc', () => ({
+    isCloudLinked: false,
+    isElectron: false,
+    serverOrigin: () => window.location.origin,
+  }));
+  return import('@/renderer/services/proxy-resolver');
+}
+
+function fetchMock() {
+  return vi.mocked(fetch);
+}
+
+describe('proxy-resolver', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('returns explicit success metadata and registers external origins', async () => {
+    fetchMock().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          proxyName: 'dyn-github',
+          proxyPath: '/proxy/dyn-github/acme/repo/pull/42?tab=files',
+        }),
+        { status: 200 }
+      )
+    );
+    const { resolveProxiedSrc } = await loadResolver();
+
+    const result = await resolveProxiedSrc('https://github.com/acme/repo/pull/42?tab=files#diff');
+
+    expect(result).toEqual({
+      ok: true,
+      canonicalUrl: 'https://github.com/acme/repo/pull/42?tab=files#diff',
+      iframeSrc: '/proxy/dyn-github/acme/repo/pull/42?tab=files#diff',
+      proxyName: 'dyn-github',
+    });
+    expect(fetchMock()).toHaveBeenCalledWith(
+      `${window.location.origin}/proxy/_register`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ upstream: 'https://github.com/acme/repo/pull/42?tab=files#diff' }),
+      })
+    );
+  });
+
+  it('returns explicit failure and retries after non-OK registration without caching', async () => {
+    fetchMock()
+      .mockResolvedValueOnce(new Response('forbidden', { status: 403 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ proxyName: 'dyn-example', proxyPath: '/proxy/dyn-example/docs?q=1' }), {
+          status: 200,
+        })
+      );
+    const { resolveProxiedSrc, unproxyUrl } = await loadResolver();
+
+    const failed = await resolveProxiedSrc('https://example.com/docs?q=1#top');
+
+    expect(failed).toEqual({
+      ok: false,
+      canonicalUrl: 'https://example.com/docs?q=1#top',
+      reason: 'Proxy registration failed (403): forbidden',
+      status: 403,
+    });
+    expect(unproxyUrl('/proxy/ext-https-example-com/docs?q=1#top')).toBe('/proxy/ext-https-example-com/docs?q=1#top');
+
+    const retried = await resolveProxiedSrc('https://example.com/docs?q=1#top');
+
+    expect(retried).toMatchObject({
+      ok: true,
+      canonicalUrl: 'https://example.com/docs?q=1#top',
+      iframeSrc: '/proxy/dyn-example/docs?q=1#top',
+      proxyName: 'dyn-example',
+    });
+    expect(fetchMock()).toHaveBeenCalledTimes(2);
+  });
+
+  it('unproxies known transport URLs while preserving query and hash', async () => {
+    fetchMock().mockResolvedValue(
+      new Response(JSON.stringify({ proxyName: 'dyn-example', proxyPath: '/proxy/dyn-example/first' }), { status: 200 })
+    );
+    const { resolveProxiedSrc, unproxyUrl } = await loadResolver();
+
+    await resolveProxiedSrc('https://example.com/first');
+
+    expect(unproxyUrl('/proxy/dyn-example/path/to/page?q=1#section')).toBe(
+      'https://example.com/path/to/page?q=1#section'
+    );
+    await expect(resolveProxiedSrc('/proxy/dyn-example/path/to/page?q=1#section')).resolves.toEqual({
+      ok: true,
+      canonicalUrl: 'https://example.com/path/to/page?q=1#section',
+      iframeSrc: '/proxy/dyn-example/path/to/page?q=1#section',
+      proxyName: 'dyn-example',
+    });
+  });
+
+  it('leaves unknown proxy transport paths safe and unregistered', async () => {
+    const { resolveProxiedSrc, unproxyUrl } = await loadResolver();
+
+    expect(unproxyUrl('/proxy/unknown/path?q=1#hash')).toBe('/proxy/unknown/path?q=1#hash');
+    await expect(resolveProxiedSrc('/proxy/unknown/path?q=1#hash')).resolves.toEqual({
+      ok: true,
+      canonicalUrl: '/proxy/unknown/path?q=1#hash',
+      iframeSrc: '/proxy/unknown/path?q=1#hash',
+      proxyName: 'unknown',
+    });
+    expect(fetchMock()).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/services/proxy-resolver.ts
+++ b/src/renderer/services/proxy-resolver.ts
@@ -22,7 +22,25 @@ import { isCloudLinked, isElectron, serverOrigin } from '@/renderer/services/ipc
 const upstreamByName = new Map<string, string>();
 const nameByOrigin = new Map<string, string>();
 /** De-dup in-flight registrations per origin. */
-const pendingByOrigin = new Map<string, Promise<void>>();
+const pendingByOrigin = new Map<string, Promise<ProxyRegistrationResult>>();
+
+type ProxyRegistrationResult =
+  | { ok: true; proxyName: string; proxyPath: string }
+  | { ok: false; reason: string; status?: number };
+
+export type ProxiedSrcResult =
+  | {
+      ok: true;
+      canonicalUrl: string;
+      iframeSrc: string;
+      proxyName?: string;
+    }
+  | {
+      ok: false;
+      canonicalUrl: string;
+      reason: string;
+      status?: number;
+    };
 
 /**
  * The launcher's origin from the renderer's perspective. In browser server
@@ -33,14 +51,6 @@ const pendingByOrigin = new Map<string, Promise<void>>();
  * renderer's own origin.
  */
 const launcherOrigin = (): string => serverOrigin();
-
-const slug = (origin: string): string =>
-  origin
-    .replace(/[^a-zA-Z0-9]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-
-const proxyNameFor = (origin: string): string => `ext-${slug(origin)}`;
 
 const tryParseUrl = (raw: string): URL | null => {
   try {
@@ -62,28 +72,75 @@ const isExternalHttp = (url: URL): boolean => {
   return false;
 };
 
-const ensureRegistered = (origin: string, name: string): Promise<void> => {
-  if (upstreamByName.has(name)) {
-    return Promise.resolve();
+const proxyNameFromPath = (proxyPath: string): string | null => {
+  const parsed = tryParseUrl(proxyPath);
+  if (!parsed || parsed.origin !== launcherOrigin() || !parsed.pathname.startsWith('/proxy/')) {
+    return null;
+  }
+  const rest = parsed.pathname.slice('/proxy/'.length);
+  const slash = rest.indexOf('/');
+  const name = slash === -1 ? rest : rest.slice(0, slash);
+  return name || null;
+};
+
+const readRegistrationError = async (res: Response): Promise<string | null> => {
+  try {
+    const contentType = res.headers.get('content-type')?.toLowerCase() ?? '';
+    if (contentType.includes('application/json')) {
+      const body = (await res.json()) as { error?: unknown; message?: unknown };
+      const message =
+        typeof body.error === 'string' ? body.error : typeof body.message === 'string' ? body.message : '';
+      return message.trim() || null;
+    }
+    const text = await res.text();
+    return text.trim() || null;
+  } catch {
+    return null;
+  }
+};
+
+const ensureRegistered = (url: URL): Promise<ProxyRegistrationResult> => {
+  const origin = url.origin;
+  const knownName = nameByOrigin.get(origin);
+  if (knownName && upstreamByName.has(knownName)) {
+    return Promise.resolve({
+      ok: true,
+      proxyName: knownName,
+      proxyPath: `/proxy/${knownName}${url.pathname}${url.search}`,
+    });
   }
   const existing = pendingByOrigin.get(origin);
   if (existing) {
     return existing;
   }
-  const pending = (async () => {
+  const pending: Promise<ProxyRegistrationResult> = (async (): Promise<ProxyRegistrationResult> => {
     try {
       // Absolute URL so cloud-linked Electron hits the cloud's /proxy/_register
       // instead of localhost:5173 (which has no such route). Browser server-
       // mode resolves to same-origin same as before.
-      await fetch(`${launcherOrigin()}/proxy/_register`, {
+      const res = await fetch(`${launcherOrigin()}/proxy/_register`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ name, upstream: origin }),
+        body: JSON.stringify({ upstream: url.href }),
       });
-      upstreamByName.set(name, origin);
+      if (!res.ok) {
+        const detail = await readRegistrationError(res);
+        return {
+          ok: false,
+          reason: `Proxy registration failed${res.status ? ` (${res.status})` : ''}${detail ? `: ${detail}` : ''}`,
+          ...(res.status ? { status: res.status } : {}),
+        };
+      }
+      const body = (await res.json()) as { proxyName?: string; proxyPath?: string };
+      const proxyName = body.proxyName ?? (body.proxyPath ? proxyNameFromPath(body.proxyPath) : null);
+      if (!proxyName || !body.proxyPath) {
+        return { ok: false, reason: 'Proxy registration response missing proxy capability' };
+      }
+      upstreamByName.set(proxyName, origin);
+      nameByOrigin.set(origin, proxyName);
+      return { ok: true, proxyName, proxyPath: body.proxyPath };
     } catch {
-      // Server unreachable — leave unregistered; the iframe load will
-      // surface a normal load error and the retry path will kick in.
+      return { ok: false, reason: 'Proxy registration failed' };
     } finally {
       pendingByOrigin.delete(origin);
     }
@@ -98,13 +155,13 @@ const ensureRegistered = (origin: string, name: string): Promise<void> => {
  * returns the corresponding `/proxy/<name>/<path>` path. Otherwise returns
  * the input unchanged.
  */
-export const resolveProxiedSrc = async (rawSrc: string): Promise<string> => {
+export const resolveProxiedSrc = async (rawSrc: string): Promise<ProxiedSrcResult> => {
   if (!rawSrc || isElectron) {
-    return rawSrc;
+    return { ok: true, canonicalUrl: rawSrc, iframeSrc: rawSrc };
   }
   const parsed = tryParseUrl(rawSrc);
   if (!parsed) {
-    return rawSrc;
+    return { ok: true, canonicalUrl: rawSrc, iframeSrc: rawSrc };
   }
   if (parsed.origin === launcherOrigin() && parsed.pathname.startsWith('/proxy/')) {
     // Already proxied — record the mapping if we recognize the name so
@@ -115,24 +172,38 @@ export const resolveProxiedSrc = async (rawSrc: string): Promise<string> => {
     }
     // In cloud-linked Electron the iframe needs the absolute URL — Vite
     // would otherwise resolve the relative path against localhost:5173.
-    return isCloudLinked
+    const iframeSrc = isCloudLinked
       ? `${launcherOrigin()}${parsed.pathname}${parsed.search}${parsed.hash}`
       : parsed.pathname + parsed.search + parsed.hash;
+    const unproxied = unproxyUrl(iframeSrc);
+    return {
+      ok: true,
+      canonicalUrl: unproxied === iframeSrc ? rawSrc : unproxied,
+      iframeSrc,
+      ...(name ? { proxyName: name } : {}),
+    };
   }
   if (!isExternalHttp(parsed)) {
-    return rawSrc;
+    return { ok: true, canonicalUrl: rawSrc, iframeSrc: rawSrc };
   }
-  const origin = parsed.origin;
-  let name = nameByOrigin.get(origin);
-  if (!name) {
-    name = proxyNameFor(origin);
-    nameByOrigin.set(origin, name);
+  const registered = await ensureRegistered(parsed);
+  if (!registered.ok) {
+    return {
+      ok: false,
+      canonicalUrl: parsed.href,
+      reason: registered.reason,
+      ...(registered.status ? { status: registered.status } : {}),
+    };
   }
-  await ensureRegistered(origin, name);
   // Absolute when cloud-linked so the iframe doesn't resolve against the
   // renderer's own origin (localhost:5173 / file://).
-  const path = `/proxy/${name}${parsed.pathname}${parsed.search}${parsed.hash}`;
-  return isCloudLinked ? `${launcherOrigin()}${path}` : path;
+  const path = `/proxy/${registered.proxyName}${parsed.pathname}${parsed.search}${parsed.hash}`;
+  return {
+    ok: true,
+    canonicalUrl: parsed.href,
+    iframeSrc: isCloudLinked ? `${launcherOrigin()}${path}` : path,
+    proxyName: registered.proxyName,
+  };
 };
 
 /**

--- a/src/server/proxy-rewriter.test.ts
+++ b/src/server/proxy-rewriter.test.ts
@@ -5,9 +5,49 @@
  * root-relative), CSP meta tag stripping, already-proxied URL skipping,
  * escapeForRegex, and status URL rewriting with upstream registration.
  */
-import { describe, expect, it } from 'vitest';
+import fastifyWebsocket from '@fastify/websocket';
+import Fastify from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { escapeForRegex, rewriteHtmlUrls, rewriteStatusUrls } from '@/server/proxy-rewriter';
+import {
+  buildProxyRuntimeShim,
+  cleanupExpiredProxyRegistrations,
+  escapeForRegex,
+  getProxyRuntimePolicy,
+  redactProxyUrlForLog,
+  registerProxyUpstream,
+  resetProxyRegistrationsForTests,
+  rewriteCssUrls,
+  rewriteHtmlUrls,
+  rewriteLocationHeader,
+  rewriteProxyRuntimeUrl,
+  rewriteMetaRefresh,
+  rewriteSetCookieHeader,
+  rewriteStatusUrls,
+  setupProxyRewriter,
+} from '@/server/proxy-rewriter';
+import type { WsHandler } from '@/server/ws-handler';
+
+const createProxyTestServer = async (isTrusted: (remoteAddress: string) => boolean) => {
+  const app = Fastify({ logger: false });
+  await app.register(fastifyWebsocket);
+  const wsHandler = {
+    addEventInterceptor: vi.fn(),
+    addResultWrapper: vi.fn(),
+  } as unknown as WsHandler;
+  setupProxyRewriter(app, wsHandler, isTrusted);
+  await app.ready();
+  return app;
+};
+
+afterEach(() => {
+  delete process.env['OMNI_ALLOW_EXTERNAL_REGISTER'];
+  delete process.env['OMNI_AUTH_MODE'];
+  delete process.env['OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS'];
+  delete process.env['OMNI_PROXY_RUNTIME_SHIMS'];
+  vi.unstubAllGlobals();
+  resetProxyRegistrationsForTests();
+});
 
 // ---------------------------------------------------------------------------
 // escapeForRegex
@@ -15,9 +55,7 @@ import { escapeForRegex, rewriteHtmlUrls, rewriteStatusUrls } from '@/server/pro
 
 describe('escapeForRegex', () => {
   it('escapes regex metacharacters', () => {
-    expect(escapeForRegex('http://host:8080/path?a=1&b=2')).toBe(
-      'http://host:8080/path\\?a=1&b=2'
-    );
+    expect(escapeForRegex('http://host:8080/path?a=1&b=2')).toBe('http://host:8080/path\\?a=1&b=2');
   });
 
   it('escapes dots, brackets, parens, and pipes', () => {
@@ -137,11 +175,643 @@ describe('rewriteHtmlUrls', () => {
     expect(result).toContain('poster="/proxy/chat-uiUrl/thumb.jpg"');
   });
 
+  it('rewrites data, iframe src, source src, and track src attributes', () => {
+    const html = [
+      '<object data="/movie.swf"></object>',
+      '<iframe src="/frame.html"></iframe>',
+      '<source src="http://localhost:8082/video.mp4">',
+      '<track src="//localhost:8082/captions.vtt">',
+    ].join('');
+
+    const result = rewriteHtmlUrls(html, upstream, proxyName);
+
+    expect(result).toContain('data="/proxy/chat-uiUrl/movie.swf"');
+    expect(result).toContain('src="/proxy/chat-uiUrl/frame.html"');
+    expect(result).toContain('src="/proxy/chat-uiUrl/video.mp4"');
+    expect(result).toContain('src="/proxy/chat-uiUrl/captions.vtt"');
+  });
+
+  it('rewrites preload, prefetch, and modulepreload link hrefs', () => {
+    const html = [
+      '<link rel="preload" href="/fonts/app.woff2">',
+      '<link rel="prefetch" href="http://localhost:8082/next.html">',
+      '<link rel="modulepreload" href="//localhost:8082/app.mjs">',
+    ].join('');
+
+    const result = rewriteHtmlUrls(html, upstream, proxyName);
+
+    expect(result).toContain('href="/proxy/chat-uiUrl/fonts/app.woff2"');
+    expect(result).toContain('href="/proxy/chat-uiUrl/next.html"');
+    expect(result).toContain('href="/proxy/chat-uiUrl/app.mjs"');
+  });
+
+  it('rewrites multiple srcset candidates independently', () => {
+    const html = '<img srcset="/small.png 1x, http://localhost:8082/large.png 2x, //localhost:8082/hero.png 1200w">';
+
+    const result = rewriteHtmlUrls(html, upstream, proxyName);
+
+    expect(result).toBe(
+      '<img srcset="/proxy/chat-uiUrl/small.png 1x, /proxy/chat-uiUrl/large.png 2x, /proxy/chat-uiUrl/hero.png 1200w">'
+    );
+  });
+
+  it('rewrites meta refresh URLs', () => {
+    const html = '<meta http-equiv="refresh" content="0; url=/login?next=%2Fhome">';
+
+    const result = rewriteHtmlUrls(html, upstream, proxyName);
+
+    expect(result).toBe('<meta http-equiv="refresh" content="0; url=/proxy/chat-uiUrl/login?next=%2Fhome">');
+  });
+
+  it('leaves data, blob, fragment, and third-party absolute HTML URLs untouched', () => {
+    const html = [
+      '<img src="data:image/png;base64,abc">',
+      '<a href="blob:http://localhost:8082/id">blob</a>',
+      '<a href="#section">fragment</a>',
+      '<a href="https://cdn.example.test/app.js">third party</a>',
+      '<img srcset="data:image/png;base64,abc 1x, https://cdn.example.test/img.png 2x">',
+    ].join('');
+
+    const result = rewriteHtmlUrls(html, upstream, proxyName);
+
+    expect(result).toBe(html);
+  });
+
   it('handles upstream URLs with special regex characters in origin', () => {
     // Port with special chars in path shouldn't break regex
     const html = '<a href="http://localhost:8082/path?q=1">Link</a>';
     const result = rewriteHtmlUrls(html, upstream, proxyName);
     expect(result).toContain('/proxy/chat-uiUrl/path?q=1');
+  });
+
+  it('keeps launcher-looking static links under the proxy prefix and documents proxy route gaps', () => {
+    const html = [
+      '<a href="/api/config">launcher api</a>',
+      '<form action="/proxy/_register" method="post"></form>',
+      '<img src="/ws-token-pixel.png">',
+    ].join('');
+
+    const result = rewriteHtmlUrls(html, upstream, proxyName);
+
+    expect(result).toContain('href="/proxy/chat-uiUrl/api/config"');
+    expect(result).toContain('action="/proxy/_register"');
+    expect(result).toContain('src="/proxy/chat-uiUrl/ws-token-pixel.png"');
+    expect(result).not.toContain('href="/api/config"');
+  });
+
+  it('documents the current hostile-script gap for launcher APIs and service workers', () => {
+    const html = [
+      '<script>fetch("/api/config")</script>',
+      '<script>navigator.serviceWorker.register("/sw.js")</script>',
+    ].join('');
+
+    const result = rewriteHtmlUrls(html, upstream, proxyName);
+
+    expect(result).toContain('fetch("/api/config")');
+    expect(result).toContain('navigator.serviceWorker.register("/sw.js")');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4 CSS and meta refresh helpers
+// ---------------------------------------------------------------------------
+
+describe('Phase 4 static rewriting helpers', () => {
+  const upstream = 'http://localhost:8082';
+  const proxyName = 'chat-uiUrl';
+
+  it('rewrites meta refresh helper output directly', () => {
+    expect(
+      rewriteMetaRefresh("<meta content='5; url=http://localhost:8082/next' http-equiv='refresh'>", upstream, proxyName)
+    ).toBe("<meta content='5; url=/proxy/chat-uiUrl/next' http-equiv='refresh'>");
+  });
+
+  it('rewrites CSS url() values with single, double, and unquoted syntax', () => {
+    const css = [
+      '.a{background:url("/a.png")}',
+      ".b{background:url('http://localhost:8082/b.png')}",
+      '.c{background:url(//localhost:8082/c.png)}',
+    ].join('\n');
+
+    const result = rewriteCssUrls(css, upstream, proxyName);
+
+    expect(result).toContain('url("/proxy/chat-uiUrl/a.png")');
+    expect(result).toContain("url('/proxy/chat-uiUrl/b.png')");
+    expect(result).toContain('url(/proxy/chat-uiUrl/c.png)');
+  });
+
+  it('leaves CSS data, blob, fragment, and third-party absolute URLs untouched', () => {
+    const css = [
+      '.a{background:url(data:image/png;base64,abc)}',
+      '.b{background:url("blob:http://localhost:8082/id")}',
+      ".c{mask:url('#icon')}",
+      '.d{background:url(https://cdn.example.test/img.png)}',
+    ].join('\n');
+
+    expect(rewriteCssUrls(css, upstream, proxyName)).toBe(css);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 5 runtime compatibility shim helpers
+// ---------------------------------------------------------------------------
+
+describe('Phase 5 runtime compatibility shims', () => {
+  const upstream = 'http://localhost:8082';
+  const currentHref = 'http://launcher.test/proxy/chat-uiUrl/app/page.html?view=1#top';
+
+  it('defaults expanded runtime URL rewriting to trusted-internal entries only', () => {
+    expect(getProxyRuntimePolicy('trusted-internal')).toEqual({
+      version: 1,
+      expandedRuntimeUrls: true,
+      blockServiceWorkerRegistration: false,
+    });
+    expect(getProxyRuntimePolicy('dynamic')).toEqual({
+      version: 1,
+      expandedRuntimeUrls: false,
+      blockServiceWorkerRegistration: true,
+    });
+  });
+
+  it('allows expanded dynamic runtime shims only behind an explicit gate', () => {
+    process.env['OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS'] = '1';
+
+    expect(getProxyRuntimePolicy('dynamic')).toMatchObject({
+      expandedRuntimeUrls: true,
+      blockServiceWorkerRegistration: true,
+    });
+
+    process.env['OMNI_PROXY_RUNTIME_SHIMS'] = '0';
+    expect(getProxyRuntimePolicy('dynamic').expandedRuntimeUrls).toBe(false);
+  });
+
+  it('rewrites same-upstream and root-relative runtime URLs through the active proxy prefix', () => {
+    expect(rewriteProxyRuntimeUrl('http://localhost:8082/api/data?q=1', currentHref, upstream, 'chat-uiUrl')).toBe(
+      'http://launcher.test/proxy/chat-uiUrl/api/data?q=1'
+    );
+    expect(rewriteProxyRuntimeUrl('/api/config', currentHref, upstream, 'chat-uiUrl')).toBe(
+      'http://launcher.test/proxy/chat-uiUrl/api/config'
+    );
+    expect(rewriteProxyRuntimeUrl('/ws', currentHref, upstream, 'chat-uiUrl', 'websocket')).toBe(
+      'ws://launcher.test/proxy/chat-uiUrl/ws'
+    );
+  });
+
+  it('does not rewrite third-party absolute runtime URLs', () => {
+    expect(rewriteProxyRuntimeUrl('https://cdn.example.test/app.js', currentHref, upstream, 'chat-uiUrl')).toBe(
+      'https://cdn.example.test/app.js'
+    );
+    expect(
+      rewriteProxyRuntimeUrl('wss://socket.example.test/ws', currentHref, upstream, 'chat-uiUrl', 'websocket')
+    ).toBe('wss://socket.example.test/ws');
+  });
+
+  it('keeps launcher API and unrelated proxy paths under the active proxy prefix', () => {
+    expect(rewriteProxyRuntimeUrl('/proxy/_register', currentHref, upstream, 'chat-uiUrl')).toBe(
+      'http://launcher.test/proxy/chat-uiUrl/proxy/_register'
+    );
+    expect(rewriteProxyRuntimeUrl('/proxy/other/private', currentHref, upstream, 'chat-uiUrl')).toBe(
+      'http://launcher.test/proxy/chat-uiUrl/proxy/other/private'
+    );
+  });
+
+  it('handles relative WebSocket URLs with the current proxied page URL as base', () => {
+    expect(rewriteProxyRuntimeUrl('../socket', currentHref, upstream, 'chat-uiUrl', 'websocket')).toBe(
+      'ws://launcher.test/proxy/chat-uiUrl/socket'
+    );
+    expect(rewriteProxyRuntimeUrl('ws://localhost:8082/live', currentHref, upstream, 'chat-uiUrl', 'websocket')).toBe(
+      'ws://launcher.test/proxy/chat-uiUrl/live'
+    );
+  });
+
+  it('generates a versioned shim with URL hooks and service worker policy controls', () => {
+    const shim = buildProxyRuntimeShim({
+      proxyName: 'dyn-abc',
+      upstream: 'https://docs.example.test',
+      policy: { version: 1, expandedRuntimeUrls: true, blockServiceWorkerRegistration: true },
+    });
+
+    expect(shim).toContain('data-omni-proxy-runtime-shim="1"');
+    expect(shim).toContain('"proxyName":"dyn-abc"');
+    expect(shim).toContain('"expandedRuntimeUrls":true');
+    expect(shim).toContain('new URL(input, location.href)');
+    expect(shim).toContain('window.fetch=function');
+    expect(shim).toContain('XMLHttpRequest.prototype.open');
+    expect(shim).toContain('window.WebSocket=function');
+    expect(shim).toContain('window.Worker=function');
+    expect(shim).toContain('navigator.serviceWorker.register=function');
+    expect(shim).toContain('__preview_navigate__');
+  });
+
+  it('injects trusted-internal pages with expanded runtime shims and dynamic pages with blocked service workers', async () => {
+    const app = await createProxyTestServer(() => true);
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation(
+          () => new Response('<html><head></head><body>ok</body></html>', { headers: { 'content-type': 'text/html' } })
+        )
+    );
+    registerProxyUpstream('chat-uiUrl', upstream);
+
+    try {
+      const trusted = await app.inject({ method: 'GET', url: '/proxy/chat-uiUrl/app' });
+      expect(trusted.body).toContain('data-omni-proxy-runtime-shim="1"');
+      expect(trusted.body).toContain('"proxyName":"chat-uiUrl"');
+      expect(trusted.body).toContain('"expandedRuntimeUrls":true');
+      expect(trusted.body).toContain('"blockServiceWorkerRegistration":false');
+
+      const registration = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        payload: { upstream: 'https://docs.example.test/app' },
+      });
+      const { proxyPath, proxyName } = registration.json() as { proxyPath: string; proxyName: string };
+      const dynamic = await app.inject({ method: 'GET', url: proxyPath });
+
+      expect(dynamic.body).toContain(`"proxyName":"${proxyName}"`);
+      expect(dynamic.body).toContain('"expandedRuntimeUrls":false');
+      expect(dynamic.body).toContain('"blockServiceWorkerRegistration":true');
+      expect(dynamic.body).toContain('navigator.serviceWorker.register=function');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 response/request helpers
+// ---------------------------------------------------------------------------
+
+describe('Phase 3 proxy helpers', () => {
+  it('rewrites same-upstream Location headers under the active proxy prefix', () => {
+    expect(rewriteLocationHeader('/next?ok=1#done', 'https://docs.example.test', 'dyn-abc')).toBe(
+      '/proxy/dyn-abc/next?ok=1#done'
+    );
+    expect(rewriteLocationHeader('https://docs.example.test/next', 'https://docs.example.test', 'dyn-abc')).toBe(
+      '/proxy/dyn-abc/next'
+    );
+  });
+
+  it('leaves cross-origin Location headers absolute and intentional', () => {
+    expect(rewriteLocationHeader('https://login.example.test/oauth', 'https://docs.example.test', 'dyn-abc')).toBe(
+      'https://login.example.test/oauth'
+    );
+  });
+
+  it('rewrites Set-Cookie Path and Domain while preserving safe attributes', () => {
+    expect(
+      rewriteSetCookieHeader(
+        'sid=abc; Domain=docs.example.test; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=60',
+        'dyn-abc'
+      )
+    ).toBe('sid=abc; Path=/proxy/dyn-abc; HttpOnly; Secure; SameSite=Lax; Max-Age=60');
+  });
+
+  it('drops invalid SameSite values during Set-Cookie rewriting', () => {
+    expect(rewriteSetCookieHeader('sid=abc; SameSite=Unexpected; HttpOnly', 'dyn-abc')).toBe(
+      'sid=abc; Path=/proxy/dyn-abc; HttpOnly'
+    );
+  });
+
+  it('redacts sensitive query parameters from log URLs', () => {
+    expect(redactProxyUrlForLog('https://docs.example.test/path?token=abc&mode=read&api_key=secret#section')).toBe(
+      'https://docs.example.test/path?token=%5BREDACTED%5D&mode=read&api_key=%5BREDACTED%5D#section'
+    );
+    expect(redactProxyUrlForLog('/proxy/name/path?code=abc&tab=1')).toBe('/proxy/name/path?code=%5BREDACTED%5D&tab=1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 HTTP proxy semantics
+// ---------------------------------------------------------------------------
+
+describe('Phase 3 HTTP proxy semantics', () => {
+  it('preserves method, query string, body, content type, and normalized upstream headers', async () => {
+    const app = await createProxyTestServer(() => true);
+    const fetchMock = vi.fn().mockResolvedValue(new Response('created', { status: 201 }));
+    vi.stubGlobal('fetch', fetchMock);
+    registerProxyUpstream('docs', 'https://docs.example.test');
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/proxy/docs/forms/submit?token=abc&mode=edit',
+        headers: {
+          'content-type': 'application/json',
+          connection: 'keep-alive, x-drop-me',
+          'x-drop-me': 'remove-this',
+          'x-keep-me': 'keep-this',
+          host: 'launcher.example.test',
+          origin: 'https://launcher.example.test',
+          referer: 'https://launcher.example.test/proxy/docs/forms/start?step=1',
+        },
+        payload: JSON.stringify({ hello: 'world' }),
+      });
+
+      expect(response.statusCode).toBe(201);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://docs.example.test/forms/submit?token=abc&mode=edit',
+        expect.objectContaining({
+          method: 'POST',
+          redirect: 'manual',
+          body: expect.any(Buffer),
+          duplex: 'half',
+        })
+      );
+      const init = fetchMock.mock.calls[0]![1] as RequestInit & { headers: Record<string, string> };
+      expect(Buffer.isBuffer(init.body)).toBe(true);
+      expect(Buffer.from(init.body as Buffer).toString()).toBe('{"hello":"world"}');
+      expect(init.headers['content-type']).toContain('application/json');
+      expect(init.headers.host).toBe('docs.example.test');
+      expect(init.headers.origin).toBe('https://docs.example.test');
+      expect(init.headers.referer).toBe('https://docs.example.test/forms/start?step=1');
+      expect(init.headers['x-keep-me']).toBe('keep-this');
+      expect(init.headers.connection).toBeUndefined();
+      expect(init.headers['x-drop-me']).toBeUndefined();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rewrites redirect Location and Set-Cookie response headers', async () => {
+    const app = await createProxyTestServer(() => true);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: [
+            ['location', '/after-login?ok=1'],
+            ['set-cookie', 'sid=abc; Domain=docs.example.test; Path=/; HttpOnly; Secure; SameSite=None'],
+            ['set-cookie', 'pref=light; Path=/settings; SameSite=Lax'],
+          ],
+        })
+      )
+    );
+    registerProxyUpstream('docs', 'https://docs.example.test');
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/proxy/docs/login' });
+
+      expect(response.statusCode).toBe(302);
+      expect(response.headers.location).toBe('/proxy/docs/after-login?ok=1');
+      expect(response.cookies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'sid', path: '/proxy/docs', httpOnly: true, secure: true, sameSite: 'None' }),
+          expect.objectContaining({ name: 'pref', path: '/proxy/docs', sameSite: 'Lax' }),
+        ])
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('leaves cross-origin redirects absolute', async () => {
+    const app = await createProxyTestServer(() => true);
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(null, { status: 302, headers: { location: 'https://login.example.test/oauth' } })
+        )
+    );
+    registerProxyUpstream('docs', 'https://docs.example.test');
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/proxy/docs/login' });
+
+      expect(response.statusCode).toBe(302);
+      expect(response.headers.location).toBe('https://login.example.test/oauth');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('streams non-HTML response bodies without using arrayBuffer', async () => {
+    const app = await createProxyTestServer(() => true);
+    const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(new Uint8Array([0, 1, 2, 255]), { headers: { 'content-type': 'application/octet-stream' } })
+        )
+    );
+    registerProxyUpstream('docs', 'https://docs.example.test');
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/proxy/docs/blob.bin' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.rawPayload).toEqual(Buffer.from([0, 1, 2, 255]));
+      expect(arrayBufferSpy).not.toHaveBeenCalled();
+    } finally {
+      arrayBufferSpy.mockRestore();
+      await app.close();
+    }
+  });
+
+  it('rewrites CSS responses only when content-type is text/css', async () => {
+    const app = await createProxyTestServer(() => true);
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('.hero{background:url(/hero.png)}', { headers: { 'content-type': 'text/css' } })
+        )
+    );
+    registerProxyUpstream('docs', 'https://docs.example.test');
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/proxy/docs/app.css' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBe('.hero{background:url(/proxy/docs/hero.png)}');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /proxy/_register current-state security contract
+// ---------------------------------------------------------------------------
+
+describe('/proxy/_register dynamic capabilities', () => {
+  it('rejects registration when the caller is outside the trusted network', async () => {
+    const app = await createProxyTestServer(() => false);
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        payload: { name: 'blocked', upstream: 'https://example.com/path' },
+      });
+
+      expect(response.statusCode).toBe(403);
+      expect(response.json()).toEqual({ error: 'Forbidden: caller not in trusted network' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('mints an opaque proxy name and preserves the initial path and query', async () => {
+    const app = await createProxyTestServer(() => true);
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        payload: { upstream: 'https://docs.example.test/guide?q=proxy#section' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json() as { ok: true; proxyName: string; proxyPath: string; expiresAt: number };
+      expect(body.ok).toBe(true);
+      expect(body.proxyName).toMatch(/^dyn-[a-f0-9]{32}$/);
+      expect(body.proxyPath).toBe(`/proxy/${body.proxyName}/guide?q=proxy`);
+      expect(body.expiresAt).toBeGreaterThan(Date.now());
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('ignores renderer-supplied names for dynamic registrations', async () => {
+    const app = await createProxyTestServer(() => true);
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        payload: { name: 'renderer-controlled', upstream: 'https://example.test/' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json() as { proxyName: string; proxyPath: string };
+      expect(body.proxyName).not.toBe('renderer-controlled');
+      expect(body.proxyPath).not.toBe('/proxy/renderer-controlled/');
+      expect(body.proxyPath).toBe(`/proxy/${body.proxyName}/`);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps the current operator escape hatch for untrusted callers', async () => {
+    process.env['OMNI_ALLOW_EXTERNAL_REGISTER'] = '1';
+    const app = await createProxyTestServer(() => false);
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        payload: { upstream: 'https://example.test/' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json() as { proxyName: string; proxyPath: string };
+      expect(body.proxyName).toMatch(/^dyn-[a-f0-9]{32}$/);
+      expect(body.proxyPath).toBe(`/proxy/${body.proxyName}/`);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('rejects non-HTTP URL schemes', async () => {
+    const app = await createProxyTestServer(() => true);
+
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        payload: { name: 'file-gap', upstream: 'file:///etc/passwd' },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({ error: 'Invalid upstream URL: expected http(s)' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('allows access to a minted proxy capability', async () => {
+    const app = await createProxyTestServer(() => true);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('proxied ok', { headers: { 'content-type': 'text/plain' } }))
+    );
+
+    try {
+      const register = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        payload: { upstream: 'https://docs.example.test/guide?q=proxy' },
+      });
+      const body = register.json() as { proxyPath: string };
+
+      const proxied = await app.inject({ method: 'GET', url: body.proxyPath });
+
+      expect(proxied.statusCode).toBe(200);
+      expect(proxied.body).toBe('proxied ok');
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        'https://docs.example.test/guide?q=proxy',
+        expect.objectContaining({ method: 'GET' })
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('checks EasyAuth owner metadata before serving dynamic proxy capabilities', async () => {
+    process.env['OMNI_AUTH_MODE'] = 'easyauth';
+    const app = await createProxyTestServer(() => true);
+
+    try {
+      const register = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        headers: { 'x-ms-client-principal-id': 'alice' },
+        payload: { upstream: 'https://docs.example.test/' },
+      });
+      const body = register.json() as { proxyPath: string };
+
+      const missingPrincipal = await app.inject({ method: 'GET', url: body.proxyPath });
+      const wrongPrincipal = await app.inject({
+        method: 'GET',
+        url: body.proxyPath,
+        headers: { 'x-ms-client-principal-id': 'bob' },
+      });
+
+      expect(missingPrincipal.statusCode).toBe(401);
+      expect(wrongPrincipal.statusCode).toBe(403);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('cleans up expired dynamic registrations deterministically', async () => {
+    const app = await createProxyTestServer(() => true);
+
+    try {
+      const register = await app.inject({
+        method: 'POST',
+        url: '/proxy/_register',
+        payload: { upstream: 'https://docs.example.test/' },
+      });
+      const body = register.json() as { proxyPath: string; expiresAt: number };
+
+      expect(cleanupExpiredProxyRegistrations(body.expiresAt + 1)).toBe(1);
+      const proxied = await app.inject({ method: 'GET', url: body.proxyPath });
+
+      expect(proxied.statusCode).toBe(502);
+      expect(proxied.json()).toEqual({ error: expect.stringContaining('No upstream registered') });
+    } finally {
+      await app.close();
+    }
   });
 });
 
@@ -150,6 +820,30 @@ describe('rewriteHtmlUrls', () => {
 // ---------------------------------------------------------------------------
 
 describe('rewriteStatusUrls', () => {
+  it('keeps trusted internal status registrations named and owner-independent', async () => {
+    process.env['OMNI_AUTH_MODE'] = 'easyauth';
+    const app = await createProxyTestServer(() => true);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('internal ok', { headers: { 'content-type': 'text/plain' } }))
+    );
+
+    try {
+      const data: Record<string, string | undefined> = {
+        uiUrl: 'http://localhost:8082/app',
+      };
+      rewriteStatusUrls(data, 'chat');
+
+      expect(data.uiUrl).toBe('/proxy/chat-uiUrl/app');
+      const proxied = await app.inject({ method: 'GET', url: data.uiUrl });
+
+      expect(proxied.statusCode).toBe(200);
+      expect(proxied.body).toBe('internal ok');
+    } finally {
+      await app.close();
+    }
+  });
+
   it('rewrites uiUrl to proxy path', () => {
     const data: Record<string, string | undefined> = {
       uiUrl: 'http://localhost:8082/app',

--- a/src/server/proxy-rewriter.ts
+++ b/src/server/proxy-rewriter.ts
@@ -1,10 +1,48 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { Readable } from 'node:stream';
 import { WebSocket as WsWebSocket } from 'ws';
 
 import type { WsHandler } from '@/server/ws-handler';
 
-/** Map from proxy prefix (e.g. "chat-uiUrl") to upstream origin (e.g. "http://localhost:8082") */
-const upstreamMap = new Map<string, string>();
+const DYNAMIC_PROXY_TTL_MS = 30 * 60 * 1000;
+const REDACTED_QUERY_VALUE = '[REDACTED]';
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+const SENSITIVE_QUERY_PARAM_RE = /(?:^|[-_])(token|secret|password|passwd|key|auth|code|sig|signature)(?:$|[-_])/i;
+const HTML_URL_ATTR_RE =
+  /(\s(?:href|src|action|formaction|poster|data|srcset)\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/gi;
+const META_ATTR_RE = /(\s(?:http-equiv|content)\s*=\s*)(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/gi;
+const CSS_URL_RE = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)'"\s][^)]*?))\s*\)/gi;
+const SKIPPED_STATIC_URL_RE = /^(?:$|#|data:|blob:|javascript:|mailto:|tel:|about:)/i;
+const PROXY_RUNTIME_SHIM_VERSION = 1;
+
+export type ProxySiteClass = 'trusted-internal' | 'dynamic';
+
+export type ProxyRuntimePolicy = {
+  version: typeof PROXY_RUNTIME_SHIM_VERSION;
+  expandedRuntimeUrls: boolean;
+  blockServiceWorkerRegistration: boolean;
+};
+
+type ProxyEntry = {
+  upstream: string;
+  kind: ProxySiteClass;
+  ownerKey?: string;
+  createdAt: number;
+  lastUsedAt: number;
+  expiresAt?: number;
+};
+
+/** Map from proxy prefix (e.g. "chat-uiUrl") to upstream metadata. */
+const upstreamMap = new Map<string, ProxyEntry>();
 
 /** Default allowlist when none is supplied: loopback only. */
 const defaultIsTrusted = (addr: string): boolean => {
@@ -18,8 +56,97 @@ const defaultIsTrusted = (addr: string): boolean => {
  * Used by the preview system to dynamically route arbitrary URLs through the proxy.
  */
 export const registerProxyUpstream = (proxyName: string, upstreamOrigin: string): string => {
-  upstreamMap.set(proxyName, upstreamOrigin);
+  const now = Date.now();
+  upstreamMap.set(proxyName, {
+    upstream: upstreamOrigin,
+    kind: 'trusted-internal',
+    createdAt: now,
+    lastUsedAt: now,
+  });
   return `/proxy/${proxyName}/`;
+};
+
+export const cleanupExpiredProxyRegistrations = (now: number = Date.now()): number => {
+  let deleted = 0;
+  for (const [proxyName, entry] of upstreamMap.entries()) {
+    if (entry.kind === 'dynamic' && entry.expiresAt !== undefined && entry.expiresAt <= now) {
+      upstreamMap.delete(proxyName);
+      deleted += 1;
+    }
+  }
+  return deleted;
+};
+
+export const resetProxyRegistrationsForTests = (): void => {
+  upstreamMap.clear();
+};
+
+const isTruthyEnv = (value: string | undefined): boolean => /^(1|true|yes|on)$/i.test(value ?? '');
+const isFalsyEnv = (value: string | undefined): boolean => /^(0|false|no|off)$/i.test(value ?? '');
+
+export const getProxyRuntimePolicy = (siteClass: ProxySiteClass): ProxyRuntimePolicy => {
+  const runtimeEnv = process.env['OMNI_PROXY_RUNTIME_SHIMS'];
+  const dynamicRuntimeEnv = process.env['OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS'];
+  const expandedRuntimeUrls =
+    !isFalsyEnv(runtimeEnv) &&
+    (siteClass === 'trusted-internal' || isTruthyEnv(dynamicRuntimeEnv) || isTruthyEnv(runtimeEnv));
+
+  return {
+    version: PROXY_RUNTIME_SHIM_VERSION,
+    expandedRuntimeUrls,
+    blockServiceWorkerRegistration: siteClass !== 'trusted-internal',
+  };
+};
+
+const ownerKeyForRequest = (request: FastifyRequest): string | null => {
+  if ((process.env['OMNI_AUTH_MODE'] ?? '') !== 'easyauth') {
+    return 'local-single-tenant';
+  }
+  const principalId = request.headers['x-ms-client-principal-id'];
+  return typeof principalId === 'string' && principalId.trim() ? `principal:${principalId.trim()}` : null;
+};
+
+const mintDynamicProxyName = (): string => `dyn-${crypto.randomUUID().replace(/-/g, '')}`;
+
+const parseHttpUpstream = (upstream: string | undefined): URL | null => {
+  if (!upstream || upstream.length > 4096) {
+    return null;
+  }
+  try {
+    const parsed = new URL(upstream);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const getProxyEntry = (
+  request: FastifyRequest,
+  proxyName: string
+): ProxyEntry | null | 'forbidden' | 'unauthorized' => {
+  const entry = upstreamMap.get(proxyName);
+  if (!entry) {
+    return null;
+  }
+  const now = Date.now();
+  if (entry.kind === 'dynamic' && entry.expiresAt !== undefined && entry.expiresAt <= now) {
+    upstreamMap.delete(proxyName);
+    return null;
+  }
+  if (entry.kind === 'dynamic') {
+    const ownerKey = ownerKeyForRequest(request);
+    if (!ownerKey) {
+      return 'unauthorized';
+    }
+    if (entry.ownerKey !== ownerKey) {
+      return 'forbidden';
+    }
+  }
+  entry.lastUsedAt = now;
+  if (entry.kind === 'dynamic') {
+    entry.expiresAt = now + DYNAMIC_PROXY_TTL_MS;
+  }
+  return entry;
 };
 
 /**
@@ -33,11 +160,16 @@ export const registerProxyUpstream = (proxyName: string, upstreamOrigin: string)
 export const setupProxyRewriter = (
   fastify: FastifyInstance,
   wsHandler: WsHandler,
-  isTrusted: (remoteAddress: string) => boolean = defaultIsTrusted,
+  isTrusted: (remoteAddress: string) => boolean = defaultIsTrusted
 ): void => {
   // --- Combined HTTP + WebSocket proxy ---
   // Register inside a plugin so GET can handle both HTTP and WS upgrades on the same path.
   void fastify.register(async function proxyRoutes(f) {
+    f.removeAllContentTypeParsers();
+    f.addContentTypeParser('*', { parseAs: 'buffer' }, (_request, body, done) => {
+      done(null, body);
+    });
+
     // GET handles both normal HTTP GET and WebSocket upgrades via full declaration syntax
     f.route({
       method: 'GET',
@@ -46,7 +178,7 @@ export const setupProxyRewriter = (
         return handleHttpProxy(request, reply);
       },
       wsHandler: (clientSocket, request) => {
-        const upstreamPath = `/${  (request.params as { '*': string })['*']}`;
+        const upstreamPath = `/${(request.params as { '*': string })['*']}`;
         handleWsProxy(clientSocket, request, upstreamPath);
       },
     });
@@ -77,20 +209,31 @@ export const setupProxyRewriter = (
       }
     },
     handler: async (request, reply) => {
-      const { name, upstream } = request.body as { name?: string; upstream?: string };
-      if (!name || !upstream) {
-        reply.code(400).send({ error: 'Missing name or upstream' });
+      cleanupExpiredProxyRegistrations();
+      const { upstream } = request.body as { name?: string; upstream?: string };
+      const ownerKey = ownerKeyForRequest(request);
+      if (!ownerKey) {
+        reply.code(401).send({ error: 'Unauthorized: missing authenticated principal' });
         return;
       }
-      try {
-        const parsed = new URL(upstream);
-        const origin = `${parsed.protocol}//${parsed.host}`;
-        upstreamMap.set(name, origin);
-        const proxyPath = `/proxy/${name}${parsed.pathname}${parsed.search}`;
-        reply.send({ ok: true, proxyPath });
-      } catch {
-        reply.code(400).send({ error: 'Invalid upstream URL' });
+      const parsed = parseHttpUpstream(upstream);
+      if (!parsed) {
+        reply.code(400).send({ error: 'Invalid upstream URL: expected http(s)' });
+        return;
       }
+      const now = Date.now();
+      const proxyName = mintDynamicProxyName();
+      const origin = `${parsed.protocol}//${parsed.host}`;
+      upstreamMap.set(proxyName, {
+        upstream: origin,
+        kind: 'dynamic',
+        ownerKey,
+        createdAt: now,
+        lastUsedAt: now,
+        expiresAt: now + DYNAMIC_PROXY_TTL_MS,
+      });
+      const proxyPath = `/proxy/${proxyName}${parsed.pathname}${parsed.search}`;
+      reply.send({ ok: true, proxyName, proxyPath, expiresAt: now + DYNAMIC_PROXY_TTL_MS });
     },
   });
 
@@ -143,54 +286,209 @@ export const setupProxyRewriter = (
 };
 
 /**
- * Rewrite URLs in HTML **attributes only** so that absolute and root-relative
+ * Rewrite URLs in HTML attributes only so static same-upstream and root-relative
  * URLs go through the proxy. Avoids touching inline JS/JSON which would break pages.
- *
- * Targets: href, src, action, formaction, poster, data, srcset attributes.
  */
 export function rewriteHtmlUrls(html: string, upstream: string, proxyName: string): string {
-  const proxyPrefix = `/proxy/${proxyName}`;
-
-  let upstreamHost = '';
-  try {
- upstreamHost = new URL(upstream).host; 
-} catch { /* skip */ }
-
-  // Single regex: match URL-bearing HTML attributes whose value starts with
-  // the upstream origin, a protocol-relative //host, or a root-relative /path.
-  // The regex captures (attribute-prefix + opening-quote + url-start).
-  const attrNames = 'href|src|action|formaction|poster|data|srcset';
-
-  // 1. Absolute upstream URLs in attributes:  href="https://upstream/path" → href="/proxy/name/path"
-  if (upstream) {
-    const absRe = new RegExp(
-      `((?:${attrNames})\\s*=\\s*["'])${escapeForRegex(upstream)}`,
-      'gi',
-    );
-    html = html.replace(absRe, `$1${proxyPrefix}`);
-  }
-
-  // 2. Protocol-relative URLs in attributes:  src="//host/path" → src="/proxy/name/path"
-  if (upstreamHost) {
-    const protoRelRe = new RegExp(
-      `((?:${attrNames})\\s*=\\s*["'])//${escapeForRegex(upstreamHost)}`,
-      'gi',
-    );
-    html = html.replace(protoRelRe, `$1${proxyPrefix}`);
-  }
-
-  // 3. Root-relative URLs in attributes:  action="/path" → action="/proxy/name/path"
-  //    Skips values already starting with /proxy/ or // (protocol-relative)
   html = html.replace(
-    new RegExp(`((?:${attrNames})\\s*=\\s*["'])\\/(?!\\/|proxy\\/)`, 'gi'),
-    `$1${proxyPrefix}/`,
+    HTML_URL_ATTR_RE,
+    (match, prefix: string, doubleValue?: string, singleValue?: string, bareValue?: string) => {
+      const value = doubleValue ?? singleValue ?? bareValue ?? '';
+      const attrName = prefix.match(/\s([^\s=]+)\s*=/)?.[1]?.toLowerCase();
+      const rewritten =
+        attrName === 'srcset'
+          ? rewriteSrcset(value, upstream, proxyName)
+          : rewriteStaticUrl(value, upstream, proxyName);
+
+      if (doubleValue !== undefined) {
+        return `${prefix}"${rewritten}"`;
+      }
+      if (singleValue !== undefined) {
+        return `${prefix}'${rewritten}'`;
+      }
+      return `${prefix}${rewritten}`;
+    }
   );
 
-  // 4. Strip CSP <meta> tags — we already strip the HTTP header, but inline CSP
-  //    blocks our injected scripts (console capture, navigation, etc.)
+  html = rewriteMetaRefresh(html, upstream, proxyName);
+
+  // Strip CSP <meta> tags — we already strip the HTTP header, but inline CSP
+  // blocks our injected scripts (console capture, navigation, etc.)
   html = html.replace(/<meta[^>]*http-equiv\s*=\s*["']Content-Security-Policy["'][^>]*>/gi, '');
 
   return html;
+}
+
+export function rewriteMetaRefresh(html: string, upstream: string, proxyName: string): string {
+  return html.replace(/<meta\b[^>]*>/gi, (tag) => {
+    const attrs = parseMetaAttrs(tag);
+    if (attrs['http-equiv']?.toLowerCase() !== 'refresh' || !attrs.content) {
+      return tag;
+    }
+    return tag.replace(
+      META_ATTR_RE,
+      (match, prefix: string, doubleValue?: string, singleValue?: string, bareValue?: string) => {
+        const attrName = prefix.match(/\s([^\s=]+)\s*=/)?.[1]?.toLowerCase();
+        if (attrName !== 'content') {
+          return match;
+        }
+        const value = doubleValue ?? singleValue ?? bareValue ?? '';
+        const rewritten = rewriteMetaRefreshContent(value, upstream, proxyName);
+        if (doubleValue !== undefined) {
+          return `${prefix}"${rewritten}"`;
+        }
+        if (singleValue !== undefined) {
+          return `${prefix}'${rewritten}'`;
+        }
+        return `${prefix}${rewritten}`;
+      }
+    );
+  });
+}
+
+export function rewriteCssUrls(css: string, upstream: string, proxyName: string): string {
+  return css.replace(CSS_URL_RE, (match, doubleValue?: string, singleValue?: string, bareValue?: string) => {
+    const value = (doubleValue ?? singleValue ?? bareValue ?? '').trim();
+    const rewritten = rewriteStaticUrl(value, upstream, proxyName);
+    if (doubleValue !== undefined) {
+      return `url("${rewritten}")`;
+    }
+    if (singleValue !== undefined) {
+      return `url('${rewritten}')`;
+    }
+    return `url(${rewritten})`;
+  });
+}
+
+function parseMetaAttrs(tag: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const match of tag.matchAll(META_ATTR_RE)) {
+    const name = match[1]?.match(/\s([^\s=]+)\s*=/)?.[1]?.toLowerCase();
+    if (name) {
+      attrs[name] = match[2] ?? match[3] ?? match[4] ?? '';
+    }
+  }
+  return attrs;
+}
+
+function rewriteMetaRefreshContent(content: string, upstream: string, proxyName: string): string {
+  return content.replace(/(\burl\s*=\s*)(['"]?)([^'";\s]+)\2/i, (match, prefix: string, quote: string, url: string) => {
+    const rewritten = rewriteStaticUrl(url, upstream, proxyName);
+    return `${prefix}${quote}${rewritten}${quote}`;
+  });
+}
+
+function rewriteSrcset(srcset: string, upstream: string, proxyName: string): string {
+  return srcset
+    .split(',')
+    .map((candidate) => {
+      const match = candidate.match(/^(\s*)(\S+)(.*)$/s);
+      if (!match) {
+        return candidate;
+      }
+      const [, leading = '', url = '', descriptor = ''] = match;
+      return `${leading}${rewriteStaticUrl(url, upstream, proxyName)}${descriptor}`;
+    })
+    .join(',');
+}
+
+function rewriteStaticUrl(url: string, upstream: string, proxyName: string): string {
+  if (SKIPPED_STATIC_URL_RE.test(url) || url.startsWith('/proxy/')) {
+    return url;
+  }
+
+  const proxyPrefix = `/proxy/${proxyName}`;
+
+  try {
+    const upstreamUrl = new URL(upstream);
+    if (url.startsWith('/')) {
+      if (url.startsWith('//')) {
+        const protocolRelative = new URL(`${upstreamUrl.protocol}${url}`);
+        if (protocolRelative.host !== upstreamUrl.host) {
+          return url;
+        }
+        return `${proxyPrefix}${protocolRelative.pathname}${protocolRelative.search}${protocolRelative.hash}`;
+      }
+      return `${proxyPrefix}${url}`;
+    }
+
+    const parsed = new URL(url);
+    if (parsed.origin !== upstreamUrl.origin) {
+      return url;
+    }
+    return `${proxyPrefix}${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    if (url.startsWith('/') && !url.startsWith('//')) {
+      return `${proxyPrefix}${url}`;
+    }
+    return url;
+  }
+}
+
+const equivalentWebRuntimeProtocol = (runtimeProtocol: string, upstreamProtocol: string): boolean => {
+  if (runtimeProtocol === upstreamProtocol) {
+    return true;
+  }
+  return (
+    (runtimeProtocol === 'ws:' && upstreamProtocol === 'http:') ||
+    (runtimeProtocol === 'wss:' && upstreamProtocol === 'https:') ||
+    (runtimeProtocol === 'http:' && upstreamProtocol === 'ws:') ||
+    (runtimeProtocol === 'https:' && upstreamProtocol === 'wss:')
+  );
+};
+
+export function rewriteProxyRuntimeUrl(
+  input: string,
+  currentHref: string,
+  upstream: string,
+  proxyName: string,
+  transport: 'http' | 'websocket' = 'http'
+): string {
+  if (SKIPPED_STATIC_URL_RE.test(input)) {
+    return input;
+  }
+
+  try {
+    const locationUrl = new URL(currentHref);
+    const upstreamUrl = new URL(upstream);
+    const runtimeUrl = new URL(input, currentHref);
+    const proxyPrefix = `/proxy/${proxyName}`;
+
+    if (!['http:', 'https:', 'ws:', 'wss:'].includes(runtimeUrl.protocol)) {
+      return input;
+    }
+
+    const alreadyActiveProxy =
+      runtimeUrl.origin === locationUrl.origin &&
+      (runtimeUrl.pathname === proxyPrefix || runtimeUrl.pathname.startsWith(`${proxyPrefix}/`));
+
+    if (alreadyActiveProxy) {
+      const rewritten = new URL(runtimeUrl.toString());
+      if (transport === 'websocket') {
+        rewritten.protocol = locationUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+      }
+      return rewritten.toString();
+    }
+
+    const sameUpstream =
+      runtimeUrl.host === upstreamUrl.host && equivalentWebRuntimeProtocol(runtimeUrl.protocol, upstreamUrl.protocol);
+    const launcherOriginRuntimeUrl = runtimeUrl.origin === locationUrl.origin;
+
+    if (!sameUpstream && !launcherOriginRuntimeUrl) {
+      return input;
+    }
+
+    const rewritten = new URL(locationUrl.origin);
+    if (transport === 'websocket') {
+      rewritten.protocol = locationUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+    }
+    rewritten.pathname = `${proxyPrefix}${runtimeUrl.pathname}`;
+    rewritten.search = runtimeUrl.search;
+    rewritten.hash = runtimeUrl.hash;
+    return rewritten.toString();
+  } catch {
+    return input;
+  }
 }
 
 /** Escape a string for use in a RegExp. */
@@ -198,54 +496,240 @@ export function escapeForRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+export function rewriteLocationHeader(location: string, upstream: string, proxyName: string): string {
+  try {
+    const upstreamUrl = new URL(upstream);
+    const resolved = new URL(location, upstreamUrl);
+    if (resolved.origin !== upstreamUrl.origin) {
+      return resolved.toString();
+    }
+    return `/proxy/${proxyName}${resolved.pathname}${resolved.search}${resolved.hash}`;
+  } catch {
+    return location;
+  }
+}
+
+export function rewriteSetCookieHeader(cookie: string, proxyName: string): string {
+  const parts = cookie
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const [nameValue, ...attributes] = parts;
+  if (!nameValue) {
+    return cookie;
+  }
+
+  const rewritten = [nameValue, `Path=/proxy/${proxyName}`];
+  for (const attribute of attributes) {
+    const [rawName = '', ...rawValueParts] = attribute.split('=');
+    const name = rawName.trim();
+    const lowerName = name.toLowerCase();
+
+    if (lowerName === 'path' || lowerName === 'domain') {
+      continue;
+    }
+    if (lowerName === 'samesite') {
+      const value = rawValueParts.join('=').trim();
+      if (/^(strict|lax|none)$/i.test(value)) {
+        rewritten.push(`${name}=${value}`);
+      }
+      continue;
+    }
+    rewritten.push(attribute);
+  }
+
+  return rewritten.join('; ');
+}
+
+export function redactProxyUrlForLog(url: string): string {
+  try {
+    const isRelative = url.startsWith('/');
+    const parsed = new URL(url, 'http://omni.invalid');
+    for (const key of Array.from(parsed.searchParams.keys())) {
+      if (SENSITIVE_QUERY_PARAM_RE.test(key)) {
+        parsed.searchParams.set(key, REDACTED_QUERY_VALUE);
+      }
+    }
+    if (isRelative) {
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    }
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function isHopByHopHeader(key: string, connectionHeaderNames: Set<string>): boolean {
+  const normalized = key.toLowerCase();
+  return HOP_BY_HOP_HEADERS.has(normalized) || connectionHeaderNames.has(normalized);
+}
+
+function getConnectionHeaderNames(headers: FastifyRequest['headers'] | Headers): Set<string> {
+  const value = headers instanceof Headers ? headers.get('connection') : headers.connection;
+  const values = Array.isArray(value) ? value : value ? [value] : [];
+  return new Set(
+    values
+      .flatMap((headerValue) => String(headerValue).split(','))
+      .map((headerName) => headerName.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+function rewriteRefererHeader(referer: string, upstream: string, proxyName: string): string | undefined {
+  try {
+    const upstreamUrl = new URL(upstream);
+    const parsed = referer.startsWith('/') ? new URL(referer, upstreamUrl) : new URL(referer);
+    const proxyPrefix = `/proxy/${proxyName}`;
+    if (parsed.pathname === proxyPrefix || parsed.pathname.startsWith(`${proxyPrefix}/`)) {
+      const upstreamPath = parsed.pathname.slice(proxyPrefix.length) || '/';
+      return `${upstreamUrl.origin}${upstreamPath}${parsed.search}${parsed.hash}`;
+    }
+    if (parsed.origin === upstreamUrl.origin) {
+      return parsed.toString();
+    }
+  } catch {
+    /* drop invalid referer */
+  }
+  return undefined;
+}
+
+function buildUpstreamHeaders(request: FastifyRequest, upstream: string, proxyName: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const connectionHeaderNames = getConnectionHeaderNames(request.headers);
+  const upstreamUrl = new URL(upstream);
+
+  for (const [key, value] of Object.entries(request.headers)) {
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === 'host' || lowerKey === 'content-length' || isHopByHopHeader(lowerKey, connectionHeaderNames)) {
+      continue;
+    }
+    if (lowerKey === 'origin' || lowerKey === 'referer') {
+      continue;
+    }
+    if (typeof value === 'string') {
+      headers[key] = value;
+    }
+  }
+
+  headers.host = upstreamUrl.host;
+  if (request.headers.origin) {
+    headers.origin = upstreamUrl.origin;
+  }
+  const referer = request.headers.referer;
+  if (typeof referer === 'string') {
+    const rewrittenReferer = rewriteRefererHeader(referer, upstream, proxyName);
+    if (rewrittenReferer) {
+      headers.referer = rewrittenReferer;
+    }
+  }
+
+  return headers;
+}
+
+function splitSetCookieHeader(header: string): string[] {
+  return header.split(/,(?=\s*[^;,\s]+=)/g).map((cookie) => cookie.trim());
+}
+
+function getSetCookieHeaders(headers: Headers): string[] {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] }).getSetCookie;
+  if (getSetCookie) {
+    return getSetCookie.call(headers);
+  }
+  const combined = headers.get('set-cookie');
+  return combined ? splitSetCookieHeader(combined) : [];
+}
+
+async function* readResponseBodyStream(body: ReadableStream<Uint8Array>): AsyncGenerator<Buffer> {
+  const reader = body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return;
+      }
+      if (value) {
+        yield Buffer.from(value);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 /**
  * Proxy an HTTP request to the upstream service.
  */
-async function handleHttpProxy(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+async function handleHttpProxy(request: FastifyRequest, reply: FastifyReply): Promise<FastifyReply | void> {
   const { proxyName } = request.params as { proxyName: string; '*': string };
   const wildcard = (request.params as { '*': string })['*'];
-  const upstream = upstreamMap.get(proxyName);
+  const entry = getProxyEntry(request, proxyName);
 
-  if (!upstream) {
+  if (entry === 'unauthorized') {
+    reply.code(401).send({ error: 'Unauthorized: missing authenticated principal' });
+    return;
+  }
+  if (entry === 'forbidden') {
+    reply.code(403).send({ error: `Forbidden: proxy "${proxyName}" belongs to another session` });
+    return;
+  }
+  if (!entry) {
     reply.code(502).send({ error: `No upstream registered for proxy "${proxyName}"` });
     return;
   }
+  const { upstream } = entry;
 
   const targetUrl = `${upstream}/${wildcard}${request.url.includes('?') ? `?${request.url.split('?')[1]}` : ''}`;
 
   try {
-    const headers: Record<string, string> = {};
-    for (const [key, value] of Object.entries(request.headers)) {
-      if (key === 'host' || key === 'connection') {
-continue;
-}
-      if (typeof value === 'string') {
-headers[key] = value;
-}
-    }
-
-    const response = await globalThis.fetch(targetUrl, {
+    const headers = buildUpstreamHeaders(request, upstream, proxyName);
+    const body =
+      request.method !== 'GET' && request.method !== 'HEAD' ? (request.body as BodyInit | undefined) : undefined;
+    const fetchInit: RequestInit & { duplex?: 'half' } = {
       method: request.method,
       headers,
-      body: request.method !== 'GET' && request.method !== 'HEAD' ? (request.body as BodyInit) : undefined,
-      // @ts-expect-error -- Node fetch supports duplex for streaming
-      duplex: request.method !== 'GET' && request.method !== 'HEAD' ? 'half' : undefined,
-    });
+      body,
+      redirect: 'manual',
+    };
+    if (body !== undefined) {
+      fetchInit.duplex = 'half';
+    }
+
+    const response = await globalThis.fetch(targetUrl, fetchInit);
 
     const contentType = response.headers.get('content-type') ?? '';
-    const isHtml = contentType.includes('text/html');
+    const normalizedContentType = contentType.toLowerCase();
+    const isHtml = normalizedContentType.includes('text/html');
+    const isCss = normalizedContentType.includes('text/css');
 
     reply.status(response.status);
+    const connectionHeaderNames = getConnectionHeaderNames(response.headers);
     for (const [key, value] of response.headers.entries()) {
-      if (key === 'transfer-encoding' || key === 'content-security-policy' || key === 'x-frame-options') {
-continue;
-}
+      const lowerKey = key.toLowerCase();
+      if (isHopByHopHeader(lowerKey, connectionHeaderNames)) {
+        continue;
+      }
+      if (lowerKey === 'content-security-policy' || lowerKey === 'x-frame-options') {
+        continue;
+      }
       // Strip content-encoding and content-length: fetch() auto-decompresses, so the
       // upstream's compressed content-length/encoding no longer match the decompressed body
-      if (key === 'content-encoding' || key === 'content-length') {
-continue;
-}
+      if (lowerKey === 'content-encoding' || lowerKey === 'content-length') {
+        continue;
+      }
+      if (lowerKey === 'location') {
+        reply.header(key, rewriteLocationHeader(value, upstream, proxyName));
+        continue;
+      }
+      if (lowerKey === 'set-cookie') {
+        continue;
+      }
       reply.header(key, value);
+    }
+    const setCookieHeaders = getSetCookieHeaders(response.headers).map((cookie) =>
+      rewriteSetCookieHeader(cookie, proxyName)
+    );
+    if (setCookieHeaders.length > 0) {
+      reply.header('set-cookie', setCookieHeaders);
     }
 
     if (isHtml && response.body) {
@@ -254,9 +738,13 @@ continue;
       // --- Server-side URL rewriting (primary mechanism) ---
       html = rewriteHtmlUrls(html, upstream, proxyName);
 
-      // Inject <base> tag and minimal scripts (console capture, navigation reporting, WS rewriting)
+      // Inject <base> tag and runtime scripts.
       const baseTag = `<base href="/proxy/${proxyName}/">`;
-      const headPayload = `${baseTag}${navigationCapture()}${consoleCapture()}${wsRewriteScript(proxyName)}`;
+      const headPayload = `${baseTag}${buildProxyRuntimeShim({
+        proxyName,
+        upstream,
+        policy: getProxyRuntimePolicy(entry.kind),
+      })}${consoleCapture()}`;
       // Handle <head>, <HEAD>, or missing <head> (lookahead excludes <header>, <heading>, etc.)
       if (/<head(?=[\s>])/i.test(html)) {
         html = html.replace(/<head(?=[\s>])[^>]*>/i, `$&${headPayload}`);
@@ -268,18 +756,20 @@ continue;
 
       // Prevent caching of rewritten HTML
       reply.header('cache-control', 'no-store');
-      reply.send(html);
-      return;
+      return reply.send(html);
+    }
+
+    if (isCss && response.body) {
+      return reply.send(rewriteCssUrls(await response.text(), upstream, proxyName));
     }
 
     if (response.body) {
-      const buffer = Buffer.from(await response.arrayBuffer());
-      reply.send(buffer);
-      return;
+      return reply.send(Readable.from(readResponseBodyStream(response.body as ReadableStream<Uint8Array>)));
     }
-    reply.send();
-  } catch {
-    reply.code(502).send({ error: 'Proxy request failed' });
+    return reply.send();
+  } catch (error) {
+    request.log.error({ err: error, targetUrl: redactProxyUrlForLog(targetUrl) }, 'Proxy request failed');
+    return reply.code(502).send({ error: 'Proxy request failed' });
   }
 }
 
@@ -292,19 +782,28 @@ function handleWsProxy(
   upstreamPath: string
 ): void {
   const proxyName = (request.params as { proxyName: string }).proxyName;
-  const upstream = upstreamMap.get(proxyName);
+  const entry = getProxyEntry(request, proxyName);
 
-  if (!upstream) {
+  if (entry === 'unauthorized') {
+    clientSocket.close(4401, 'Unauthorized');
+    return;
+  }
+  if (entry === 'forbidden') {
+    clientSocket.close(4403, 'Forbidden');
+    return;
+  }
+  if (!entry) {
     clientSocket.close(4502, `No upstream for "${proxyName}"`);
     return;
   }
+  const { upstream } = entry;
 
   // Convert http(s) upstream to ws(s)
   const wsUpstream = upstream.replace(/^http/, 'ws');
   const query = request.url.includes('?') ? `?${request.url.split('?')[1]}` : '';
   const targetUrl = `${wsUpstream}${upstreamPath}${query}`;
 
-  console.log(`[ws-proxy] ${proxyName}: client → upstream ${targetUrl}`);
+  console.log(`[ws-proxy] ${proxyName}: client → upstream ${redactProxyUrlForLog(targetUrl)}`);
   const upstreamSocket = new WsWebSocket(targetUrl, { handshakeTimeout: 10_000 });
 
   // Buffer client messages until upstream is ready
@@ -366,33 +865,24 @@ function handleWsProxy(
   });
 }
 
-/**
- * Generate a <script> tag for lightweight behaviour capture only.
- * URL rewriting is handled server-side by rewriteHtmlUrls() — this script
- * only handles things that can't be done server-side:
- * 1. target="_blank" → _self (keep navigation in-frame)
- * 2. window.open → location.href
- * 3. Navigation change notifications (pushState/replaceState/popstate)
- * 4. Title change notifications
- */
-function navigationCapture(): string {
-  return `<script>(function(){` +
-    // Keep navigation in-frame
-    `document.addEventListener("click",function(e){` +
-    `var a=e.target;while(a&&a.tagName!=="A")a=a.parentElement;` +
-    `if(a&&(a.target==="_blank"||a.target==="_new"))a.target='_self'` +
-    `},true);` +
-    `window.open=function(u){if(u)location.href=u;return window};` +
-    // Notify parent on navigation
-    `function N(){window.parent.postMessage({type:"__preview_navigate__",url:location.href},"*")}` +
-    `var oPS=history.pushState,oRS=history.replaceState;` +
-    `history.pushState=function(){oPS.apply(this,arguments);N()};` +
-    `history.replaceState=function(){oRS.apply(this,arguments);N()};` +
-    `window.addEventListener("popstate",N);window.addEventListener("hashchange",N);` +
-    // Title notifications
-    `function T(){window.parent.postMessage({type:"__preview_title__",title:document.title},"*")}` +
-    `new MutationObserver(T).observe(document.querySelector("title")||document.head,{childList:true,subtree:true,characterData:true});T()` +
-    `})()</script>`;
+export function buildProxyRuntimeShim({
+  proxyName,
+  upstream,
+  policy,
+}: {
+  proxyName: string;
+  upstream: string;
+  policy: ProxyRuntimePolicy;
+}): string {
+  const config = JSON.stringify({
+    version: policy.version,
+    proxyName,
+    upstreamOrigin: upstream,
+    expandedRuntimeUrls: policy.expandedRuntimeUrls,
+    blockServiceWorkerRegistration: policy.blockServiceWorkerRegistration,
+  });
+
+  return `<script data-omni-proxy-runtime-shim="${PROXY_RUNTIME_SHIM_VERSION}">(function(){"use strict";var C=${config};var P="/proxy/"+C.proxyName;function pair(a,b){return a===b||(a==="ws:"&&b==="http:")||(a==="wss:"&&b==="https:")||(a==="http:"&&b==="ws:")||(a==="https:"&&b==="wss:")}function ignored(v){return /^(?:$|#|data:|blob:|javascript:|mailto:|tel:|about:)/i.test(String(v))}function proxied(u,t){var o=new URL(location.origin);if(t==="websocket")o.protocol=location.protocol==="https:"?"wss:":"ws:";o.pathname=P+u.pathname;o.search=u.search;o.hash=u.hash;return o.toString()}function rewrite(input,t){try{if(ignored(input))return input;var u=new URL(input, location.href);if(["http:","https:","ws:","wss:"].indexOf(u.protocol)===-1)return input;var up=new URL(C.upstreamOrigin);if(u.origin===location.origin&&(u.pathname===P||u.pathname.indexOf(P+"/")===0)){if(t==="websocket")u.protocol=location.protocol==="https:"?"wss:":"ws:";return u.toString()}if(u.host===up.host&&pair(u.protocol,up.protocol))return proxied(u,t);if(u.origin===location.origin)return proxied(u,t);return input}catch(e){return input}}function canonical(){try{var u=new URL(location.href);if(u.origin===location.origin&&(u.pathname===P||u.pathname.indexOf(P+"/")===0)){var up=new URL(C.upstreamOrigin);var path=u.pathname.slice(P.length)||"/";return up.origin+path+u.search+u.hash}}catch(e){}return location.href}function nav(){try{window.parent.postMessage({type:"__preview_navigate__",url:canonical()},"*")}catch(e){}}function title(){try{window.parent.postMessage({type:"__preview_title__",title:document.title},"*")}catch(e){}}document.addEventListener("click",function(e){var a=e.target;while(a&&a.tagName!=="A")a=a.parentElement;if(!a)return;if(a.target==="_blank"||a.target==="_new")a.target="_self";if(C.expandedRuntimeUrls&&a.href)a.href=rewrite(a.href,"http")},true);document.addEventListener("submit",function(e){var f=e.target;if(C.expandedRuntimeUrls&&f&&f.action)f.action=rewrite(f.action,"http")},true);var open=window.open;window.open=function(u,n,s){if(u){var next=C.expandedRuntimeUrls?rewrite(u,"http"):u;location.href=next;return window}return open?open.call(window,u,n,s):null};var ps=history.pushState,rs=history.replaceState;history.pushState=function(){ps.apply(this,arguments);nav()};history.replaceState=function(){rs.apply(this,arguments);nav()};window.addEventListener("popstate",nav);window.addEventListener("hashchange",nav);if(document.head){new MutationObserver(title).observe(document.querySelector("title")||document.head,{childList:true,subtree:true,characterData:true});title()}if(C.blockServiceWorkerRegistration&&navigator.serviceWorker&&navigator.serviceWorker.register){navigator.serviceWorker.register=function(){return Promise.reject(new DOMException("Service worker registration is blocked for this proxied page","SecurityError"))}}if(!C.expandedRuntimeUrls)return;var fetchOrig=window.fetch;if(fetchOrig){window.fetch=function(input,init){var next=input;if(typeof Request!=="undefined"&&input instanceof Request){var url=rewrite(input.url,"http");if(url!==input.url)next=new Request(url,input)}else if(typeof input==="string"||input instanceof URL){next=rewrite(String(input),"http")}return fetchOrig.call(this,next,init)}}var xo=XMLHttpRequest.prototype.open;XMLHttpRequest.prototype.open=function(m,u){arguments[1]=rewrite(u,"http");return xo.apply(this,arguments)};if(window.EventSource){var ES=window.EventSource;window.EventSource=function(u,c){return new ES(rewrite(u,"http"),c)};window.EventSource.prototype=ES.prototype}if(window.WebSocket){var WS=window.WebSocket;window.WebSocket=function(u,p){var next=rewrite(u,"websocket");return p?new WS(next,p):new WS(next)};window.WebSocket.prototype=WS.prototype;window.WebSocket.CONNECTING=WS.CONNECTING;window.WebSocket.OPEN=WS.OPEN;window.WebSocket.CLOSING=WS.CLOSING;window.WebSocket.CLOSED=WS.CLOSED}if(window.Worker){var W=window.Worker;window.Worker=function(u,o){return new W(rewrite(u,"http"),o)};window.Worker.prototype=W.prototype}})()</script>`;
 }
 
 /**
@@ -401,7 +891,8 @@ function navigationCapture(): string {
  * Also sends a connection confirmation so the UI knows capture is active.
  */
 function consoleCapture(): string {
-  return `<script>(function(){` +
+  return (
+    `<script>(function(){` +
     `var P=function(l,m){try{window.parent.postMessage({type:"__preview_console__",level:l,message:m},"*")}catch(e){}};` +
     `["log","info","debug","warn","error"].forEach(function(l){` +
     `var o=console[l];console[l]=function(){o.apply(console,arguments);` +
@@ -409,19 +900,8 @@ function consoleCapture(): string {
     `try{return typeof a==="object"?JSON.stringify(a):String(a)}catch(e){return String(a)}` +
     `}).join(" ");P(l==="info"||l==="debug"?"log":l,m)}catch(e){}}});` +
     `P("log","[console connected]")` +
-    `})()</script>`;
-}
-
-/**
- * Generate a <script> tag that patches the WebSocket constructor to rewrite
- * all same-host WS connections through the proxy prefix.
- */
-function wsRewriteScript(proxyName: string): string {
-  // Rewrites ALL same-host WebSocket URLs through the proxy:
-  // ws://host/ws → ws://host/proxy/<proxyName>/ws
-  // ws://host/websockify → ws://host/proxy/<proxyName>/websockify
-  // Already-proxied paths (starting with /proxy/) are left untouched.
-  return `<script>(function(){var P="/proxy/${proxyName}",O=WebSocket;window.WebSocket=function(u,p){var a=new URL(u);if(a.host===location.host&&!a.pathname.startsWith("/proxy/")){a.pathname=P+a.pathname}return p?new O(a.toString(),p):new O(a.toString())};window.WebSocket.prototype=O.prototype;window.WebSocket.CONNECTING=O.CONNECTING;window.WebSocket.OPEN=O.OPEN;window.WebSocket.CLOSING=O.CLOSING;window.WebSocket.CLOSED=O.CLOSED})()</script>`;
+    `})()</script>`
+  );
 }
 
 /**
@@ -482,12 +962,17 @@ function registerAndRewrite(url: string, proxyKey: string): string | null {
     }
     const parsed = new URL(url);
     const upstream = `${parsed.protocol}//${parsed.host}`;
-    upstreamMap.set(proxyKey, upstream);
+    const now = Date.now();
+    upstreamMap.set(proxyKey, {
+      upstream,
+      kind: 'trusted-internal',
+      createdAt: now,
+      lastUsedAt: now,
+    });
     const proxyPath = `/proxy/${proxyKey}${parsed.pathname}${parsed.search}`;
-    console.log(`[proxy-rewrite] ${proxyKey}: ${url} → ${proxyPath} (upstream: ${upstream})`);
+    console.log(`[proxy-rewrite] ${proxyKey}: ${redactProxyUrlForLog(url)} → ${proxyPath} (upstream: ${upstream})`);
     return proxyPath;
   } catch {
     return null;
   }
 }
-

--- a/tests/e2e/fixtures/test.ts
+++ b/tests/e2e/fixtures/test.ts
@@ -88,6 +88,12 @@ async function launchServerLocal(
         HOST: parsed.hostname,
         PORT: parsed.port || '3001',
         OMNI_WEB_AUTO_OPEN: 'false',
+        ...(process.env.OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS
+          ? { OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS: process.env.OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS }
+          : {}),
+        ...(process.env.OMNI_PROXY_RUNTIME_SHIMS
+          ? { OMNI_PROXY_RUNTIME_SHIMS: process.env.OMNI_PROXY_RUNTIME_SHIMS }
+          : {}),
         OPENAI_BASE_URL: process.env.OPENAI_BASE_URL ?? process.env.SANDBOX_OPENAI_BASE_URL ?? 'http://127.0.0.1:9/v1',
         OPENAI_API_KEY: process.env.OPENAI_API_KEY ?? process.env.SANDBOX_OPENAI_API_KEY ?? 'test-key',
       },

--- a/tests/e2e/specs/proxy-browser.spec.ts
+++ b/tests/e2e/specs/proxy-browser.spec.ts
@@ -1,0 +1,163 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { WebSocketServer } from 'ws';
+
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { openCode } from 'tests/e2e/support/app';
+
+type TestUpstream = {
+  origin: string;
+  close: () => Promise<void>;
+};
+
+function sendHtml(res: ServerResponse, body: string, status = 200): void {
+  res.writeHead(status, { 'content-type': 'text/html; charset=utf-8' });
+  res.end(`<!doctype html><html><head><title>Proxy E2E</title></head><body>${body}</body></html>`);
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => resolve(body));
+  });
+}
+
+async function startTestUpstream(): Promise<TestUpstream> {
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+
+    if (url.pathname === '/') {
+      sendHtml(
+        res,
+        [
+          '<h1>Proxy Test Home</h1>',
+          '<a id="next-link" href="/next?via=link">Next page</a>',
+          '<button id="fetch-button">Fetch data</button>',
+          '<output id="fetch-result"></output>',
+          '<button id="xhr-button">XHR data</button>',
+          '<output id="xhr-result"></output>',
+          '<button id="ws-button">WebSocket data</button>',
+          '<output id="ws-result"></output>',
+          '<form id="post-form" method="post" action="/submit"><input name="message" value="hello"><button type="submit">Submit form</button></form>',
+          '<script>',
+          'document.getElementById("fetch-button").addEventListener("click", async () => { const res = await fetch("/api/data?from=fetch"); document.getElementById("fetch-result").textContent = await res.text(); });',
+          'document.getElementById("xhr-button").addEventListener("click", () => { const xhr = new XMLHttpRequest(); xhr.onload = () => { document.getElementById("xhr-result").textContent = xhr.responseText; }; xhr.open("GET", "/api/data?from=xhr"); xhr.send(); });',
+          'document.getElementById("ws-button").addEventListener("click", () => { const ws = new WebSocket("/ws"); ws.onmessage = (event) => { document.getElementById("ws-result").textContent = event.data; ws.close(); }; });',
+          '</script>',
+        ].join('\n')
+      );
+      return;
+    }
+
+    if (url.pathname === '/next') {
+      sendHtml(res, '<h1>Proxy Test Next</h1><p id="next-marker">arrived via link</p>');
+      return;
+    }
+
+    if (url.pathname === '/submit') {
+      const body = await readBody(req);
+      sendHtml(res, `<h1>Proxy Test Submitted</h1><p id="submit-body">${body}</p>`);
+      return;
+    }
+
+    if (url.pathname === '/api/data') {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end(`api:${url.searchParams.get('from') ?? 'unknown'}`);
+      return;
+    }
+
+    res.writeHead(404, { 'content-type': 'text/plain' });
+    res.end('not found');
+  });
+
+  const wsServer = new WebSocketServer({ noServer: true });
+  wsServer.on('connection', (socket) => {
+    socket.send('ws:ok');
+  });
+  server.on('upgrade', (req, socket, head) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    if (url.pathname !== '/ws') {
+      socket.destroy();
+      return;
+    }
+    wsServer.handleUpgrade(req, socket, head, (ws) => wsServer.emit('connection', ws, req));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo;
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      await new Promise<void>((resolve) => wsServer.close(() => resolve()));
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function openStandaloneBrowser(page: import('@playwright/test').Page): Promise<void> {
+  await openCode(page);
+  await page.getByRole('button', { name: 'New' }).first().click();
+  await page.getByRole('menuitem', { name: 'Apps' }).click();
+  await page.getByRole('button', { name: 'Browser' }).click();
+  await expect(page.getByText('Browser').first()).toBeVisible();
+  await expect(page.getByPlaceholder('Search or enter URL').first()).toBeVisible();
+}
+
+test.describe('browser/server proxy browser', () => {
+  test('loads proxied pages while keeping canonical browser state for common operations', async ({ appPage, mode }) => {
+    test.skip(mode !== 'server-local', 'browser/server proxy behavior is only exercised in server mode');
+
+    const upstream = await startTestUpstream();
+    const upstreamHome = `${upstream.origin}/`;
+    try {
+      await openStandaloneBrowser(appPage);
+      const omnibox = appPage.getByPlaceholder('Search or enter URL').first();
+      await omnibox.fill(upstream.origin);
+      await omnibox.press('Enter');
+
+      await expect(omnibox).toHaveValue(upstreamHome);
+      const iframe = appPage.locator('iframe[src*="/proxy/"]').first();
+      await expect(iframe).toBeVisible();
+      await expect(iframe).toHaveAttribute('src', /\/proxy\//);
+      await expect(iframe).not.toHaveAttribute(
+        'src',
+        new RegExp(upstream.origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      );
+
+      const frame = appPage.frameLocator('iframe[src*="/proxy/"]').first();
+      await expect(frame.getByRole('heading', { name: 'Proxy Test Home' })).toBeVisible();
+
+      await frame.locator('#next-link').click();
+      await expect(frame.getByRole('heading', { name: 'Proxy Test Next' })).toBeVisible();
+      await expect(omnibox).toHaveValue(`${upstream.origin}/next?via=link`);
+      await expect(appPage.locator('iframe[src*="/proxy/"]').first()).toHaveAttribute('src', /\/proxy\//);
+      await expect(omnibox).not.toHaveValue(/\/proxy\//);
+
+      await omnibox.fill(upstream.origin);
+      await omnibox.press('Enter');
+      await expect(frame.getByRole('heading', { name: 'Proxy Test Home' })).toBeVisible();
+
+      await frame.locator('#fetch-button').click();
+      await expect(frame.locator('#fetch-result')).toHaveText('api:fetch');
+
+      await frame.locator('#xhr-button').click();
+      await expect(frame.locator('#xhr-result')).toHaveText('api:xhr');
+
+      await frame.locator('#ws-button').click();
+      await expect(frame.locator('#ws-result')).toHaveText('ws:ok');
+
+      await frame.getByRole('button', { name: 'Submit form' }).click();
+      await expect(frame.getByRole('heading', { name: 'Proxy Test Submitted' })).toBeVisible();
+      await expect(omnibox).toHaveValue(`${upstream.origin}/submit`);
+      await expect(omnibox).not.toHaveValue(/\/proxy\//);
+    } finally {
+      await upstream.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Separates canonical browser URLs from iframe `/proxy` transport URLs in browser/server mode.
- Reworks dynamic proxy registration to use server-minted scoped capabilities with validation, expiry, and clearer registration failure diagnostics.
- Hardens proxy behavior for headers, redirects, cookies, streaming, static assets, runtime shims, and user-facing fallback UI.
- Adds proxy security/overhaul docs, focused unit/integration-style tests, and a server-mode Playwright E2E spec.

## Why
Browser/server mode uses an iframe plus `/proxy`, unlike Electron's real `<webview>`. Proxy transport URLs could leak into tab state and break flows such as PR badge/browser navigation. This makes the proxy contract explicit, keeps user-facing browser state canonical, and adds coverage for common same-upstream browser operations.

## Validation
- `npx vitest run src/main/browser-manager.test.ts src/lib/url.test.ts src/renderer/services/proxy-resolver.test.ts src/renderer/features/Tickets/preview-bridge.test.ts src/server/proxy-rewriter.test.ts src/renderer/common/webview-fallback.test.ts`
- `OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS=1 npx playwright test tests/e2e/specs/proxy-browser.spec.ts --project=server-local`
- `npx prettier --check` on touched files
- `git diff --check`

## Notes
- Full repo `npm run lint:tsc` still has unrelated pre-existing failures outside this change; touched-file type filtering showed no proxy/browser diagnostics during implementation.
- Dynamic runtime shims remain gated for dynamic external sites and are enabled in the new E2E via `OMNI_PROXY_DYNAMIC_RUNTIME_SHIMS=1`.
