### PR TITLE
Show /loop scheduler status in Desktop chat

### DIFF
--- a/src/renderer/omniagents-ui/App.tsx
+++ b/src/renderer/omniagents-ui/App.tsx
@@ -25,6 +25,7 @@ import { ArtifactPortalProvider, type Attachment, MessageList } from './componen
 import { QueuedMessages } from './components/QueuedMessages';
 import { GoalPanel, type GoalSnapshot } from './components/GoalPanel';
 import { WakeupPanel, type WakeupSnapshot } from './components/WakeupPanel';
+import { LoopPanel, type LoopTaskSnapshot } from './components/LoopPanel';
 import { WorkersPanel, type WorkerSummary, type WorkersKillResult } from './components/WorkersPanel';
 import { ResizableDivider } from './components/ResizableDivider';
 import { type SessionItem, SessionList } from './components/SessionList';
@@ -166,6 +167,7 @@ export function App({
   const [liveBashJobs, setLiveBashJobs] = useState<BashJobSummary[] | null>(null);
   const [goalSnapshot, setGoalSnapshot] = useState<GoalSnapshot | null>(null);
   const [wakeupSnapshot, setWakeupSnapshot] = useState<WakeupSnapshot | null>(null);
+  const [loopTasks, setLoopTasks] = useState<LoopTaskSnapshot[]>([]);
   const [workers, setWorkers] = useState<WorkerSummary[]>([]);
   // Dismissed IDs for each docked panel. Snapshotted on user submit:
   // every item currently in a terminal state gets added so it disappears
@@ -260,10 +262,7 @@ export function App({
   // reaching into the transcript. Scoped by the same context the voice
   // system uses (the Code tab id; CHAT_VOICE_SCOPE on the Chat tab).
   const activityScope = useContext(VoiceScopeContext);
-  const pendingApproval = useMemo(
-    () => items.some((it) => (it as { type?: string }).type === 'approval'),
-    [items]
-  );
+  const pendingApproval = useMemo(() => items.some((it) => (it as { type?: string }).type === 'approval'), [items]);
   useEffect(() => {
     if (!activityScope) {
       return;
@@ -590,6 +589,26 @@ export function App({
         }
         return;
       }
+      if (fn === 'ui.loop.update') {
+        const request_id = String(p?.request_id ?? '');
+        const eventSessionId = typeof p?.session_id === 'string' ? p.session_id : undefined;
+        const currentSessionId = actor.getSnapshot().context.sessionId;
+        if (eventSessionId && currentSessionId && currentSessionId !== eventSessionId) {
+          if (request_id) {
+            client.clientResponse(request_id, true, { ack: true }).catch(() => {});
+          }
+          return;
+        }
+        const args = p?.args || {};
+        const snap = args?.snapshot;
+        if (Array.isArray(snap)) {
+          setLoopTasks(snap as LoopTaskSnapshot[]);
+        }
+        if (request_id) {
+          client.clientResponse(request_id, true, { ack: true }).catch(() => {});
+        }
+        return;
+      }
       if (fn === 'escalate') {
         // Agent ``escalate`` builtin — blocking. Surface the banner and
         // intentionally do NOT call clientResponse here; the next user
@@ -763,6 +782,7 @@ export function App({
 
   const handleGoalDismiss = useCallback(() => setGoalSnapshot(null), []);
   const handleWakeupDismiss = useCallback(() => setWakeupSnapshot(null), []);
+  const handleLoopDismiss = useCallback(() => setLoopTasks([]), []);
 
   useEffect(() => {
     const handler = () => setIsLargeScreen(window.innerWidth >= 1024);
@@ -1552,6 +1572,17 @@ export function App({
       } else {
         setWakeupSnapshot(null);
       }
+      if (resolvedId) {
+        try {
+          const res = (await client.serverCall('loop.status', {}, resolvedId)) as { snapshot?: unknown } | undefined;
+          const snap = res?.snapshot;
+          setLoopTasks(Array.isArray(snap) ? (snap as LoopTaskSnapshot[]) : []);
+        } catch {
+          setLoopTasks([]);
+        }
+      } else {
+        setLoopTasks([]);
+      }
       // Seed the workers panel from server state. Same rationale as goal:
       // catches the case where workers were spawned earlier and are still
       // running when we attach.
@@ -1798,6 +1829,7 @@ export function App({
               </div>
               <GoalPanel snapshot={goalSnapshot} onDismiss={handleGoalDismiss} />
               <WakeupPanel snapshot={wakeupSnapshot} onDismiss={handleWakeupDismiss} />
+              <LoopPanel tasks={loopTasks} onDismiss={handleLoopDismiss} />
               <Tasks tasks={tasks} />
               <WorkersPanel workers={visibleWorkers} onKill={handleWorkerKill} onDismiss={handleWorkerDismiss} />
               <BashJobs

--- a/src/renderer/omniagents-ui/components/LoopPanel.tsx
+++ b/src/renderer/omniagents-ui/components/LoopPanel.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+export type LoopTaskSnapshot = {
+  id: string;
+  prompt: string;
+  mode: 'dynamic' | 'fixed_interval' | 'fixed_cron';
+  cron: string | null;
+  interval_seconds: number | null;
+  recurring: boolean;
+  created_at: number;
+  expires_at: number | null;
+  next_fire_at: number | null;
+  fires: number;
+  status: 'active' | 'cancelled' | 'expired' | 'completed';
+  last_fire_at: number | null;
+  last_reason: string | null;
+  jitter_seconds: number;
+};
+
+const PROMPT_TRUNCATE = 100;
+
+function shortPrompt(prompt: string, max: number): string {
+  const oneLine = prompt.replace(/\s+/g, ' ').trim();
+  if (oneLine.length <= max) return oneLine;
+  return oneLine.slice(0, max - 1) + '…';
+}
+
+function formatInterval(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rem = minutes - hours * 60;
+  return rem === 0 ? `${hours}h` : `${hours}h${rem}m`;
+}
+
+function formatTimeRemaining(unixTimestamp: number): string {
+  const remaining = Math.max(0, unixTimestamp - Date.now() / 1000);
+  return formatInterval(remaining);
+}
+
+export function LoopPanel({ tasks, onDismiss }: { tasks: LoopTaskSnapshot[]; onDismiss?: () => void }) {
+  const active = tasks.filter((task) => task.status === 'active');
+  if (active.length === 0) return null;
+
+  const next = [...active].sort(
+    (a, b) => (a.next_fire_at ?? Number.MAX_SAFE_INTEGER) - (b.next_fire_at ?? Number.MAX_SAFE_INTEGER)
+  )[0];
+  if (!next) return null;
+  const cadence =
+    next.mode === 'dynamic'
+      ? 'dynamic'
+      : next.interval_seconds
+        ? `every ${formatInterval(next.interval_seconds)}`
+        : `cron ${next.cron}`;
+  const tail = [cadence, `id ${next.id}`];
+  if (next.next_fire_at) tail.unshift(`in ${formatTimeRemaining(next.next_fire_at)}`);
+  if (active.length > 1) tail.push(`${active.length} loops`);
+
+  return (
+    <div className="px-3 pt-2">
+      <div className="rounded-md border border-bgCardAlt bg-bgCardAlt/60 px-2.5 py-1.5">
+        <div className="flex items-center gap-2 text-xs text-textSubtle">
+          <span className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 bg-primary animate-pulse" aria-hidden />
+          <span className="font-medium text-textPrimary">loop</span>
+          <span aria-hidden>·</span>
+          <span className="truncate min-w-0 text-textPrimary" title={next.prompt}>
+            {shortPrompt(next.prompt, PROMPT_TRUNCATE)}
+          </span>
+          {tail.map((part, idx) => (
+            <React.Fragment key={idx}>
+              <span aria-hidden>·</span>
+              <span className="whitespace-nowrap">{part}</span>
+            </React.Fragment>
+          ))}
+          {onDismiss ? (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="ml-auto text-textSubtle hover:text-textPrimary transition-colors px-1.5 py-0.5 rounded hover:bg-bgCardAlt"
+              title="Dismiss loop status"
+              aria-label="Dismiss loop status"
+            >
+              dismiss
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a loop scheduler status panel to the embedded OmniAgents chat UI.
- Handle `ui.loop.update` snapshots, seed status from `loop.status`, and render the next active loop alongside goal/wakeup panels.
- Show prompt preview, cadence, next fire timing, loop id, and active loop count.

## Related
- Backend support: https://github.com/ericmichael/omni-code/pull/14
- OmniAgents UI support: https://github.com/utrgv-software-engineering/omniagents/pull/277

## Validation
- `npx tsc --noEmit --skipLibCheck --jsx react-jsx --moduleResolution bundler --module ESNext --target ES2022 --allowSyntheticDefaultImports --esModuleInterop src/renderer/omniagents-ui/components/LoopPanel.tsx`
- `npx prettier --check src/renderer/omniagents-ui/components/LoopPanel.tsx src/renderer/omniagents-ui/App.tsx`

## Notes
- Full `npm run lint:tsc` still fails on existing unrelated repo errors, including missing `omni-projects-db` typings and pre-existing strictness issues.
