### PR TITLE
Add inbox and project actions to command palette

### DIFF
--- a/src/renderer/features/CommandPalette/CommandPalette.tsx
+++ b/src/renderer/features/CommandPalette/CommandPalette.tsx
@@ -14,6 +14,8 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 
 import { codeApi } from '@/renderer/features/Code/state';
+import { $quickCaptureOpen } from '@/renderer/features/Inbox/QuickCapture';
+import { ticketApi } from '@/renderer/features/Tickets/state';
 import { persistedStoreApi } from '@/renderer/services/store';
 import type { CodeTab, LayoutMode } from '@/shared/types';
 
@@ -117,6 +119,32 @@ export const CommandPalette = memo(() => {
     persistedStoreApi.setKey('layoutMode', 'spaces');
   }, []);
 
+  const goToInbox = useCallback(() => {
+    persistedStoreApi.setKey('layoutMode', 'projects');
+    ticketApi.goToInbox();
+  }, []);
+
+  const addInboxItem = useCallback(() => {
+    $quickCaptureOpen.set(true);
+  }, []);
+
+  const createProject = useCallback(() => {
+    const name = window.prompt('Project name');
+    const label = name?.trim();
+    if (!label) {
+      return;
+    }
+    const slug =
+      label
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '') || 'project';
+    void ticketApi.addProject({ label, slug, sources: [] }).then((project) => {
+      persistedStoreApi.setKey('layoutMode', 'projects');
+      ticketApi.goToProject(project.id);
+    });
+  }, []);
+
   const resolveTabLabel = useCallback(
     (tab: CodeTab) => {
       const project = store.projects.find((p) => p.id === tab.projectId);
@@ -136,6 +164,9 @@ export const CommandPalette = memo(() => {
         resolveTabLabel,
         navigate,
         activateColumn,
+        goToInbox,
+        addInboxItem,
+        createProject,
         newSession: () => {
           void codeApi.addTab();
           persistedStoreApi.setKey('layoutMode', 'spaces');
@@ -145,7 +176,16 @@ export const CommandPalette = memo(() => {
           persistedStoreApi.setKey('layoutMode', 'spaces');
         },
       }),
-    [store.codeTabs, store.codeLayoutMode, resolveTabLabel, navigate, activateColumn]
+    [
+      store.codeTabs,
+      store.codeLayoutMode,
+      resolveTabLabel,
+      navigate,
+      activateColumn,
+      goToInbox,
+      addInboxItem,
+      createProject,
+    ]
   );
 
   const filtered = useMemo(() => filterCommands(commands, query), [commands, query]);

--- a/src/renderer/features/CommandPalette/commands.test.ts
+++ b/src/renderer/features/CommandPalette/commands.test.ts
@@ -17,6 +17,9 @@ const ctx = (codeTabs: CodeTab[] = []) => ({
   resolveTabLabel: (t: CodeTab) => `label:${t.id}`,
   navigate: vi.fn(),
   activateColumn: vi.fn(),
+  goToInbox: vi.fn(),
+  addInboxItem: vi.fn(),
+  createProject: vi.fn(),
   newSession: vi.fn(),
   setDeckLayout: vi.fn(),
 });
@@ -39,13 +42,27 @@ describe('buildCommands', () => {
     const commands = buildCommands(c);
     const ids = commands.map((cmd) => cmd.id);
     expect(ids).toEqual(
-      expect.arrayContaining(['nav-chat', 'nav-spaces', 'nav-projects', 'nav-settings', 'new-session', 'toggle-layout', 'column-a'])
+      expect.arrayContaining([
+        'nav-chat',
+        'nav-spaces',
+        'nav-projects',
+        'nav-inbox',
+        'nav-settings',
+        'add-inbox-item',
+        'create-project',
+        'new-session',
+        'toggle-layout',
+        'column-a',
+      ])
     );
     expect(ids).not.toContain('column-chat');
   });
 
   it('labels the layout toggle by the current mode and numbers column hints', () => {
-    const c = { ...ctx([tab({ id: 'a', projectId: 'p1' }), tab({ id: 'b', projectId: 'p2' })]), codeLayoutMode: 'focus' as const };
+    const c = {
+      ...ctx([tab({ id: 'a', projectId: 'p1' }), tab({ id: 'b', projectId: 'p2' })]),
+      codeLayoutMode: 'focus' as const,
+    };
     const commands = buildCommands(c);
     expect(commands.find((cmd) => cmd.id === 'toggle-layout')!.label).toContain('Tile');
     expect(commands.find((cmd) => cmd.id === 'column-b')!.hint).toBe('⌘2');
@@ -56,6 +73,12 @@ describe('buildCommands', () => {
     const commands = buildCommands(c);
     commands.find((cmd) => cmd.id === 'nav-projects')!.run();
     expect(c.navigate).toHaveBeenCalledWith('projects');
+    commands.find((cmd) => cmd.id === 'nav-inbox')!.run();
+    expect(c.goToInbox).toHaveBeenCalled();
+    commands.find((cmd) => cmd.id === 'add-inbox-item')!.run();
+    expect(c.addInboxItem).toHaveBeenCalled();
+    commands.find((cmd) => cmd.id === 'create-project')!.run();
+    expect(c.createProject).toHaveBeenCalled();
     commands.find((cmd) => cmd.id === 'column-a')!.run();
     expect(c.activateColumn).toHaveBeenCalledWith('a');
   });

--- a/src/renderer/features/CommandPalette/commands.ts
+++ b/src/renderer/features/CommandPalette/commands.ts
@@ -22,7 +22,10 @@ export type PaletteContext = {
   /** Resolve a session tab's display label (project name etc.). */
   resolveTabLabel: (tab: CodeTab) => string;
   navigate: (mode: LayoutMode) => void;
+  goToInbox: () => void;
   activateColumn: (tabId: string) => void;
+  addInboxItem: () => void;
+  createProject: () => void;
   newSession: () => void;
   setDeckLayout: (mode: CodeLayoutMode) => void;
 };
@@ -35,8 +38,21 @@ export function buildCommands(ctx: PaletteContext): PaletteCommand[] {
   const commands: PaletteCommand[] = [
     { id: 'nav-chat', label: 'Go to Chat', keywords: 'conversation talk', run: () => ctx.navigate('chat') },
     { id: 'nav-spaces', label: 'Go to Spaces', keywords: 'deck columns code', run: () => ctx.navigate('spaces') },
-    { id: 'nav-projects', label: 'Go to Projects', keywords: 'tickets board home inbox', run: () => ctx.navigate('projects') },
-    { id: 'nav-settings', label: 'Go to Settings', keywords: 'preferences models mcp git', run: () => ctx.navigate('settings') },
+    {
+      id: 'nav-projects',
+      label: 'Go to Projects',
+      keywords: 'tickets board home inbox',
+      run: () => ctx.navigate('projects'),
+    },
+    { id: 'nav-inbox', label: 'Go to Inbox', keywords: 'capture ideas todo triage', run: ctx.goToInbox },
+    {
+      id: 'nav-settings',
+      label: 'Go to Settings',
+      keywords: 'preferences models mcp git',
+      run: () => ctx.navigate('settings'),
+    },
+    { id: 'add-inbox-item', label: 'Add inbox item', keywords: 'capture idea todo quick', run: ctx.addInboxItem },
+    { id: 'create-project', label: 'Create project', keywords: 'new workspace initiative', run: ctx.createProject },
     { id: 'new-session', label: 'New session', keywords: 'create column agent', run: ctx.newSession },
     {
       id: 'toggle-layout',
@@ -65,7 +81,5 @@ export function filterCommands(commands: PaletteCommand[], query: string): Palet
   if (!q) {
     return commands;
   }
-  return commands.filter(
-    (c) => c.label.toLowerCase().includes(q) || (c.keywords ?? '').toLowerCase().includes(q)
-  );
+  return commands.filter((c) => c.label.toLowerCase().includes(q) || (c.keywords ?? '').toLowerCase().includes(q));
 }


### PR DESCRIPTION
## Summary
- Add `Go to Inbox`, `Add inbox item`, and `Create project` to the Cmd/Ctrl+K command palette.
- Reuse existing inbox navigation, Quick Capture, and project creation APIs.
- Extend command registry tests for the new actions.

## Validation
- [x] `npx vitest run src/renderer/features/CommandPalette/commands.test.ts`
- [x] `npx prettier --check src/renderer/features/CommandPalette/CommandPalette.tsx src/renderer/features/CommandPalette/commands.ts src/renderer/features/CommandPalette/commands.test.ts`
- [ ] `npm run lint:tsc` — fails on existing unrelated repo-wide TypeScript errors, including missing `omni-projects-db` types and pre-existing strictness failures in tests/components.
