### PR TITLE
Allow longer local voice transcriptions

### DIFF
--- a/src/server/voice-http.ts
+++ b/src/server/voice-http.ts
@@ -13,6 +13,7 @@ import type { FastifyInstance } from 'fastify';
 import { getVoiceService } from '@/main/voice-service';
 
 export const VOICE_HTTP_PREFIX = '/api/voice';
+const VOICE_TRANSCRIBE_BODY_LIMIT = 32 * 1024 * 1024;
 
 export function registerVoiceRoutes(fastify: FastifyInstance): void {
   const voice = getVoiceService();
@@ -24,11 +25,11 @@ export function registerVoiceRoutes(fastify: FastifyInstance): void {
     return voice.getStatus();
   });
 
-  fastify.post(`${VOICE_HTTP_PREFIX}/transcribe`, async (request) => {
+  fastify.post(`${VOICE_HTTP_PREFIX}/transcribe`, { bodyLimit: VOICE_TRANSCRIBE_BODY_LIMIT }, async (request) => {
     const { pcm, sampleRate } = (request.body ?? {}) as { pcm?: string; sampleRate?: number };
     if (!pcm) {
-return { text: '' };
-}
+      return { text: '' };
+    }
     const text = await voice.transcribe(pcm, sampleRate ?? 24000);
     return { text };
   });
@@ -37,8 +38,8 @@ return { text: '' };
   fastify.post(`${VOICE_HTTP_PREFIX}/speak`, async (request) => {
     const { text, voice: voiceName } = (request.body ?? {}) as { text?: string; voice?: string };
     if (!text) {
-return { pcm: '', sampleRate: 24000 };
-}
+      return { pcm: '', sampleRate: 24000 };
+    }
     const chunks: Buffer[] = [];
     let sampleRate = 24000;
     await voice.speak(
@@ -47,7 +48,7 @@ return { pcm: '', sampleRate: 24000 };
         sampleRate = sr;
         chunks.push(Buffer.from(pcmBase64, 'base64'));
       },
-      voiceName,
+      voiceName
     );
     return { pcm: Buffer.concat(chunks).toString('base64'), sampleRate };
   });
@@ -59,8 +60,8 @@ return { pcm: '', sampleRate: 24000 };
       data?: string;
     };
     if (!personaId || !data) {
-return { file: '', embeddingFile: '' };
-}
+      return { file: '', embeddingFile: '' };
+    }
     return await voice.importSample(personaId, filename ?? 'sample.wav', data);
   });
 }


### PR DESCRIPTION
## Summary
- Increase the local voice `/api/voice/transcribe` request body limit to 32 MiB.
- Preserve existing STT behavior while allowing longer push-to-talk recordings through Fastify.
- Run Prettier on the touched voice route file.

## Why
Local speech-to-text buffers the full recording client-side and sends it as base64 PCM in one request. Fastify's default ~1 MiB body limit only fits about 16 seconds of 24 kHz PCM16 audio after base64 encoding, so longer recordings fail before reaching the Parakeet STT sidecar.

## Validation
- `npx prettier --check src/server/voice-http.ts`
- `npm run lint:tsc` *(fails on existing repo-wide TypeScript issues, including missing `omni-projects-db` modules and unrelated strictness errors; not introduced by this change)*
