### PR TITLE
Fix omni-projects MCP schema coverage

### DIFF
--- a/packages/projects-db/src/migrate-from-json.ts
+++ b/packages/projects-db/src/migrate-from-json.ts
@@ -228,7 +228,6 @@ return 0;
         id: p.id,
         label: p.label,
         slug: p.slug,
-        workspace_dir: null,
         is_personal: p.isPersonal ? 1 : 0,
         auto_dispatch: p.autoDispatch ? 1 : 0,
         sources: JSON.stringify(_legacyToSources(p)),

--- a/packages/projects-db/src/migrate.test.ts
+++ b/packages/projects-db/src/migrate.test.ts
@@ -143,3 +143,32 @@ describe('v12 shaping removal', () => {
     expect(cols.map((c) => c.name)).not.toContain('shaping');
   });
 });
+
+describe('v13 source cutover', () => {
+  it('moves workspace_dir into sources and drops workspace_dir', () => {
+    migrateTo(13);
+    db.prepare("INSERT INTO projects (id, label, slug, workspace_dir) VALUES ('proj_1', 'P', 'p', '/tmp/project')").run();
+
+    runMigrations(db);
+
+    const row = db.prepare("SELECT sources FROM projects WHERE id = 'proj_1'").get() as { sources: string };
+    expect(JSON.parse(row.sources)).toEqual([
+      expect.objectContaining({ kind: 'local', mountName: 'p', workspaceDir: '/tmp/project' }),
+    ]);
+    const cols = db.prepare('PRAGMA table_info(projects)').all() as Array<{ name: string }>;
+    expect(cols.map((c) => c.name)).not.toContain('workspace_dir');
+  });
+});
+
+describe('v14 inbox status tightening', () => {
+  it('removes shaped from the inbox status check', () => {
+    migrateTo(14);
+    db.prepare("INSERT INTO inbox_items (id, title, status) VALUES ('inb_1', 'I', 'shaped')").run();
+
+    runMigrations(db);
+
+    const row = db.prepare("SELECT status FROM inbox_items WHERE id = 'inb_1'").get() as { status: string };
+    expect(row.status).toBe('new');
+    expect(() => db.prepare("INSERT INTO inbox_items (id, title, status) VALUES ('inb_2', 'I2', 'shaped')").run()).toThrow(/CHECK constraint/);
+  });
+});

--- a/packages/projects-db/src/pg/pg-repo.test.ts
+++ b/packages/projects-db/src/pg/pg-repo.test.ts
@@ -21,7 +21,6 @@ const projectRow = (id: string, slug: string): ProjectRow => ({
   id,
   label: `Project ${id}`,
   slug,
-  workspace_dir: null,
   is_personal: 0,
   auto_dispatch: 0,
   sources: '[]',

--- a/packages/projects-db/src/pg/pg-repo.ts
+++ b/packages/projects-db/src/pg/pg-repo.ts
@@ -87,16 +87,16 @@ export class PgProjectsRepo implements IProjectsRepo {
 
   private upsertProjectIn(c: PoolClient, row: ProjectRow): Promise<unknown> {
     return c.query(
-      `INSERT INTO projects (tenant_id, id, label, slug, workspace_dir, is_personal, auto_dispatch, sources, sandbox_profile, due_date, pinned_at, created_at, updated_at)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+      `INSERT INTO projects (tenant_id, id, label, slug, is_personal, auto_dispatch, sources, sandbox_profile, due_date, pinned_at, created_at, updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
        ON CONFLICT (id) DO UPDATE SET
-         label = EXCLUDED.label, slug = EXCLUDED.slug, workspace_dir = EXCLUDED.workspace_dir,
+         label = EXCLUDED.label, slug = EXCLUDED.slug,
          is_personal = EXCLUDED.is_personal, auto_dispatch = EXCLUDED.auto_dispatch,
          sources = EXCLUDED.sources, sandbox_profile = EXCLUDED.sandbox_profile,
          due_date = EXCLUDED.due_date, pinned_at = EXCLUDED.pinned_at,
          updated_at = EXCLUDED.updated_at`,
       [
-        this.tenantId, row.id, row.label, row.slug, row.workspace_dir,
+        this.tenantId, row.id, row.label, row.slug,
         row.is_personal, row.auto_dispatch, row.sources, row.sandbox_profile,
         row.due_date, row.pinned_at, row.created_at, row.updated_at,
       ]

--- a/packages/projects-db/src/pg/schema.ts
+++ b/packages/projects-db/src/pg/schema.ts
@@ -523,4 +523,34 @@ ALTER TABLE tickets DROP COLUMN shaping;
 ALTER TABLE inbox_items DROP COLUMN shaping;
 `,
   },
+  {
+    version: 13,
+    sql: `
+-- Hard cutover to projects.sources as the only project source model.
+ALTER TABLE projects DISABLE ROW LEVEL SECURITY;
+
+UPDATE projects
+SET sources = jsonb_build_array(jsonb_build_object(
+  'kind', 'local',
+  'id', substr(md5(random()::text || clock_timestamp()::text), 1, 16),
+  'mountName', slug,
+  'workspaceDir', workspace_dir
+))::text
+WHERE workspace_dir IS NOT NULL
+  AND workspace_dir <> ''
+  AND (sources IS NULL OR sources = '[]');
+
+ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE projects DROP COLUMN workspace_dir;
+`,
+  },
+  {
+    version: 14,
+    sql: `
+-- Tighten inbox status now that shaping is gone.
+ALTER TABLE inbox_items DROP CONSTRAINT inbox_items_status_check;
+ALTER TABLE inbox_items ADD CONSTRAINT inbox_items_status_check CHECK (status IN ('new','later'));
+`,
+  },
 ];

--- a/packages/projects-db/src/repo.test.ts
+++ b/packages/projects-db/src/repo.test.ts
@@ -291,7 +291,6 @@ describe('replaceAll* preserves child data', () => {
         id: 'proj_b',
         label: 'B',
         slug: 'b',
-        workspace_dir: null,
         is_personal: 0,
         auto_dispatch: 0,
         sources: '[]',

--- a/packages/projects-db/src/repo.ts
+++ b/packages/projects-db/src/repo.ts
@@ -59,7 +59,7 @@ export class ProjectsRepo {
 
   upsertProject(row: ProjectRow): void {
     this.stmts.upsertProject.run(
-      row.id, row.label, row.slug, row.workspace_dir,
+      row.id, row.label, row.slug,
       row.is_personal, row.auto_dispatch, row.sources, row.sandbox_profile,
       row.due_date, row.pinned_at,
       row.created_at, row.updated_at,
@@ -116,7 +116,7 @@ export class ProjectsRepo {
       }
       for (const row of rows) {
         this.stmts.upsertProject.run(
-          row.id, row.label, row.slug, row.workspace_dir,
+          row.id, row.label, row.slug,
           row.is_personal, row.auto_dispatch, row.sources, row.sandbox_profile,
           row.due_date, row.pinned_at,
           row.created_at, row.updated_at,
@@ -621,10 +621,10 @@ function prepareStatements(db: DatabaseSync) {
     getProject: db.prepare('SELECT * FROM projects WHERE id = ?'),
     getProjectBySlug: db.prepare('SELECT * FROM projects WHERE slug = ?'),
     upsertProject: db.prepare(`
-      INSERT INTO projects (id, label, slug, workspace_dir, is_personal, auto_dispatch, sources, sandbox_profile, due_date, pinned_at, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO projects (id, label, slug, is_personal, auto_dispatch, sources, sandbox_profile, due_date, pinned_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
-        label = excluded.label, slug = excluded.slug, workspace_dir = excluded.workspace_dir,
+        label = excluded.label, slug = excluded.slug,
         is_personal = excluded.is_personal, auto_dispatch = excluded.auto_dispatch,
         sources = excluded.sources, sandbox_profile = excluded.sandbox_profile,
         due_date = excluded.due_date, pinned_at = excluded.pinned_at,

--- a/packages/projects-db/src/schema.ts
+++ b/packages/projects-db/src/schema.ts
@@ -191,11 +191,9 @@ ALTER TABLE projects ADD COLUMN sandbox_profile TEXT;
   {
     version: 6,
     sql: `
--- PR review state on tickets. Used by the local-PR UI flow:
---   pr_review:    JSON {"status":"approved|changes_requested","at":<epoch ms>}
---                 NULL = no review yet (Approve/Request changes buttons enabled).
---   pr_merged_at: epoch ms (stringified). Set when the user merges the agent's
---                 container changes into the host repo. NULL = not merged.
+-- PR state on tickets. Used by the per-source PR UI flow:
+--   pr_review:    JSON array of linked pull requests (Ticket.pullRequests).
+--   pr_merged_at: JSON map of source id -> epoch ms (Ticket.prMergedAt).
 -- Pre-existing rows get NULL; the Ticket model already treats both fields as
 -- optional so no backfill is needed.
 ALTER TABLE tickets ADD COLUMN pr_review TEXT;
@@ -277,8 +275,7 @@ ALTER TABLE pipeline_columns ADD COLUMN workflow TEXT;
 -- free-text channel (ticket description / inbox note) so the data survives;
 -- the 'shaped' inbox status collapses to 'new' with a fresh capture
 -- timestamp (so the expiry sweep doesn't instantly defer those items).
--- The status CHECK constraint still lists 'shaped' — harmlessly permissive;
--- nothing writes it anymore.
+-- The v13 rebuild below tightens the CHECK constraint to new/later only.
 UPDATE tickets
 SET description = CASE WHEN description = '' THEN '' ELSE description || char(10) || char(10) END
   || '**Done when:** ' || TRIM(json_extract(shaping, '$.doneLooksLike'))
@@ -310,6 +307,58 @@ WHERE status = 'shaped';
 
 ALTER TABLE tickets DROP COLUMN shaping;
 ALTER TABLE inbox_items DROP COLUMN shaping;
+`,
+  },
+  {
+    version: 13,
+    sql: `
+-- Hard cutover to projects.sources as the only project source model.
+-- Preserve old workspace_dir values once, then remove the column so runtime
+-- code cannot keep treating it as a second source of truth.
+UPDATE projects
+SET sources = json_array(
+  json_object(
+    'kind', 'local',
+    'id', lower(hex(randomblob(8))),
+    'mountName', slug,
+    'workspaceDir', workspace_dir
+  )
+)
+WHERE workspace_dir IS NOT NULL
+  AND workspace_dir <> ''
+  AND (sources IS NULL OR sources = '[]' OR json_array_length(sources) = 0);
+
+ALTER TABLE projects DROP COLUMN workspace_dir;
+`,
+  },
+  {
+    version: 14,
+    sql: `
+-- Tighten inbox status now that shaping is gone. Rebuild is required because
+-- SQLite cannot alter CHECK constraints in place.
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE inbox_items_new (
+  id          TEXT PRIMARY KEY,
+  title       TEXT NOT NULL,
+  note        TEXT,
+  project_id  TEXT REFERENCES projects(id) ON DELETE SET NULL,
+  status      TEXT NOT NULL DEFAULT 'new' CHECK(status IN ('new','later')),
+  later_at    TEXT,
+  promoted_to TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO inbox_items_new (id, title, note, project_id, status, later_at, promoted_to, created_at, updated_at)
+SELECT id, title, note, project_id, CASE WHEN status = 'later' THEN 'later' ELSE 'new' END, later_at, promoted_to, created_at, updated_at
+FROM inbox_items;
+
+DROP TABLE inbox_items;
+ALTER TABLE inbox_items_new RENAME TO inbox_items;
+CREATE INDEX idx_inbox_status ON inbox_items(status);
+
+PRAGMA foreign_keys = ON;
 `,
   },
 ];

--- a/packages/projects-db/src/sqlite-repo.test.ts
+++ b/packages/projects-db/src/sqlite-repo.test.ts
@@ -25,7 +25,6 @@ const projectRow = (id: string, slug: string): ProjectRow => ({
   id,
   label: `Project ${id}`,
   slug,
-  workspace_dir: null,
   is_personal: 0,
   auto_dispatch: 0,
   sources: '[]',

--- a/packages/projects-db/src/types.ts
+++ b/packages/projects-db/src/types.ts
@@ -4,7 +4,6 @@ export type ProjectRow = {
   id: string;
   label: string;
   slug: string;
-  workspace_dir: string | null;
   is_personal: number;
   auto_dispatch: number;
   sources: string;             // JSON array of ProjectSource; defaults to '[]'
@@ -57,9 +56,9 @@ export type TicketRow = {
   supervisor_task_id: string | null;
   token_usage: string | null;           // JSON
   runs: string;                          // JSON array
-  // Launcher-specific (v6) — PR review state
-  pr_review: string | null;             // JSON { status, at } or null
-  pr_merged_at: string | null;          // epoch ms, stringified
+  // Launcher-specific PR state
+  pr_review: string | null;             // JSON array of PullRequestLink
+  pr_merged_at: string | null;          // JSON map source id -> epoch ms
   // Teams (SQLite v9 / PG v6) — assigned member's principal id, or null
   assignee: string | null;
   created_at: string;

--- a/packages/projects-mcp/index.d.ts
+++ b/packages/projects-mcp/index.d.ts
@@ -1,9 +1,15 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { IProjectsRepo } from 'omni-projects-db';
 
+export interface ProjectsMcpContext {
+  listSandboxProfiles?: () => Promise<Array<{ name: string; label?: string; available?: boolean; source?: string }>>;
+  listTeamMembers?: () => Promise<Array<{ user_id: string; display_name?: string | null; email?: string | null; role?: string | null }>>;
+  getCurrentPrincipal?: () => Promise<string | null>;
+}
+
 /**
  * Build the omni-projects MCP server over a backend-agnostic repo. The stdio
  * cli supplies a SqliteProjectsRepo; the launcher server's HTTP MCP route
  * supplies a tenant-scoped PgProjectsRepo.
  */
-export declare function createServer(repo: IProjectsRepo): McpServer;
+export declare function createServer(repo: IProjectsRepo, context?: ProjectsMcpContext): McpServer;

--- a/packages/projects-mcp/src/seed.ts
+++ b/packages/projects-mcp/src/seed.ts
@@ -31,13 +31,25 @@ export interface SeededProject {
   columns: string[];
 }
 
+export type ProjectSource = (
+  | { kind: 'local'; workspaceDir: string; gitDetected?: boolean }
+  | { kind: 'git-remote'; repoUrl: string; defaultBranch?: string }
+) & { id: string; mountName: string };
+
 /**
  * Create a project row, its default pipeline columns, and a root page (with
  * `# <label>` content). Caller must have already checked slug uniqueness.
  */
 export async function seedProject(
   repo: IProjectsRepo,
-  opts: { label: string; workspaceDir?: string | null; dueDate?: string | null; pinned?: boolean }
+  opts: {
+    label: string;
+    sources?: ProjectSource[];
+    autoDispatch?: boolean;
+    sandboxProfile?: string | null;
+    dueDate?: string | null;
+    pinned?: boolean;
+  }
 ): Promise<SeededProject> {
   const id = projectId();
   const slug = slugify(opts.label);
@@ -47,11 +59,10 @@ export async function seedProject(
     id,
     label: opts.label,
     slug,
-    workspace_dir: opts.workspaceDir ?? null,
     is_personal: 0,
-    auto_dispatch: 0,
-    sources: '[]',
-    sandbox_profile: null,
+    auto_dispatch: opts.autoDispatch ? 1 : 0,
+    sources: JSON.stringify(opts.sources ?? []),
+    sandbox_profile: opts.sandboxProfile ?? null,
     config: null,
     due_date: opts.dueDate ?? null,
     pinned_at: opts.pinned ? now : null,

--- a/packages/projects-mcp/src/server.ts
+++ b/packages/projects-mcp/src/server.ts
@@ -9,6 +9,12 @@ import { registerPipelineTools } from './tools/pipeline.js';
 import { registerProjectTools } from './tools/projects.js';
 import { registerTicketTools } from './tools/tickets.js';
 
+export interface ProjectsMcpContext {
+  listSandboxProfiles?: () => Promise<Array<{ name: string; label?: string; available?: boolean; source?: string }>>;
+  listTeamMembers?: () => Promise<Array<{ user_id: string; display_name?: string | null; email?: string | null; role?: string | null }>>;
+  getCurrentPrincipal?: () => Promise<string | null>;
+}
+
 /**
  * Build the omni-projects MCP server over a backend-agnostic
  * {@link IProjectsRepo}. Two callers supply the repo:
@@ -20,7 +26,7 @@ import { registerTicketTools } from './tools/tickets.js';
  * Page bodies live in the DB (`getPageContent`/`setPageContent`), so the
  * server no longer touches the filesystem.
  */
-export function createServer(repo: IProjectsRepo): McpServer {
+export function createServer(repo: IProjectsRepo, context: ProjectsMcpContext = {}): McpServer {
   const server = new McpServer({ name: 'omni-projects', version: '0.1.0' }, { capabilities: { tools: {} } });
 
   registerProjectTools(server, repo);
@@ -30,6 +36,41 @@ export function createServer(repo: IProjectsRepo): McpServer {
   registerPageTools(server, repo);
   registerInboxTools(server, repo);
   registerPipelineTools(server, repo);
+
+  server.tool(
+    'list_sandbox_profiles',
+    'List sandbox profile names valid for project sandbox_profile and launch profile settings.',
+    {},
+    async () => {
+      const profiles = context.listSandboxProfiles
+        ? await context.listSandboxProfiles()
+        : [
+            { name: 'host', label: 'This computer (no sandbox)', available: true, source: 'builtin' },
+            { name: 'devbox', label: 'Devbox (Docker)', available: true, source: 'builtin' },
+          ];
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ profiles }) }] };
+    }
+  );
+
+  server.tool(
+    'list_team_members',
+    'List team members valid for ticket assignee. Empty in single-user/local mode.',
+    {},
+    async () => {
+      const members = context.listTeamMembers ? await context.listTeamMembers() : [];
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ members }) }] };
+    }
+  );
+
+  server.tool(
+    'get_current_principal',
+    'Return the current principal/user ID for assigning tickets to self. Null in single-user/local mode.',
+    {},
+    async () => {
+      const principal = context.getCurrentPrincipal ? await context.getCurrentPrincipal() : null;
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ principal }) }] };
+    }
+  );
 
   return server;
 }

--- a/packages/projects-mcp/src/tools/pipeline.ts
+++ b/packages/projects-mcp/src/tools/pipeline.ts
@@ -17,6 +17,35 @@ const parseWorkflow = (raw: string | null): unknown | undefined => {
   }
 };
 
+const workflowSchema = z
+  .object({
+    purpose: z.string().optional(),
+    entryCriteria: z.array(z.string()).optional(),
+    definitionOfDone: z.array(z.string()).optional(),
+    agentInstructions: z.string().optional(),
+    recommendedSkills: z.array(z.string()).optional(),
+    allowedTransitions: z.array(z.string()).optional(),
+    autoDispatch: z.boolean().optional(),
+  })
+  .passthrough();
+
+const columnSchema = z.object({
+  id: z.string().optional().describe('Stable logical column ID. If omitted, derived from the label.'),
+  label: z.string().describe('Column label.'),
+  description: z.string().optional().describe('Column description.'),
+  gate: z.boolean().optional().describe('Whether this column is a human-review gate.'),
+  maxConcurrent: z.number().int().positive().optional().describe('Maximum concurrent work items for this column.'),
+  workflow: workflowSchema.optional().describe('Workflow contract for agents and humans.'),
+});
+
+function logicalIdFor(label: string): string {
+  const slug = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return slug || 'column';
+}
+
 export function registerPipelineTools(server: McpServer, repo: IProjectsRepo): void {
   server.tool(
     'get_pipeline',
@@ -42,6 +71,44 @@ export function registerPipelineTools(server: McpServer, repo: IProjectsRepo): v
           workflow: parseWorkflow(c.workflow),
         })),
       });
+    }
+  );
+
+  server.tool(
+    'update_pipeline',
+    'Replace the pipeline definition for a project. Remaps tickets safely when columns are removed.',
+    {
+      project_id: z.string().describe('The project ID to update the pipeline for.'),
+      columns: z.array(columnSchema).min(1).describe('Ordered pipeline column definitions.'),
+    },
+    async ({ project_id, columns }) => {
+      const exists = await repo.getProject(project_id);
+      if (!exists) return err(`Project not found: ${project_id}`);
+
+      const labels = new Set<string>();
+      const logicalIds = new Set<string>();
+      for (const column of columns) {
+        const labelKey = column.label.toLowerCase();
+        if (labels.has(labelKey)) return err(`Duplicate column label: ${column.label}`);
+        labels.add(labelKey);
+        const logicalId = column.id ?? logicalIdFor(column.label);
+        if (logicalIds.has(logicalId)) return err(`Duplicate column id: ${logicalId}`);
+        logicalIds.add(logicalId);
+      }
+
+      const result = await repo.syncColumnsForProject(
+        project_id,
+        columns.map((column) => ({
+          logicalId: column.id ?? logicalIdFor(column.label),
+          label: column.label,
+          description: column.description ?? null,
+          gate: column.gate ?? false,
+          maxConcurrent: column.maxConcurrent ?? null,
+          workflow: column.workflow,
+        }))
+      );
+
+      return json({ ok: true, ...result });
     }
   );
 }

--- a/packages/projects-mcp/src/tools/projects.ts
+++ b/packages/projects-mcp/src/tools/projects.ts
@@ -1,11 +1,82 @@
+import { randomBytes } from 'node:crypto';
+
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { type IProjectsRepo, nowTimestamp } from 'omni-projects-db';
 import { z } from 'zod';
 
-import { seedProject, slugify } from '../seed.js';
+import { type ProjectSource, seedProject, slugify } from '../seed.js';
 
 const json = (data: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(data) }] });
 const err = (message: string) => ({ content: [{ type: 'text' as const, text: JSON.stringify({ error: message }) }], isError: true as const });
+
+const sourceSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('local'),
+    id: z.string().optional(),
+    mountName: z.string(),
+    workspaceDir: z.string(),
+    gitDetected: z.boolean().optional(),
+  }),
+  z.object({
+    kind: z.literal('git-remote'),
+    id: z.string().optional(),
+    mountName: z.string(),
+    repoUrl: z.string(),
+    defaultBranch: z.string().optional(),
+  }),
+]);
+
+function normalizeSources(sources: z.infer<typeof sourceSchema>[] | undefined): ProjectSource[] {
+  return (sources ?? []).map((source) => ({ ...source, id: source.id ?? randomBytes(8).toString('hex') }));
+}
+
+const trimTrailingSlashes = (value: string): string => value.replace(/[\\/]+$/, '');
+
+function normalizeLocalSourcePath(workspaceDir: string): string {
+  const normalized = trimTrailingSlashes(workspaceDir.trim().replace(/\\+/g, '/'));
+  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function normalizeGitRemoteUrl(repoUrl: string): string {
+  const trimmed = trimTrailingSlashes(repoUrl.trim()).replace(/\.git$/i, '');
+  const scpLike = trimmed.match(/^([^@\s]+)@([^:\s]+):(.+)$/);
+  const parseTarget = scpLike ? `ssh://${scpLike[1]}@${scpLike[2]}/${scpLike[3]}` : trimmed;
+
+  try {
+    const parsed = new URL(parseTarget);
+    const host = parsed.hostname.toLowerCase();
+    const pathname = trimTrailingSlashes(decodeURIComponent(parsed.pathname)).replace(/^\/+/, '').replace(/\.git$/i, '');
+    return `${host}/${pathname.toLowerCase()}`;
+  } catch {
+    return trimmed.toLowerCase();
+  }
+}
+
+function sourceIdentityKey(source: ProjectSource): string {
+  return source.kind === 'local'
+    ? `local:${normalizeLocalSourcePath(source.workspaceDir)}`
+    : `git-remote:${normalizeGitRemoteUrl(source.repoUrl)}`;
+}
+
+function validateSources(sources: ProjectSource[]): string | null {
+  const mountNames = new Set<string>();
+  const identities = new Set<string>();
+  for (const source of sources) {
+    if (mountNames.has(source.mountName)) return `Duplicate mount name: "${source.mountName}". Each source needs a unique name.`;
+    mountNames.add(source.mountName);
+    const identity = sourceIdentityKey(source);
+    if (identities.has(identity)) {
+      return source.kind === 'local' ? 'This project already includes that local folder.' : 'This project already includes that repository.';
+    }
+    identities.add(identity);
+  }
+  return null;
+}
+
+function parseSources(raw: string): ProjectSource[] {
+  const parsed = JSON.parse(raw) as unknown;
+  return Array.isArray(parsed) ? (parsed as ProjectSource[]) : [];
+}
 
 export function registerProjectTools(server: McpServer, repo: IProjectsRepo): void {
   server.tool(
@@ -21,8 +92,10 @@ export function registerProjectTools(server: McpServer, repo: IProjectsRepo): vo
             id: p.id,
             label: p.label,
             slug: p.slug,
-            workspace_dir: p.workspace_dir,
+            sources: parseSources(p.sources),
             is_personal: !!p.is_personal,
+            auto_dispatch: !!p.auto_dispatch,
+            sandbox_profile: p.sandbox_profile,
             due_date: p.due_date,
             pinned_at: p.pinned_at,
             columns: cols.map((c) => c.label),
@@ -36,14 +109,16 @@ export function registerProjectTools(server: McpServer, repo: IProjectsRepo): vo
 
   server.tool(
     'create_project',
-    'Create a new project. Optionally link a local directory as the workspace.',
+    'Create a new project. Optionally attach local or git-remote sources.',
     {
       label: z.string().describe('Human-readable project name'),
-      workspace_dir: z.string().optional().describe('Local directory to link as the project workspace.'),
+      sources: z.array(sourceSchema).optional().describe('Sources to attach to the project.'),
+      auto_dispatch: z.boolean().optional().describe('Enable automatic dispatch for ready tickets.'),
+      sandbox_profile: z.string().optional().describe('Per-project sandbox profile name. Omit or pass empty string to inherit the default.'),
       due_date: z.string().optional().describe('Optional due date in ISO format (e.g. 2026-04-30).'),
       pinned: z.boolean().optional().describe('Pin the project to Home on creation.'),
     },
-    async ({ label, workspace_dir, due_date, pinned }) => {
+    async ({ label, sources, auto_dispatch, sandbox_profile, due_date, pinned }) => {
       if (due_date) {
         const parsed = Date.parse(due_date);
         if (Number.isNaN(parsed)) return err('Invalid due_date. Use an ISO date like 2026-04-30.');
@@ -53,9 +128,15 @@ export function registerProjectTools(server: McpServer, repo: IProjectsRepo): vo
       const existing = await repo.getProjectBySlug(slug);
       if (existing) return err(`A project with slug "${slug}" already exists.`);
 
+      const normalizedSources = normalizeSources(sources);
+      const sourceError = validateSources(normalizedSources);
+      if (sourceError) return err(sourceError);
+
       const seeded = await seedProject(repo, {
         label,
-        workspaceDir: workspace_dir ?? null,
+        sources: normalizedSources,
+        autoDispatch: auto_dispatch ?? false,
+        sandboxProfile: sandbox_profile || null,
         dueDate: due_date ?? null,
         pinned: pinned ?? false,
       });
@@ -64,7 +145,9 @@ export function registerProjectTools(server: McpServer, repo: IProjectsRepo): vo
         id: seeded.id,
         label: seeded.label,
         slug: seeded.slug,
-        workspace_dir: workspace_dir ?? null,
+        sources: normalizedSources,
+        auto_dispatch: auto_dispatch ?? false,
+        sandbox_profile: sandbox_profile || null,
         pipeline: seeded.columns,
         root_page_id: seeded.rootPageId,
       });
@@ -73,15 +156,17 @@ export function registerProjectTools(server: McpServer, repo: IProjectsRepo): vo
 
   server.tool(
     'update_project',
-    "Update a project's label, linked workspace, deadline, or pin state.",
+    "Update a project's label, sources, auto-dispatch, sandbox profile, deadline, or pin state.",
     {
       project_id: z.string().describe('The project ID to update'),
       label: z.string().optional().describe('New project name'),
-      workspace_dir: z.string().optional().describe('Set the linked local directory. Pass empty string to unlink.'),
+      sources: z.array(sourceSchema).optional().describe('Replace the project source list.'),
+      auto_dispatch: z.boolean().optional().describe('Enable or disable automatic dispatch for ready tickets.'),
+      sandbox_profile: z.string().optional().describe('Per-project sandbox profile name. Pass empty string to inherit the default.'),
       due_date: z.string().optional().describe('Due date in ISO format. Pass empty string to clear.'),
       pinned: z.boolean().optional().describe('true pins the project to Home, false unpins it.'),
     },
-    async ({ project_id, label, workspace_dir, due_date, pinned }) => {
+    async ({ project_id, label, sources, auto_dispatch, sandbox_profile, due_date, pinned }) => {
       const project = await repo.getProject(project_id);
       if (!project) return err(`Project not found: ${project_id}`);
 
@@ -98,8 +183,17 @@ export function registerProjectTools(server: McpServer, repo: IProjectsRepo): vo
         next.label = label;
         next.slug = slug;
       }
-      if (workspace_dir !== undefined) {
-        next.workspace_dir = workspace_dir || null;
+      if (sources !== undefined) {
+        const normalizedSources = normalizeSources(sources);
+        const sourceError = validateSources(normalizedSources);
+        if (sourceError) return err(sourceError);
+        next.sources = JSON.stringify(normalizedSources);
+      }
+      if (auto_dispatch !== undefined) {
+        next.auto_dispatch = auto_dispatch ? 1 : 0;
+      }
+      if (sandbox_profile !== undefined) {
+        next.sandbox_profile = sandbox_profile || null;
       }
       if (due_date !== undefined) {
         if (due_date === '') {

--- a/packages/projects-mcp/src/tools/tickets.ts
+++ b/packages/projects-mcp/src/tools/tickets.ts
@@ -19,6 +19,8 @@ function ticketPayload(t: TicketRow, cols: ColumnRow[], comments: CommentRow[]) 
     pipeline: cols.map((c) => c.label),
     blocked_by: JSON.parse(t.blocked_by),
     branch: t.branch,
+    use_worktree: !!t.use_worktree,
+    assignee: t.assignee,
     resolution: t.resolution,
     archived_at: t.archived_at,
     created_at: t.created_at,
@@ -57,8 +59,11 @@ export function registerTicketTools(server: McpServer, repo: IProjectsRepo): voi
       description: z.string().optional().describe('Ticket description'),
       priority: z.enum(['low', 'medium', 'high', 'critical']).optional().describe('Ticket priority (default: medium)'),
       milestone_id: z.string().optional().describe('Optional milestone ID to group this ticket under.'),
+      branch: z.string().optional().describe('Git branch for this ticket.'),
+      use_worktree: z.boolean().optional().describe('Whether to create/use an isolated git worktree for this ticket.'),
+      assignee: z.string().optional().describe('Assigned principal/user ID.'),
     },
-    async ({ project_id, title, description, priority, milestone_id }) => {
+    async ({ project_id, title, description, priority, milestone_id, branch, use_worktree, assignee }) => {
       const cols = await repo.listColumns(project_id);
       const firstCol = cols[0];
       if (!firstCol) return err(`Project not found or has no pipeline: ${project_id}`);
@@ -73,13 +78,13 @@ export function registerTicketTools(server: McpServer, repo: IProjectsRepo): voi
         title,
         description: description ?? '',
         priority: priority ?? 'medium',
-        branch: null,
+        branch: branch || null,
         blocked_by: '[]',
         resolution: null,
         resolved_at: null,
         archived_at: null,
         column_changed_at: null,
-        use_worktree: 0,
+        use_worktree: use_worktree ? 1 : 0,
         worktree_path: null,
         worktree_name: null,
         supervisor_session_id: null,
@@ -90,7 +95,7 @@ export function registerTicketTools(server: McpServer, repo: IProjectsRepo): voi
         runs: '[]',
         pr_review: null,
         pr_merged_at: null,
-        assignee: null,
+        assignee: assignee || null,
         created_at: now,
         updated_at: now,
       });
@@ -108,10 +113,12 @@ export function registerTicketTools(server: McpServer, repo: IProjectsRepo): voi
       description: z.string().optional().describe('New description'),
       priority: z.enum(['low', 'medium', 'high', 'critical']).optional().describe('New priority'),
       branch: z.string().optional().describe('Git branch for this ticket.'),
+      use_worktree: z.boolean().optional().describe('Whether to create/use an isolated git worktree for this ticket.'),
+      assignee: z.string().optional().describe('Assigned principal/user ID. Pass empty string to clear.'),
       add_blocked_by: z.array(z.string()).optional().describe('Ticket IDs to add as blockers.'),
       remove_blocked_by: z.array(z.string()).optional().describe('Ticket IDs to remove as blockers.'),
     },
-    async ({ ticket_id, title, description, priority, branch, add_blocked_by, remove_blocked_by }) => {
+    async ({ ticket_id, title, description, priority, branch, use_worktree, assignee, add_blocked_by, remove_blocked_by }) => {
       const ticket = await repo.getTicket(ticket_id);
       if (!ticket) return err(`Ticket not found: ${ticket_id}`);
 
@@ -120,6 +127,8 @@ export function registerTicketTools(server: McpServer, repo: IProjectsRepo): voi
       if (description !== undefined) next.description = description;
       if (priority !== undefined) next.priority = priority;
       if (branch !== undefined) next.branch = branch || null;
+      if (use_worktree !== undefined) next.use_worktree = use_worktree ? 1 : 0;
+      if (assignee !== undefined) next.assignee = assignee || null;
 
       if (add_blocked_by || remove_blocked_by) {
         const current = new Set<string>(JSON.parse(ticket.blocked_by));
@@ -226,6 +235,9 @@ export function registerTicketTools(server: McpServer, repo: IProjectsRepo): voi
             column: col?.label ?? t.column_id,
             milestone_id: t.milestone_id,
             blocked_by: JSON.parse(t.blocked_by),
+            branch: t.branch,
+            use_worktree: !!t.use_worktree,
+            assignee: t.assignee,
             created_at: t.created_at,
             updated_at: t.updated_at,
           };
@@ -269,6 +281,9 @@ export function registerTicketTools(server: McpServer, repo: IProjectsRepo): voi
           description: t.description,
           priority: t.priority,
           column: await labelFor(t),
+          branch: t.branch,
+          use_worktree: !!t.use_worktree,
+          assignee: t.assignee,
           created_at: t.created_at,
           updated_at: t.updated_at,
         }))

--- a/src/main/db-store-bridge.ts
+++ b/src/main/db-store-bridge.ts
@@ -113,20 +113,6 @@ export function rowToProject(row: ProjectRow): Project {
     // Malformed JSON — treat as no sources rather than crash.
   }
 
-  // ``workspace_dir`` column is the authoritative single-source store for
-  // MCP ``update_project workspace_dir`` writes (callers don't know about
-  // the multi-source model yet). When set + the project has at least one
-  // local source, override the first local source's workspaceDir.
-  if (row.workspace_dir) {
-    const idx = sources.findIndex((s) => s.kind === 'local');
-    if (idx >= 0) {
-      const existing = sources[idx]!;
-      if (existing.kind === 'local') {
-        sources[idx] = { ...existing, workspaceDir: row.workspace_dir };
-      }
-    }
-  }
-
   const project: Project = {
     id: row.id as ProjectId,
     label: row.label,
@@ -298,19 +284,10 @@ export function rowToTask(row: TaskRow): Task {
 
 export function projectToRow(p: Project): ProjectRow {
   const now = toIso(Date.now());
-  // ``workspace_dir`` column mirrors the first local source's path so the
-  // launcher and the MCP server (which reads/writes the column directly)
-  // agree on the project's linked directory for the single-source
-  // ergonomic case. Multi-source projects: still mirror the first local
-  // source, since MCP's update_project workspace_dir API doesn't know
-  // about the array model.
-  const firstLocal = p.sources.find((s) => s.kind === 'local');
-  const workspaceDir = firstLocal?.kind === 'local' ? firstLocal.workspaceDir : null;
   return {
     id: p.id,
     label: p.label,
     slug: p.slug,
-    workspace_dir: workspaceDir,
     is_personal: p.isPersonal ? 1 : 0,
     auto_dispatch: p.autoDispatch ? 1 : 0,
     sources: JSON.stringify(p.sources),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -234,6 +234,7 @@ const main = async () => {
     getProcessManager,
     ensureTenantReady,
     getTenantRepo,
+    getMcpContext,
     teamsEnabled,
     ensureUserBootstrapped,
     resolveActiveTeam,
@@ -256,7 +257,11 @@ const main = async () => {
   // HTTP MCP route — remote agent sandboxes reach their tenant's project data
   // here (authenticated by the signed runtime token). Local Electron/stdio
   // doesn't use it; it's harmless when no sandbox calls it.
-  registerMcpHttpRoute(fastify, { runtimeTokenSecret, getTenantRepo });
+  registerMcpHttpRoute(fastify, {
+    runtimeTokenSecret,
+    getTenantRepo,
+    getContext: (claims) => getMcpContext(claims.tenantId, claims.principalId ?? claims.tenantId),
+  });
   console.log(`[mcp-http] omni-projects MCP available at ${MCP_PROJECTS_PATH}`);
 
   // Local voice (Option A) — self-hosted only. STT/TTS run on this host, so it

--- a/src/server/managers.ts
+++ b/src/server/managers.ts
@@ -698,6 +698,42 @@ export const wireGlobalHandlers = async (arg: {
     }
     return snapshot;
   };
+
+  const sandboxProfileLabel = (name: string): string => {
+    if (name === 'host') return 'This computer (no sandbox)';
+    if (name === 'devbox') return 'Devbox (Docker)';
+    if (name === 'platform') return 'Cloud (managed)';
+    if (name === ACI_PROFILE_NAME) return 'Cloud · Fast';
+    if (name === ACI_DESKTOP_PROFILE_NAME) return 'Cloud · Desktop (IDE + VNC)';
+    if (name.startsWith('local:')) return `Local · ${name.slice('local:'.length, 'local:'.length + 8)}`;
+    return name.length > 0 ? name[0]!.toUpperCase() + name.slice(1) : name;
+  };
+
+  const getMcpContext = (tenantId: string, principalId: string = tenantId) => ({
+    listSandboxProfiles: async () => {
+      const snapshot = getStoreSnapshot(tenantId, principalId);
+      const names = snapshot.availableSandboxProfiles && snapshot.availableSandboxProfiles.length > 0
+        ? snapshot.availableSandboxProfiles
+        : ['host', 'devbox'];
+      return names.map((name) => ({
+        name,
+        label: sandboxProfileLabel(name),
+        available: true,
+        source: name.startsWith('local:') ? 'local-machine' : name.startsWith('aci') ? 'cloud' : 'builtin',
+      }));
+    },
+    listTeamMembers: async () => {
+      if (!teamsEnabled || !controlPlane) return [];
+      const rows = await controlPlane.listMembers(tenantId);
+      return rows.map((m) => ({
+        user_id: m.user_id,
+        display_name: m.display_name,
+        email: m.email,
+        role: m.role,
+      }));
+    },
+    getCurrentPrincipal: async () => (teamsEnabled ? principalId : null),
+  });
   /**
    * Broadcast a (team, principal) store snapshot. Cloud: to ONLY that principal's
    * sessions (the snapshot carries user-scoped keys that must not leak to other
@@ -1550,6 +1586,7 @@ export const wireGlobalHandlers = async (arg: {
     getProcessManager,
     ensureTenantReady,
     getTenantRepo,
+    getMcpContext,
     runtimeTokenSecret,
     teamsEnabled,
     controlPlane,

--- a/src/server/mcp-http.ts
+++ b/src/server/mcp-http.ts
@@ -24,7 +24,7 @@
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import type { FastifyInstance } from 'fastify';
 import type { IProjectsRepo } from 'omni-projects-db';
-import { createServer } from 'omni-projects-mcp';
+import { createServer, type ProjectsMcpContext } from 'omni-projects-mcp';
 
 import { verifyRuntimeToken } from '@/server/runtime-token';
 
@@ -33,6 +33,8 @@ export interface McpHttpDeps {
   runtimeTokenSecret: string;
   /** Resolve a tenant-scoped repo from the verified token's tenant. */
   getTenantRepo: (tenantId: string) => IProjectsRepo;
+  /** Resolve option-discovery providers from the verified token claims. */
+  getContext?: (claims: { tenantId: string; principalId?: string }) => ProjectsMcpContext;
 }
 
 export const MCP_PROJECTS_PATH = '/mcp/projects';
@@ -70,7 +72,7 @@ export function registerMcpHttpRoute(fastify: FastifyInstance, deps: McpHttpDeps
     }
 
     const repo = deps.getTenantRepo(claims.tenantId);
-    const server = createServer(repo);
+    const server = createServer(repo, deps.getContext?.(claims) ?? {});
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 
     // Hand the raw Node req/res to the transport; Fastify must not also try to

--- a/src/server/mcp-projects-smoke.test.ts
+++ b/src/server/mcp-projects-smoke.test.ts
@@ -35,7 +35,16 @@ beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), 'omni-mcp-'));
   db = openDatabase(join(dir, 'projects.db'));
   repo = new SqliteProjectsRepo(new ProjectsRepo(db));
-  const server = createServer(repo);
+  const server = createServer(repo, {
+    listSandboxProfiles: async () => [
+      { name: 'host', label: 'This computer (no sandbox)', available: true, source: 'builtin' },
+      { name: 'devbox', label: 'Devbox (Docker)', available: true, source: 'builtin' },
+    ],
+    listTeamMembers: async () => [
+      { user_id: 'principal-1', display_name: 'Ada Lovelace', email: 'ada@example.com', role: 'member' },
+    ],
+    getCurrentPrincipal: async () => 'principal-1',
+  });
 
   const [clientT, serverT] = InMemoryTransport.createLinkedPair();
   client = new Client({ name: 'test', version: '0.0.0' });
@@ -52,16 +61,49 @@ describe('omni-projects MCP tools (async IProjectsRepo, SQLite)', () => {
   let projectId: string;
   let ticketId: string;
 
+  it('lists valid option values for sandbox profiles and assignees', async () => {
+    const profiles = await call('list_sandbox_profiles');
+    expect(profiles.profiles.map((profile: any) => profile.name)).toContain('devbox');
+
+    const members = await call('list_team_members');
+    expect(members.members).toEqual([
+      expect.objectContaining({ user_id: 'principal-1', display_name: 'Ada Lovelace' }),
+    ]);
+
+    const principal = await call('get_current_principal');
+    expect(principal.principal).toBe('principal-1');
+  });
+
   it('creates and lists a project with seeded pipeline + root page', async () => {
-    const created = await call('create_project', { label: 'Test Project' });
+    const sources = [
+      { kind: 'local', mountName: 'local-app', workspaceDir: '/tmp/local-app', gitDetected: true },
+      { kind: 'git-remote', mountName: 'remote-app', repoUrl: 'https://github.com/acme/remote-app.git', defaultBranch: 'main' },
+    ];
+    const created = await call('create_project', {
+      label: 'Test Project',
+      sources,
+      auto_dispatch: true,
+      sandbox_profile: 'devbox',
+    });
     expect(created._isError).toBe(false);
     expect(created.id).toMatch(/^proj_/);
+    expect(created.sources).toEqual([
+      expect.objectContaining(sources[0]),
+      expect.objectContaining(sources[1]),
+    ]);
+    expect(created.sources[0].id).toBeTruthy();
+    expect(created.auto_dispatch).toBe(true);
+    expect(created.sandbox_profile).toBe('devbox');
     expect(created.pipeline.length).toBeGreaterThan(0);
     expect(created.root_page_id).toMatch(/^pg_/);
     projectId = created.id;
 
     const listed = await call('list_projects');
-    expect(listed.projects.find((p: any) => p.id === projectId)?.label).toBe('Test Project');
+    const listedProject = listed.projects.find((p: any) => p.id === projectId);
+    expect(listedProject?.label).toBe('Test Project');
+    expect(listedProject?.sources).toEqual(created.sources);
+    expect(listedProject?.auto_dispatch).toBe(true);
+    expect(listedProject?.sandbox_profile).toBe('devbox');
 
     // Root page content was written to the DB (not the filesystem).
     const page = await call('read_page', { page_id: created.root_page_id });
@@ -74,17 +116,64 @@ describe('omni-projects MCP tools (async IProjectsRepo, SQLite)', () => {
     expect(dup.error).toMatch(/already exists/);
   });
 
+  it('updates project sources and rejects duplicates', async () => {
+    const duplicateSources = [
+      { kind: 'git-remote', mountName: 'repo', repoUrl: 'https://github.com/acme/repo.git' },
+      { kind: 'git-remote', mountName: 'repo-copy', repoUrl: 'git@github.com:acme/repo.git' },
+    ];
+    const duplicate = await call('update_project', { project_id: projectId, sources: duplicateSources });
+    expect(duplicate._isError).toBe(true);
+    expect(duplicate.error).toMatch(/repository/);
+
+    const sources = [{ kind: 'local', mountName: 'replacement', workspaceDir: '/tmp/replacement' }];
+    const updated = await call('update_project', {
+      project_id: projectId,
+      sources,
+      auto_dispatch: false,
+      sandbox_profile: '',
+    });
+    expect(updated.ok).toBe(true);
+
+    const listed = await call('list_projects');
+    expect(listed.projects.find((p: any) => p.id === projectId)?.sources).toEqual([
+      expect.objectContaining(sources[0]),
+    ]);
+    expect(listed.projects.find((p: any) => p.id === projectId)?.auto_dispatch).toBe(false);
+    expect(listed.projects.find((p: any) => p.id === projectId)?.sandbox_profile).toBeNull();
+  });
+
+  it('updates pipeline definitions', async () => {
+    const updated = await call('update_pipeline', {
+      project_id: projectId,
+      columns: [
+        { id: 'backlog', label: 'Backlog', workflow: { purpose: 'Collect work' } },
+        { id: 'implementation', label: 'Implementation', maxConcurrent: 2, workflow: { definitionOfDone: ['changed'] } },
+        { id: 'review', label: 'Review', gate: true },
+        { id: 'completed', label: 'Completed' },
+      ],
+    });
+    expect(updated.ok).toBe(true);
+
+    const pipeline = await call('get_pipeline', { project_id: projectId });
+    const implementation = pipeline.columns.find((column: any) => column.label === 'Implementation');
+    expect(implementation.maxConcurrent).toBe(2);
+    expect(implementation.workflow.definitionOfDone).toEqual(['changed']);
+  });
+
   it('creates, moves, and lists a ticket', async () => {
     const pipeline = await call('get_pipeline', { project_id: projectId });
-    const spec = pipeline.columns.find((column: any) => column.label === 'Spec');
-    expect(spec.workflow).toMatchObject({
-      purpose: expect.stringContaining('decision-complete'),
-      definitionOfDone: expect.arrayContaining([expect.stringContaining('plan')]),
-      recommendedSkills: expect.arrayContaining(['software-planning']),
-    });
+    const implementation = pipeline.columns.find((column: any) => column.label === 'Implementation');
+    expect(implementation.workflow.definitionOfDone).toEqual(['changed']);
     const lastCol = pipeline.columns[pipeline.columns.length - 1].label;
 
-    const created = await call('create_ticket', { project_id: projectId, title: 'Do the thing', priority: 'high' });
+    const created = await call('create_ticket', {
+      project_id: projectId,
+      title: 'Do the thing',
+      priority: 'high',
+      branch: 'main',
+      use_worktree: true,
+      assignee: 'principal-1',
+    });
     expect(created._isError).toBe(false);
     ticketId = created.id;
 
@@ -122,12 +211,16 @@ describe('omni-projects MCP tools (async IProjectsRepo, SQLite)', () => {
     const upd = await call('update_ticket', {
       ticket_id: ticketId,
       description: 'now described',
+      use_worktree: false,
+      assignee: '',
       add_blocked_by: ['tkt_other'],
     });
     expect(upd.ok).toBe(true);
 
     const got = await call('get_ticket', { ticket_id: ticketId });
     expect(got.description).toBe('now described');
+    expect(got.use_worktree).toBe(false);
+    expect(got.assignee).toBeNull();
     expect(got.blocked_by).toEqual(['tkt_other']);
   });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -681,9 +681,7 @@ export const schema: Schema<StoreData> = {
         note: { type: 'string' },
         attachments: { type: 'array', items: { type: 'string' } },
         projectId: { type: ['string', 'null'] },
-        // 'shaped' stays in the storage enum so pre-v25 data validates at
-        // store construction; the v25 migration remaps it to 'new'.
-        status: { type: 'string', enum: ['new', 'shaped', 'later'] },
+        status: { type: 'string', enum: ['new', 'later'] },
         laterAt: { type: 'number' },
         promotedTo: {
           type: 'object',


### PR DESCRIPTION
## Summary
- cut over projects DB/MCP from legacy `workspace_dir` to canonical multi-source `sources`
- expose live project/ticket/pipeline fields through the omni-projects MCP server
- add option-discovery tools for sandbox profiles, team members, and current principal

## Validation
- `npm --workspace packages/projects-db run build`
- `npm --workspace packages/projects-mcp run build`
- `npx vitest run packages/projects-db/src/migrate.test.ts packages/projects-db/src/sqlite-repo.test.ts packages/projects-db/src/repo.test.ts src/server/mcp-projects-smoke.test.ts`

## Notes
- Adds DB migrations for source cutover and inbox status tightening.
- Leaves project runtime config internal; it is still derived/backfilled rather than exposed as a normal MCP control surface.
