### PR TITLE
Add spoken replies toggle for local voice

### DIFF
--- a/src/renderer/omniagents-ui/App.tsx
+++ b/src/renderer/omniagents-ui/App.tsx
@@ -190,9 +190,9 @@ export function App({
   const [runActive, setRunActive] = useState(false);
   const [initialSessionParam] = useState<string | undefined>(() => uiConfig.session);
   const [queuedMessages, setQueuedMessages] = useState<import('./rpc/client').QueuedMessage[]>([]);
+  const [speakRepliesEnabled, setSpeakRepliesEnabled] = useState(false);
   const readyRef = useRef(false);
   const onClientToolCallRef = useRef(onClientToolCall);
-  // Armed by the mic button so the next run (and only that run) gets the speak tool.
   const voiceRunRef = useRef(false);
   useEffect(() => {
     onClientToolCallRef.current = onClientToolCall;
@@ -1021,13 +1021,9 @@ export function App({
         const liveWorkspaceSupported = caps?.workspaceSupported ?? workspaceSupported;
         const workspaceVars: Record<string, unknown> | undefined =
           liveWorkspacePath && liveWorkspaceSupported ? { workspace_root: liveWorkspacePath } : undefined;
-        // One-shot voice arming: a submission from the mic button uses the
-        // voice-enabled variables (speak tool + persona) for *this run only*;
-        // every other run (typed, or another column) stays speak-free. The ref
-        // is per-App-instance, so columns don't race.
         const useVoiceRun = voiceRunRef.current;
         voiceRunRef.current = false;
-        const variablesSource = useVoiceRun && voiceVariables ? voiceVariables : variablesProp;
+        const variablesSource = (speakRepliesEnabled || useVoiceRun) && voiceVariables ? voiceVariables : variablesProp;
         const baseVariables: Record<string, unknown> | undefined =
           variablesSource || workspaceVars ? { ...variablesSource, ...workspaceVars } : undefined;
         // Merge per-dispatch overrides (from the orchestrator's bridge.run call)
@@ -1102,6 +1098,7 @@ export function App({
       bootState.actor,
       variablesProp,
       voiceVariables,
+      speakRepliesEnabled,
       submit,
       submitError,
       workspacePath,
@@ -1118,9 +1115,9 @@ export function App({
     ]
   );
 
-  // Submit from the mic button: arm the speak tool for just this run.
   const handleVoiceSubmit = useCallback(
     (text: string) => {
+      setSpeakRepliesEnabled(true);
       voiceRunRef.current = true;
       void handleSubmit(text);
     },
@@ -1867,6 +1864,8 @@ export function App({
                 }}
                 onVoiceSubmit={handleVoiceSubmit}
                 voiceEnabled={voiceEnabled}
+                speakRepliesEnabled={!!voiceVariables && speakRepliesEnabled}
+                onSpeakRepliesChange={setSpeakRepliesEnabled}
                 workspacePath={workspaceSupported ? workspacePath : undefined}
                 workspaceLocked={workspaceLocked}
                 onWorkspaceClick={() => setWorkspacePickerOpen(true)}

--- a/src/renderer/omniagents-ui/components/Input.tsx
+++ b/src/renderer/omniagents-ui/components/Input.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpIcon, CheckIcon, FolderIcon, Loader2Icon, LockIcon,MicIcon, MonitorIcon, PaperclipIcon, SquareIcon, XIcon } from 'lucide-react'
+import { ArrowUpIcon, CheckIcon, FolderIcon, Loader2Icon, LockIcon, MicIcon, MonitorIcon, PaperclipIcon, SquareIcon, Volume2Icon, VolumeXIcon, XIcon } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { PromptInput, PromptInputActions,PromptInputTextarea } from './promptkit/PromptInput'
@@ -27,8 +27,8 @@ function workspaceLabel(p: string): string {
   return UUID_RE.test(tail) ? 'Workspace' : tail
 }
 
-export function Input({ disabled, thinking, onStop, onSubmit, onVoiceSubmit, voiceEnabled, workspacePath, workspaceLocked, onWorkspaceClick, sandboxLabel, sandboxLocked, sandboxLoading, sandboxOptions, currentSandboxProfile, onSandboxChange, sessionId, onVoiceSessionCreated, onVoiceClose }:
-  { disabled?: boolean; thinking?: boolean; onStop?: () => void; onSubmit: (text: string, files?: File[]) => void; onVoiceSubmit?: (text: string) => void; voiceEnabled?: boolean; workspacePath?: string | null; workspaceLocked?: boolean; onWorkspaceClick?: () => void; sandboxLabel?: string; sandboxLocked?: boolean; sandboxLoading?: boolean; sandboxOptions?: { value: string; label: string }[]; currentSandboxProfile?: string; onSandboxChange?: (value: string) => void; sessionId?: string; onVoiceSessionCreated?: (id: string) => void; onVoiceClose?: () => void }) {
+export function Input({ disabled, thinking, onStop, onSubmit, onVoiceSubmit, voiceEnabled, speakRepliesEnabled, onSpeakRepliesChange, workspacePath, workspaceLocked, onWorkspaceClick, sandboxLabel, sandboxLocked, sandboxLoading, sandboxOptions, currentSandboxProfile, onSandboxChange, sessionId, onVoiceSessionCreated, onVoiceClose }:
+  { disabled?: boolean; thinking?: boolean; onStop?: () => void; onSubmit: (text: string, files?: File[]) => void; onVoiceSubmit?: (text: string) => void; voiceEnabled?: boolean; speakRepliesEnabled?: boolean; onSpeakRepliesChange?: (enabled: boolean) => void; workspacePath?: string | null; workspaceLocked?: boolean; onWorkspaceClick?: () => void; sandboxLabel?: string; sandboxLocked?: boolean; sandboxLoading?: boolean; sandboxOptions?: { value: string; label: string }[]; currentSandboxProfile?: string; onSandboxChange?: (value: string) => void; sessionId?: string; onVoiceSessionCreated?: (id: string) => void; onVoiceClose?: () => void }) {
   const [text, setText] = useState('')
   const [files, setFiles] = useState<File[]>([])
   const [history, setHistory] = useState<string[]>([])
@@ -40,6 +40,7 @@ export function Input({ disabled, thinking, onStop, onSubmit, onVoiceSubmit, voi
   // VoiceModal mic button.
   const localVoiceEnabled = useStore(persistedStoreApi.$atom).localVoiceEnabled
   const localVoiceSupported = localVoiceEnabled && isLocalVoiceCapable()
+  const speakerToggleLabel = speakRepliesEnabled ? 'Spoken replies on' : 'Spoken replies off'
   const [sandboxMenuOpen, setSandboxMenuOpen] = useState(false)
   const taRef = useRef<HTMLTextAreaElement | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -338,9 +339,21 @@ fileInputRef.current.value = ''
 
             <div className="flex items-center gap-1 sm:gap-2 shrink-0">
               {localVoiceSupported ? (
-                // Local models active → push-to-talk replaces the realtime
-                // VoiceModal mic button entirely.
-                <LocalVoiceButton onSubmit={(t) => (onVoiceSubmit ?? onSubmit)(t)} />
+                <>
+                  <button
+                    type="button"
+                    onClick={() => onSpeakRepliesChange?.(!speakRepliesEnabled)}
+                    className={`flex h-8 w-8 items-center justify-center rounded-2xl transition-colors ${
+                      speakRepliesEnabled ? 'bg-primary/15 text-primary hover:bg-primary/20' : 'hover:bg-accent/50 text-muted-foreground hover:text-foreground'
+                    }`}
+                    aria-label={speakerToggleLabel}
+                    aria-pressed={!!speakRepliesEnabled}
+                    title={speakerToggleLabel}
+                  >
+                    {speakRepliesEnabled ? <Volume2Icon size={20} /> : <VolumeXIcon size={20} />}
+                  </button>
+                  <LocalVoiceButton onSubmit={(t) => (onVoiceSubmit ?? onSubmit)(t)} />
+                </>
               ) : voiceEnabled ? (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- Add a visible spoken-replies toggle next to the local voice mic button.
- Keep `speak` client-tool variables active for typed follow-up runs while the toggle is on.
- Turn spoken replies on automatically when the user submits via the mic.

## Rationale
The previous one-shot mic arming made `speak` appear and disappear based on hidden run state. This separates voice input from spoken output: the mic controls input, while the speaker toggle controls whether replies can speak.

## Validation
- `npx vitest run src/lib/client-tools.test.ts src/renderer/omniagents-ui/components/Input.test.tsx`
- `npm run lint:tsc` attempted; still fails on existing unrelated repo-wide type errors, including missing `omni-projects-db` types and pre-existing strictness issues.
