### PR TITLE
Add Desktop Routines scheduled tasks

### DIFF
--- a/src/lib/scheduled-task-schedule.test.ts
+++ b/src/lib/scheduled-task-schedule.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mostRecentMissedScheduledTaskRun,
+  nextScheduledTaskRun,
+  normalizeScheduledTaskTime,
+  shouldCatchUpScheduledTask,
+} from '@/lib/scheduled-task-schedule';
+
+describe('scheduled task schedule helpers', () => {
+  it('computes interval schedules from the provided timestamp', () => {
+    expect(nextScheduledTaskRun({ kind: 'interval', everyMinutes: 15 }, 1_000)).toBe(901_000);
+  });
+
+  it('computes the next daily time', () => {
+    const after = new Date('2026-06-13T10:30:00').getTime();
+    const next = nextScheduledTaskRun({ kind: 'daily', time: '09:00' }, after);
+    expect(new Date(next!).getHours()).toBe(9);
+    expect(new Date(next!).getDate()).toBe(14);
+  });
+
+  it('skips weekends for weekday schedules', () => {
+    const after = new Date('2026-06-12T10:30:00').getTime();
+    const next = nextScheduledTaskRun({ kind: 'daily', time: '09:00', weekdaysOnly: true }, after);
+    expect(new Date(next!).getDay()).toBe(1);
+  });
+
+  it('bounds catch-up runs to seven days', () => {
+    const now = 10 * 24 * 60 * 60 * 1000;
+    expect(shouldCatchUpScheduledTask(now - 6 * 24 * 60 * 60 * 1000, now)).toBe(true);
+    expect(shouldCatchUpScheduledTask(now - 8 * 24 * 60 * 60 * 1000, now)).toBe(false);
+  });
+
+  it('returns the most recent missed interval run within seven days', () => {
+    const hour = 60 * 60 * 1000;
+    const nextRunAt = new Date('2026-06-01T09:00:00').getTime();
+    const now = nextRunAt + 10 * hour + 10 * 60 * 1000;
+
+    expect(mostRecentMissedScheduledTaskRun({ kind: 'interval', everyMinutes: 60 }, nextRunAt, now)).toBe(
+      nextRunAt + 10 * hour
+    );
+  });
+
+  it('does not catch up interval runs outside the seven-day window', () => {
+    const day = 24 * 60 * 60 * 1000;
+    const nextRunAt = new Date('2026-06-01T09:00:00').getTime();
+    const now = nextRunAt + 8 * day;
+
+    expect(mostRecentMissedScheduledTaskRun({ kind: 'interval', everyMinutes: 10 * 24 * 60 }, nextRunAt, now)).toBe(
+      null
+    );
+  });
+
+  it('does not catch up manual schedules', () => {
+    const now = Date.now();
+
+    expect(mostRecentMissedScheduledTaskRun({ kind: 'manual' }, now - 1_000, now)).toBe(null);
+  });
+
+  it('normalizes HH:MM times', () => {
+    expect(normalizeScheduledTaskTime('9:05')).toBe('09:05');
+  });
+});

--- a/src/lib/scheduled-task-schedule.ts
+++ b/src/lib/scheduled-task-schedule.ts
@@ -1,0 +1,97 @@
+import type { ScheduledTaskSchedule } from '@/shared/types';
+
+const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
+const CATCH_UP_WINDOW_MS = 7 * DAY_MS;
+
+export function nextScheduledTaskRun(schedule: ScheduledTaskSchedule, afterMs: number = Date.now()): number | null {
+  if (schedule.kind === 'manual') {
+    return null;
+  }
+  if (schedule.kind === 'interval') {
+    return afterMs + Math.max(1, Math.floor(schedule.everyMinutes)) * MINUTE_MS;
+  }
+
+  const [hour, minute] = parseTime(schedule.time);
+  const candidate = new Date(afterMs);
+  candidate.setSeconds(0, 0);
+  candidate.setHours(hour, minute, 0, 0);
+  if (candidate.getTime() <= afterMs) {
+    candidate.setDate(candidate.getDate() + 1);
+  }
+
+  while (!dateMatchesSchedule(candidate, schedule)) {
+    candidate.setDate(candidate.getDate() + 1);
+  }
+  return candidate.getTime();
+}
+
+export function shouldCatchUpScheduledTask(nextRunAt: number | null | undefined, nowMs: number = Date.now()): boolean {
+  return typeof nextRunAt === 'number' && nextRunAt <= nowMs && nowMs - nextRunAt <= CATCH_UP_WINDOW_MS;
+}
+
+export function mostRecentMissedScheduledTaskRun(
+  schedule: ScheduledTaskSchedule,
+  nextRunAt: number | null | undefined,
+  nowMs: number = Date.now()
+): number | null {
+  if (schedule.kind === 'manual' || typeof nextRunAt !== 'number' || nextRunAt > nowMs) {
+    return null;
+  }
+
+  if (schedule.kind === 'interval') {
+    const intervalMs = Math.max(1, Math.floor(schedule.everyMinutes)) * MINUTE_MS;
+    const missedIntervals = Math.floor((nowMs - nextRunAt) / intervalMs);
+    const missedRunAt = nextRunAt + missedIntervals * intervalMs;
+    return shouldCatchUpScheduledTask(missedRunAt, nowMs) ? missedRunAt : null;
+  }
+
+  let missedRunAt: number | null = null;
+  const scanAfter = Math.max(nextRunAt - 1, nowMs - CATCH_UP_WINDOW_MS - DAY_MS);
+  const firstCandidate = nextScheduledTaskRun(schedule, scanAfter);
+  if (firstCandidate === null) {
+    return null;
+  }
+  let candidate = firstCandidate;
+  while (candidate <= nowMs) {
+    if (candidate >= nextRunAt && shouldCatchUpScheduledTask(candidate, nowMs)) {
+      missedRunAt = candidate;
+    }
+    const next = nextScheduledTaskRun(schedule, candidate);
+    if (next === null || next <= candidate) {
+      break;
+    }
+    candidate = next;
+  }
+
+  return missedRunAt;
+}
+
+export function normalizeScheduledTaskTime(value: string): string {
+  const [hour, minute] = parseTime(value);
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+}
+
+function dateMatchesSchedule(date: Date, schedule: ScheduledTaskSchedule): boolean {
+  if (schedule.kind === 'daily') {
+    const day = date.getDay();
+    return !schedule.weekdaysOnly || (day >= 1 && day <= 5);
+  }
+  if (schedule.kind === 'weekly') {
+    return date.getDay() === schedule.dayOfWeek;
+  }
+  return true;
+}
+
+function parseTime(value: string): [number, number] {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+  if (!match) {
+    throw new Error('Time must be in HH:MM format');
+  }
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    throw new Error('Time must be in HH:MM format');
+  }
+  return [hour, minute];
+}

--- a/src/lib/store-init.ts
+++ b/src/lib/store-init.ts
@@ -7,7 +7,7 @@
 
 import type { LayoutMode, OmniTheme } from '@/shared/types';
 
-const VALID_LAYOUT_MODES: LayoutMode[] = ['chat', 'spaces', 'projects', 'dashboards', 'settings'];
+const VALID_LAYOUT_MODES: LayoutMode[] = ['chat', 'spaces', 'projects', 'dashboards', 'routines', 'settings'];
 
 /**
  * Migrate legacy layout modes to current valid modes.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ if (process.env.NODE_ENV === 'development') {
   require('dotenv/config');
 }
 
-import { app, dialog, net, protocol, shell } from 'electron';
+import { app, dialog, ipcMain, net, protocol, shell } from 'electron';
 import { existsSync, writeFileSync } from 'fs';
 import { migrateFromJson } from 'omni-projects-db';
 import { join, resolve } from 'path';
@@ -52,6 +52,7 @@ import { backfillProjectConfigs } from '@/main/project-config-backfill';
 import { closeProjectDb, getDb, openProjectDb } from '@/main/project-db';
 import { createProjectManager } from '@/main/project-manager';
 import { wireReverseRpcRouter } from '@/main/reverse-rpc-bridge';
+import { registerScheduledTaskHandlers, ScheduledTaskManager } from '@/main/scheduled-task-manager';
 import { LocalSecretStore } from '@/main/secret-store';
 import { DEFAULT_CHAT_SNAPSHOT_TTL_MS, gcStaleSnapshots, registerSnapshotHandlers } from '@/main/snapshot-manager';
 import { getStore } from '@/main/store';
@@ -292,6 +293,13 @@ const [processManager, cleanupProcessManager] = createProcessManager({
   // which omni serve folds into manifest.environment (`_inject_user_env`).
   getExtraEnv: () => parseEnvVars(store.get('envVars') ?? ''),
 });
+const scheduledTaskManager = new ScheduledTaskManager({
+  store,
+  processManager,
+  sendToWindow: main.sendToWindow,
+});
+const scheduledTaskChannels = registerScheduledTaskHandlers(main.ipc, () => scheduledTaskManager);
+scheduledTaskManager.start();
 
 // Create ConsoleManager — proxies terminal:* IPC into omni serve's
 // WebSocket. Constructed after ProcessManager because it needs the
@@ -468,6 +476,12 @@ async function cleanup() {
     cleanupConsole(),
     cleanupAppControl(),
     cleanupOmniInstall(),
+    (async () => {
+      scheduledTaskManager.stop();
+      for (const channel of scheduledTaskChannels) {
+        ipcMain.removeHandler(channel);
+      }
+    })(),
     cleanupProcessManager(),
     cleanupProject(),
     cleanupExtensions(),

--- a/src/main/scheduled-task-manager.ts
+++ b/src/main/scheduled-task-manager.ts
@@ -64,7 +64,10 @@ type ManagerDeps = {
   now?: () => number;
 };
 
-type NotifiableRunStatus = Extract<ScheduledTaskRun['status'], 'running' | 'waiting_for_approval' | 'completed' | 'failed'>;
+type NotifiableRunStatus = Extract<
+  ScheduledTaskRun['status'],
+  'running' | 'waiting_for_approval' | 'completed' | 'failed'
+>;
 
 export class ScheduledTaskManager {
   private store: ScheduledTaskStore;
@@ -770,7 +773,8 @@ function parseRunEventIdentity(params: unknown): RunEndResult {
 function parseApprovalRequest(method: string, params: unknown): ApprovalRequest {
   const data = isRecord(params) ? params : {};
   const toolName = typeof data.tool_name === 'string' && data.tool_name.trim() ? data.tool_name.trim() : undefined;
-  const serverLabel = typeof data.server_label === 'string' && data.server_label.trim() ? data.server_label.trim() : undefined;
+  const serverLabel =
+    typeof data.server_label === 'string' && data.server_label.trim() ? data.server_label.trim() : undefined;
   return {
     kind: method === 'mcp_approval_requested' ? 'mcp' : 'function',
     ...(toolName ? { toolName } : {}),
@@ -796,7 +800,11 @@ function runEndStatus(reason: string | undefined): 'completed' | 'failed' {
   return reason && ['failed', 'error', 'cancelled', 'canceled'].includes(reason) ? 'failed' : 'completed';
 }
 
-function buildRunToast(taskName: string, status: NotifiableRunStatus, reason?: string): IpcRendererEvents['toast:show'][0] {
+function buildRunToast(
+  taskName: string,
+  status: NotifiableRunStatus,
+  reason?: string
+): IpcRendererEvents['toast:show'][0] {
   if (status === 'waiting_for_approval') {
     return {
       level: 'warning',

--- a/src/main/scheduled-task-manager.ts
+++ b/src/main/scheduled-task-manager.ts
@@ -1,0 +1,938 @@
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+
+import type Store from 'electron-store';
+import { WebSocket as WsWebSocket } from 'ws';
+
+import { mostRecentMissedScheduledTaskRun, nextScheduledTaskRun } from '@/lib/scheduled-task-schedule';
+import type { ProcessManager } from '@/main/process-manager';
+import { ensureDirectory } from '@/main/util';
+import type { IIpcListener } from '@/shared/ipc-listener';
+import type {
+  IpcRendererEvents,
+  ScheduledTask,
+  ScheduledTaskAllowedMcpTool,
+  ScheduledTaskInput,
+  ScheduledTaskPermissionMode,
+  ScheduledTaskRun,
+  ScheduledTaskUpdate,
+  StoreData,
+} from '@/shared/types';
+
+const TICK_MS = 60_000;
+const HISTORY_LIMIT = 25;
+const START_TIMEOUT_MS = 120_000;
+const RPC_TIMEOUT_MS = 10_000;
+const DEFAULT_PERMISSION_MODE: ScheduledTaskPermissionMode = 'ask';
+
+type ScheduledTaskStore = Pick<Store<StoreData>, 'get' | 'set'>;
+
+type StartRunResult = {
+  runId?: string;
+  sessionId?: string;
+};
+
+type RunEndResult = {
+  runId?: string;
+  sessionId?: string;
+  reason?: string;
+};
+
+type StartRunWatcher = StartRunResult & {
+  close: () => void;
+};
+
+type SafeToolOverrides = {
+  safe_tool_names?: string[];
+  safe_mcp_tools?: { server_label: string; tool_name: string }[];
+};
+
+type StartRunOptions = {
+  safeToolOverrides?: SafeToolOverrides;
+};
+
+type ApprovalRequest = {
+  kind: 'function' | 'mcp';
+  toolName?: string;
+  serverLabel?: string;
+};
+
+type ManagerDeps = {
+  store: ScheduledTaskStore;
+  processManager: ProcessManager;
+  sendToWindow?: <T extends keyof IpcRendererEvents>(channel: T, ...args: IpcRendererEvents[T]) => void;
+  now?: () => number;
+};
+
+type NotifiableRunStatus = Extract<ScheduledTaskRun['status'], 'running' | 'waiting_for_approval' | 'completed' | 'failed'>;
+
+export class ScheduledTaskManager {
+  private store: ScheduledTaskStore;
+  private processManager: ProcessManager;
+  private sendToWindow?: ManagerDeps['sendToWindow'];
+  private now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private ticking = false;
+  private launching = new Set<string>();
+  private completing = new Set<string>();
+
+  constructor(deps: ManagerDeps) {
+    this.store = deps.store;
+    this.processManager = deps.processManager;
+    this.sendToWindow = deps.sendToWindow;
+    this.now = deps.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.timer) {
+      return;
+    }
+    this.recomputeNextRuns();
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), TICK_MS);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  list(): ScheduledTask[] {
+    return this.tasks();
+  }
+
+  create(input: ScheduledTaskInput): ScheduledTask {
+    const now = this.now();
+    const task: ScheduledTask = {
+      id: randomUUID(),
+      name: input.name.trim(),
+      description: input.description?.trim() ?? '',
+      instructions: input.instructions.trim(),
+      schedule: input.schedule,
+      permissionMode: input.permissionMode ?? DEFAULT_PERMISSION_MODE,
+      enabled: input.enabled ?? true,
+      ...(input.projectId ? { projectId: input.projectId } : {}),
+      ...(input.profileName ? { profileName: input.profileName } : {}),
+      createdAt: now,
+      updatedAt: now,
+      nextRunAt: input.enabled === false ? null : nextScheduledTaskRun(input.schedule, now),
+      allowedToolNames: [],
+      allowedMcpTools: [],
+      history: [],
+    };
+    validateTask(task);
+    this.writeTasks([...this.tasks(), task]);
+    return task;
+  }
+
+  update(taskId: string, patch: ScheduledTaskUpdate): ScheduledTask {
+    const tasks = this.tasks();
+    const index = tasks.findIndex((task) => task.id === taskId);
+    if (index < 0) {
+      throw new Error(`Scheduled task not found: ${taskId}`);
+    }
+    const prior = tasks[index];
+    if (!prior) {
+      throw new Error(`Scheduled task not found: ${taskId}`);
+    }
+    const next: ScheduledTask = { ...prior, updatedAt: this.now() };
+    if (patch.name !== undefined) {
+      next.name = patch.name.trim();
+    }
+    if (patch.description !== undefined) {
+      next.description = patch.description.trim();
+    }
+    if (patch.instructions !== undefined) {
+      next.instructions = patch.instructions.trim();
+    }
+    if (patch.schedule !== undefined) {
+      next.schedule = patch.schedule;
+    }
+    next.permissionMode = patch.permissionMode ?? prior.permissionMode ?? DEFAULT_PERMISSION_MODE;
+    if (patch.enabled !== undefined) {
+      next.enabled = patch.enabled;
+    }
+    if (patch.projectId !== undefined) {
+      next.projectId = patch.projectId;
+    }
+    if (patch.profileName !== undefined) {
+      next.profileName = patch.profileName;
+    }
+    validateTask(next);
+    next.nextRunAt = next.enabled ? nextScheduledTaskRun(next.schedule, this.now()) : null;
+    const updated = [...tasks];
+    updated[index] = next;
+    this.writeTasks(updated);
+    return next;
+  }
+
+  delete(taskId: string): void {
+    this.writeTasks(this.tasks().filter((task) => task.id !== taskId));
+  }
+
+  runNow(taskId: string): ScheduledTask {
+    const task = this.tasks().find((item) => item.id === taskId);
+    if (!task) {
+      throw new Error(`Scheduled task not found: ${taskId}`);
+    }
+    void this.fireTask(task, this.now(), 'manual');
+    return task;
+  }
+
+  allowTool(taskId: string, toolName: string): ScheduledTask {
+    const normalized = normalizeToolName(toolName);
+    const tasks = this.tasks();
+    const index = tasks.findIndex((task) => task.id === taskId);
+    if (index < 0 || !tasks[index]) {
+      throw new Error(`Scheduled task not found: ${taskId}`);
+    }
+    const prior = tasks[index];
+    if ((prior.allowedToolNames ?? []).includes(normalized)) {
+      return prior;
+    }
+    const next: ScheduledTask = {
+      ...prior,
+      allowedToolNames: [...(prior.allowedToolNames ?? []), normalized].sort((a, b) => a.localeCompare(b)),
+      updatedAt: this.now(),
+    };
+    const updated = [...tasks];
+    updated[index] = next;
+    this.writeTasks(updated);
+    return next;
+  }
+
+  revokeTool(taskId: string, toolName: string): ScheduledTask {
+    const normalized = normalizeToolName(toolName);
+    const tasks = this.tasks();
+    const index = tasks.findIndex((task) => task.id === taskId);
+    if (index < 0 || !tasks[index]) {
+      throw new Error(`Scheduled task not found: ${taskId}`);
+    }
+    const prior = tasks[index];
+    const next: ScheduledTask = {
+      ...prior,
+      allowedToolNames: (prior.allowedToolNames ?? []).filter((item) => item !== normalized),
+      updatedAt: this.now(),
+    };
+    const updated = [...tasks];
+    updated[index] = next;
+    this.writeTasks(updated);
+    return next;
+  }
+
+  allowMcpTool(taskId: string, tool: ScheduledTaskAllowedMcpTool): ScheduledTask {
+    const normalized = normalizeMcpTool(tool);
+    const tasks = this.tasks();
+    const index = tasks.findIndex((task) => task.id === taskId);
+    if (index < 0 || !tasks[index]) {
+      throw new Error(`Scheduled task not found: ${taskId}`);
+    }
+    const prior = tasks[index];
+    if ((prior.allowedMcpTools ?? []).some((item) => sameMcpTool(item, normalized))) {
+      return prior;
+    }
+    const next: ScheduledTask = {
+      ...prior,
+      allowedMcpTools: normalizeMcpTools([...(prior.allowedMcpTools ?? []), normalized]),
+      updatedAt: this.now(),
+    };
+    const updated = [...tasks];
+    updated[index] = next;
+    this.writeTasks(updated);
+    return next;
+  }
+
+  revokeMcpTool(taskId: string, tool: ScheduledTaskAllowedMcpTool): ScheduledTask {
+    const normalized = normalizeMcpTool(tool);
+    const tasks = this.tasks();
+    const index = tasks.findIndex((task) => task.id === taskId);
+    if (index < 0 || !tasks[index]) {
+      throw new Error(`Scheduled task not found: ${taskId}`);
+    }
+    const prior = tasks[index];
+    const next: ScheduledTask = {
+      ...prior,
+      allowedMcpTools: normalizeMcpTools(prior.allowedMcpTools).filter((item) => !sameMcpTool(item, normalized)),
+      updatedAt: this.now(),
+    };
+    const updated = [...tasks];
+    updated[index] = next;
+    this.writeTasks(updated);
+    return next;
+  }
+
+  private async tick(): Promise<void> {
+    if (this.ticking) {
+      return;
+    }
+    this.ticking = true;
+    try {
+      const now = this.now();
+      for (const task of this.tasks()) {
+        if (!task.enabled || task.schedule.kind === 'manual') {
+          continue;
+        }
+        if (task.nextRunAt && task.nextRunAt <= now) {
+          const missedRunAt = mostRecentMissedScheduledTaskRun(task.schedule, task.nextRunAt, now);
+          if (missedRunAt !== null) {
+            await this.fireTask(task, missedRunAt, 'scheduled');
+          } else {
+            this.patchTask(task.id, {
+              nextRunAt: nextScheduledTaskRun(task.schedule, now),
+              history: this.prependHistory(task, {
+                id: randomUUID(),
+                scheduledFor: task.nextRunAt,
+                startedAt: now,
+                status: 'skipped',
+                reason: 'missed_window',
+              }),
+            });
+          }
+        }
+      }
+    } finally {
+      this.ticking = false;
+    }
+  }
+
+  private async fireTask(task: ScheduledTask, scheduledFor: number, reason: 'scheduled' | 'manual'): Promise<void> {
+    const current = this.getTask(task.id);
+    if (this.hasActiveRun(current)) {
+      this.recordSkipped(
+        current,
+        scheduledFor,
+        this.launching.has(current.id) ? 'previous_run_starting' : 'previous_run_active'
+      );
+      return;
+    }
+    this.launching.add(current.id);
+    const historyRunId = randomUUID();
+    const sessionId = randomUUID();
+    const processId = `scheduled-task:${current.id}:${historyRunId}`;
+    const startedAt = this.now();
+    try {
+      const workspaceDir = await this.resolveWorkspaceDir(current, sessionId);
+      this.patchTask(current.id, {
+        runningSessionId: sessionId,
+        runningProcessId: processId,
+        lastRunAt: startedAt,
+        nextRunAt: current.schedule.kind === 'manual' ? null : nextScheduledTaskRun(current.schedule, startedAt),
+      });
+      await this.processManager.start(processId, {
+        workspaceDir,
+        sessionId,
+        ...(current.projectId ? { projectId: current.projectId } : {}),
+        ...(current.profileName ? { profileNameOverride: current.profileName } : {}),
+      });
+      const wsUrl = await this.waitForWsUrl(processId);
+      const watcher = await startRun(
+        wsUrl,
+        current.instructions,
+        sessionId,
+        {
+          workspace_root: workspaceDir,
+          cwd: workspaceDir,
+          scheduled_task_id: current.id,
+          scheduled_task_name: current.name,
+          scheduled_task_reason: reason,
+        },
+        {
+          onRunEnd: (result) => {
+            void this.finishRun(current.id, historyRunId, processId, runEndStatus(result.reason), result.reason);
+          },
+          onApprovalRequested: (approval) => {
+            this.updateRunStatus(current.id, historyRunId, 'waiting_for_approval', approval);
+          },
+          onApprovalResolved: () => {
+            this.updateRunStatus(current.id, historyRunId, 'running');
+          },
+          onDisconnect: (message) => {
+            void this.finishRun(current.id, historyRunId, processId, 'failed', message);
+          },
+        },
+        buildStartRunOptions(current)
+      );
+      this.patchTask(current.id, {
+        runningSessionId: watcher.sessionId ?? sessionId,
+        runningProcessId: processId,
+        history: this.prependHistory(this.getTask(current.id), {
+          id: historyRunId,
+          scheduledFor,
+          startedAt,
+          status: 'running',
+          ...(watcher.runId ? { runId: watcher.runId } : {}),
+          sessionId: watcher.sessionId ?? sessionId,
+          processId,
+        }),
+      });
+      this.notifyRun(current.name, 'running');
+    } catch (error) {
+      await this.stopRunProcess(processId);
+      const message = (error as Error).message;
+      this.patchTask(current.id, {
+        runningSessionId: undefined,
+        runningProcessId: undefined,
+        history: this.prependHistory(this.getTask(current.id), {
+          id: historyRunId,
+          scheduledFor,
+          startedAt,
+          completedAt: this.now(),
+          status: 'failed',
+          sessionId,
+          processId,
+          reason: message,
+        }),
+      });
+      this.notifyRun(current.name, 'failed', message);
+    } finally {
+      this.launching.delete(current.id);
+    }
+  }
+
+  private hasActiveRun(task: ScheduledTask): boolean {
+    return this.launching.has(task.id) || Boolean(task.runningProcessId || task.runningSessionId);
+  }
+
+  private async finishRun(
+    taskId: string,
+    historyRunId: string,
+    processId: string,
+    status: 'completed' | 'failed',
+    reason?: string
+  ): Promise<void> {
+    if (this.completing.has(historyRunId)) {
+      return;
+    }
+    this.completing.add(historyRunId);
+    try {
+      await this.stopRunProcess(processId);
+      const task = this.tasks().find((item) => item.id === taskId);
+      if (!task) {
+        return;
+      }
+      const history = (task.history ?? []).map((run) =>
+        run.id === historyRunId
+          ? {
+              ...run,
+              completedAt: this.now(),
+              status,
+              pendingApprovalToolName: undefined,
+              pendingApprovalServerLabel: undefined,
+              pendingApprovalKind: undefined,
+              ...(reason ? { reason } : {}),
+            }
+          : run
+      );
+      this.patchTask(taskId, {
+        ...(task.runningProcessId === processId ? { runningSessionId: undefined, runningProcessId: undefined } : {}),
+        history,
+      });
+      this.notifyRun(task.name, status, reason);
+    } finally {
+      this.completing.delete(historyRunId);
+    }
+  }
+
+  private updateRunStatus(
+    taskId: string,
+    historyRunId: string,
+    status: ScheduledTaskRun['status'],
+    approval?: ApprovalRequest
+  ): void {
+    const task = this.tasks().find((item) => item.id === taskId);
+    if (!task) {
+      return;
+    }
+    let changed = false;
+    const history = (task.history ?? []).map((run) => {
+      if (run.id !== historyRunId || (run.status !== 'running' && run.status !== 'waiting_for_approval')) {
+        return run;
+      }
+      if (run.status === status && !approval) {
+        return run;
+      }
+      changed = true;
+      if (status === 'waiting_for_approval') {
+        return {
+          ...run,
+          status,
+          ...(approval?.toolName ? { pendingApprovalToolName: approval.toolName } : {}),
+          ...(approval?.serverLabel ? { pendingApprovalServerLabel: approval.serverLabel } : {}),
+          ...(approval?.kind ? { pendingApprovalKind: approval.kind } : {}),
+        };
+      }
+      return {
+        ...run,
+        status,
+        pendingApprovalToolName: undefined,
+        pendingApprovalServerLabel: undefined,
+        pendingApprovalKind: undefined,
+      };
+    });
+    if (!changed) {
+      return;
+    }
+    this.patchTask(taskId, { history });
+    if (status === 'waiting_for_approval') {
+      this.notifyRun(task.name, status);
+    }
+  }
+
+  private notifyRun(taskName: string, status: NotifiableRunStatus, reason?: string): void {
+    this.sendToWindow?.('toast:show', buildRunToast(taskName, status, reason));
+  }
+
+  private async stopRunProcess(processId: string): Promise<void> {
+    try {
+      await this.processManager.stop(processId);
+    } catch {}
+  }
+
+  private async waitForWsUrl(processId: string): Promise<string> {
+    const deadline = Date.now() + START_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const status = this.processManager.getStatus(processId);
+      if ((status.type === 'running' || status.type === 'connecting') && status.data.wsUrl) {
+        return status.data.wsUrl;
+      }
+      if (status.type === 'error') {
+        throw new Error(status.error.message);
+      }
+      await delay(500);
+    }
+    throw new Error('Timed out waiting for scheduled task agent process');
+  }
+
+  private async resolveWorkspaceDir(task: ScheduledTask, sessionId: string): Promise<string> {
+    const baseDir = this.store.get('workspaceDir');
+    if (!baseDir?.trim()) {
+      throw new Error('Workspace root is not configured');
+    }
+    if (task.projectId) {
+      return baseDir;
+    }
+    const safeId = sessionId.replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
+    const dir = join(baseDir, 'Sessions', safeId);
+    await ensureDirectory(dir);
+    return dir;
+  }
+
+  private recomputeNextRuns(): void {
+    const now = this.now();
+    let changed = false;
+    const tasks = this.tasks().map((task) => {
+      if (!task.enabled || task.nextRunAt !== undefined) {
+        return task;
+      }
+      changed = true;
+      return { ...task, nextRunAt: nextScheduledTaskRun(task.schedule, now) };
+    });
+    if (changed) {
+      this.writeTasks(tasks);
+    }
+  }
+
+  private recordSkipped(task: ScheduledTask, scheduledFor: number, reason: string): void {
+    const current = this.getTask(task.id);
+    this.patchTask(task.id, {
+      nextRunAt: task.schedule.kind === 'manual' ? null : nextScheduledTaskRun(task.schedule, this.now()),
+      history: this.prependHistory(current, {
+        id: randomUUID(),
+        scheduledFor,
+        startedAt: this.now(),
+        status: 'skipped',
+        reason,
+      }),
+    });
+  }
+
+  private prependHistory(task: ScheduledTask, run: ScheduledTaskRun): ScheduledTaskRun[] {
+    return [run, ...(task.history ?? [])].slice(0, HISTORY_LIMIT);
+  }
+
+  private getTask(taskId: string): ScheduledTask {
+    const task = this.tasks().find((item) => item.id === taskId);
+    if (!task) {
+      throw new Error(`Scheduled task not found: ${taskId}`);
+    }
+    return task;
+  }
+
+  private patchTask(taskId: string, patch: Partial<ScheduledTask>): void {
+    const tasks = this.tasks();
+    const index = tasks.findIndex((task) => task.id === taskId);
+    if (index < 0) {
+      return;
+    }
+    const prior = tasks[index];
+    if (!prior) {
+      return;
+    }
+    const next: ScheduledTask = { ...prior, ...patch, updatedAt: this.now() };
+    const updated = [...tasks];
+    updated[index] = next;
+    this.writeTasks(updated);
+  }
+
+  private tasks(): ScheduledTask[] {
+    return (this.store.get('scheduledTasks') ?? []).map(normalizeScheduledTask);
+  }
+
+  private writeTasks(tasks: ScheduledTask[]): void {
+    this.store.set('scheduledTasks', tasks);
+    this.sendToWindow?.('store:changed', (this.store as Store<StoreData>).store as StoreData | undefined);
+  }
+}
+
+export function registerScheduledTaskHandlers(
+  ipc: IIpcListener,
+  resolve: (event: unknown) => ScheduledTaskManager
+): string[] {
+  ipc.handle('scheduled-task:list', (event: unknown) => resolve(event).list());
+  ipc.handle('scheduled-task:create', (event: unknown, input: ScheduledTaskInput) => resolve(event).create(input));
+  ipc.handle('scheduled-task:update', (event: unknown, taskId: string, patch: ScheduledTaskUpdate) =>
+    resolve(event).update(taskId, patch)
+  );
+  ipc.handle('scheduled-task:delete', (event: unknown, taskId: string) => resolve(event).delete(taskId));
+  ipc.handle('scheduled-task:run-now', (event: unknown, taskId: string) => resolve(event).runNow(taskId));
+  ipc.handle('scheduled-task:allow-tool', (event: unknown, taskId: string, toolName: string) =>
+    resolve(event).allowTool(taskId, toolName)
+  );
+  ipc.handle('scheduled-task:revoke-tool', (event: unknown, taskId: string, toolName: string) =>
+    resolve(event).revokeTool(taskId, toolName)
+  );
+  ipc.handle('scheduled-task:allow-mcp-tool', (event: unknown, taskId: string, tool: ScheduledTaskAllowedMcpTool) =>
+    resolve(event).allowMcpTool(taskId, tool)
+  );
+  ipc.handle('scheduled-task:revoke-mcp-tool', (event: unknown, taskId: string, tool: ScheduledTaskAllowedMcpTool) =>
+    resolve(event).revokeMcpTool(taskId, tool)
+  );
+  return [
+    'scheduled-task:list',
+    'scheduled-task:create',
+    'scheduled-task:update',
+    'scheduled-task:delete',
+    'scheduled-task:run-now',
+    'scheduled-task:allow-tool',
+    'scheduled-task:revoke-tool',
+    'scheduled-task:allow-mcp-tool',
+    'scheduled-task:revoke-mcp-tool',
+  ];
+}
+
+async function startRun(
+  wsUrl: string,
+  prompt: string,
+  sessionId: string,
+  variables: Record<string, unknown>,
+  handlers: {
+    onRunEnd: (result: RunEndResult) => void;
+    onApprovalRequested: (approval: ApprovalRequest) => void;
+    onApprovalResolved: () => void;
+    onDisconnect: (message: string) => void;
+  },
+  options?: StartRunOptions
+): Promise<StartRunWatcher> {
+  return new Promise((resolve, reject) => {
+    const socket = new WsWebSocket(wsUrl);
+    const id = randomUUID();
+    let resolved = false;
+    let finished = false;
+    let closedByManager = false;
+    let runId: string | undefined;
+    let resolvedSessionId: string | undefined = sessionId;
+    const timer = setTimeout(() => {
+      closedByManager = true;
+      socket.close();
+      reject(new Error('start_run timed out'));
+    }, RPC_TIMEOUT_MS);
+    const close = (): void => {
+      closedByManager = true;
+      socket.close();
+    };
+    socket.once('open', () => {
+      socket.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          method: 'start_run',
+          params: {
+            prompt,
+            session_id: sessionId,
+            variables,
+            ...(options?.safeToolOverrides ? { safe_tool_overrides: options.safeToolOverrides } : {}),
+          },
+        })
+      );
+    });
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(String(raw));
+        if (msg.id === id) {
+          clearTimeout(timer);
+          if (msg.error) {
+            closedByManager = true;
+            socket.close();
+            reject(new Error(msg.error.message ?? 'start_run failed'));
+            return;
+          }
+          const result = parseStartRunResult(msg.result, sessionId);
+          runId = result.runId;
+          resolvedSessionId = result.sessionId;
+          resolved = true;
+          resolve({ ...result, close });
+          return;
+        }
+        if (msg.method === 'tool_approval_requested' || msg.method === 'mcp_approval_requested') {
+          const result = parseRunEventIdentity(msg.params);
+          if (!hasRunIdentity(result) || matchesRun(result, runId, resolvedSessionId)) {
+            handlers.onApprovalRequested(parseApprovalRequest(msg.method, msg.params));
+          }
+          return;
+        }
+        if (msg.method === 'tool_approval_resolved' || msg.method === 'mcp_approval_resolved') {
+          const result = parseRunEventIdentity(msg.params);
+          if (!hasRunIdentity(result) || matchesRun(result, runId, resolvedSessionId)) {
+            handlers.onApprovalResolved();
+          }
+          return;
+        }
+        if (msg.method !== 'run_end') {
+          return;
+        }
+        const result = parseRunEndResult(msg.params);
+        if (!matchesRun(result, runId, resolvedSessionId)) {
+          return;
+        }
+        finished = true;
+        close();
+        handlers.onRunEnd(result);
+      } catch (error) {
+        if (!resolved) {
+          clearTimeout(timer);
+          closedByManager = true;
+          socket.close();
+          reject(error);
+        }
+      }
+    });
+    socket.once('error', (error) => {
+      clearTimeout(timer);
+      if (resolved) {
+        if (!finished && !closedByManager) {
+          finished = true;
+          handlers.onDisconnect(error.message);
+        }
+      } else {
+        reject(error);
+      }
+    });
+    socket.once('close', () => {
+      clearTimeout(timer);
+      if (resolved && !finished && !closedByManager) {
+        finished = true;
+        handlers.onDisconnect('scheduled task run connection closed before run_end');
+      } else if (!resolved && !closedByManager) {
+        reject(new Error('start_run connection closed'));
+      }
+    });
+  });
+}
+
+function parseStartRunResult(result: unknown, fallbackSessionId: string): StartRunResult {
+  const data = isRecord(result) ? result : {};
+  return {
+    ...(typeof data.run_id === 'string' && data.run_id ? { runId: data.run_id } : {}),
+    sessionId: typeof data.session_id === 'string' && data.session_id ? data.session_id : fallbackSessionId,
+  };
+}
+
+function parseRunEndResult(params: unknown): RunEndResult {
+  const data = isRecord(params) ? params : {};
+  return {
+    ...(typeof data.run_id === 'string' && data.run_id ? { runId: data.run_id } : {}),
+    ...(typeof data.session_id === 'string' && data.session_id ? { sessionId: data.session_id } : {}),
+    ...(typeof data.end_reason === 'string' && data.end_reason ? { reason: data.end_reason } : {}),
+  };
+}
+
+function parseRunEventIdentity(params: unknown): RunEndResult {
+  const data = isRecord(params) ? params : {};
+  return {
+    ...(typeof data.run_id === 'string' && data.run_id ? { runId: data.run_id } : {}),
+    ...(typeof data.session_id === 'string' && data.session_id ? { sessionId: data.session_id } : {}),
+  };
+}
+
+function parseApprovalRequest(method: string, params: unknown): ApprovalRequest {
+  const data = isRecord(params) ? params : {};
+  const toolName = typeof data.tool_name === 'string' && data.tool_name.trim() ? data.tool_name.trim() : undefined;
+  const serverLabel = typeof data.server_label === 'string' && data.server_label.trim() ? data.server_label.trim() : undefined;
+  return {
+    kind: method === 'mcp_approval_requested' ? 'mcp' : 'function',
+    ...(toolName ? { toolName } : {}),
+    ...(serverLabel ? { serverLabel } : {}),
+  };
+}
+
+function hasRunIdentity(result: RunEndResult): boolean {
+  return Boolean(result.runId || result.sessionId);
+}
+
+function matchesRun(result: RunEndResult, runId: string | undefined, sessionId: string | undefined): boolean {
+  if (result.runId && runId) {
+    return result.runId === runId;
+  }
+  if (result.sessionId && sessionId) {
+    return result.sessionId === sessionId;
+  }
+  return false;
+}
+
+function runEndStatus(reason: string | undefined): 'completed' | 'failed' {
+  return reason && ['failed', 'error', 'cancelled', 'canceled'].includes(reason) ? 'failed' : 'completed';
+}
+
+function buildRunToast(taskName: string, status: NotifiableRunStatus, reason?: string): IpcRendererEvents['toast:show'][0] {
+  if (status === 'waiting_for_approval') {
+    return {
+      level: 'warning',
+      title: `Routine needs approval: ${taskName}`,
+      description: 'Open the routine session to review the request.',
+    };
+  }
+  if (status === 'completed') {
+    return {
+      level: 'success',
+      title: `Routine completed: ${taskName}`,
+      ...(reason && reason !== 'completed' ? { description: reason } : {}),
+    };
+  }
+  if (status === 'failed') {
+    return {
+      level: 'error',
+      title: `Routine failed: ${taskName}`,
+      description: reason ?? 'The run ended with an error.',
+    };
+  }
+  return {
+    level: 'info',
+    title: `Routine started: ${taskName}`,
+    description: 'Run is in progress.',
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function validateTask(task: ScheduledTask): void {
+  if (!task.name.trim()) {
+    throw new Error('Name is required');
+  }
+  if (!task.instructions.trim()) {
+    throw new Error('Instructions are required');
+  }
+  if (task.permissionMode !== 'ask') {
+    throw new Error('Unsupported permission mode');
+  }
+  if (!Array.isArray(task.allowedToolNames) || task.allowedToolNames.some((toolName) => !normalizeToolName(toolName))) {
+    throw new Error('Allowed tool names must be non-empty strings');
+  }
+  normalizeMcpTools(task.allowedMcpTools);
+}
+
+function normalizeScheduledTask(task: ScheduledTask): ScheduledTask {
+  return {
+    ...task,
+    permissionMode: task.permissionMode ?? DEFAULT_PERMISSION_MODE,
+    allowedToolNames: normalizeToolNames(task.allowedToolNames),
+    allowedMcpTools: normalizeMcpTools(task.allowedMcpTools),
+  };
+}
+
+function buildStartRunOptions(task: ScheduledTask): StartRunOptions | undefined {
+  const allowedToolNames = normalizeToolNames(task.allowedToolNames);
+  const allowedMcpTools = normalizeMcpTools(task.allowedMcpTools);
+  const safeToolOverrides: SafeToolOverrides = {
+    ...(allowedToolNames.length > 0 ? { safe_tool_names: allowedToolNames } : {}),
+    ...(allowedMcpTools.length > 0
+      ? {
+          safe_mcp_tools: allowedMcpTools.map((tool) => ({
+            server_label: tool.serverLabel,
+            tool_name: tool.toolName,
+          })),
+        }
+      : {}),
+  };
+  if (safeToolOverrides.safe_tool_names || safeToolOverrides.safe_mcp_tools) {
+    return { safeToolOverrides };
+  }
+  return undefined;
+}
+
+function normalizeToolName(toolName: string): string {
+  const normalized = toolName.trim();
+  if (!normalized) {
+    throw new Error('Tool name is required');
+  }
+  return normalized;
+}
+
+function normalizeToolNames(toolNames: unknown): string[] {
+  if (!Array.isArray(toolNames)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      toolNames
+        .filter((toolName): toolName is string => typeof toolName === 'string')
+        .map((toolName) => toolName.trim())
+        .filter(Boolean)
+    ),
+  ].sort((a, b) => a.localeCompare(b));
+}
+
+function normalizeMcpTool(tool: ScheduledTaskAllowedMcpTool): ScheduledTaskAllowedMcpTool {
+  const serverLabel = typeof tool.serverLabel === 'string' ? tool.serverLabel.trim() : '';
+  const toolName = typeof tool.toolName === 'string' ? tool.toolName.trim() : '';
+  if (!serverLabel) {
+    throw new Error('MCP server label is required');
+  }
+  if (!toolName) {
+    throw new Error('MCP tool name is required');
+  }
+  return { serverLabel, toolName };
+}
+
+function normalizeMcpTools(tools: unknown): ScheduledTaskAllowedMcpTool[] {
+  if (!Array.isArray(tools)) {
+    return [];
+  }
+  const normalized: ScheduledTaskAllowedMcpTool[] = [];
+  for (const item of tools) {
+    if (!isRecord(item)) {
+      continue;
+    }
+    const serverLabel = typeof item.serverLabel === 'string' ? item.serverLabel.trim() : '';
+    const toolName = typeof item.toolName === 'string' ? item.toolName.trim() : '';
+    if (!serverLabel || !toolName || normalized.some((tool) => sameMcpTool(tool, { serverLabel, toolName }))) {
+      continue;
+    }
+    normalized.push({ serverLabel, toolName });
+  }
+  return normalized.sort((a, b) => a.serverLabel.localeCompare(b.serverLabel) || a.toolName.localeCompare(b.toolName));
+}
+
+function sameMcpTool(left: ScheduledTaskAllowedMcpTool, right: ScheduledTaskAllowedMcpTool): boolean {
+  return left.serverLabel === right.serverLabel && left.toolName === right.toolName;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/renderer/app/MainContent.tsx
+++ b/src/renderer/app/MainContent.tsx
@@ -8,6 +8,7 @@ import { Code } from '@/renderer/features/Code/Code';
 import { Dashboards } from '@/renderer/features/Dashboards/Dashboards';
 import { Gallery } from '@/renderer/features/Gallery/Gallery';
 import { OnboardingWizard } from '@/renderer/features/Onboarding/OnboardingWizard';
+import { ScheduledTasks } from '@/renderer/features/ScheduledTasks/ScheduledTasks';
 import { SettingsPage } from '@/renderer/features/SettingsModal/SettingsPage';
 import { Tickets } from '@/renderer/features/Tickets/Tickets';
 import { persistedStoreApi } from '@/renderer/services/store';
@@ -93,6 +94,7 @@ export const MainContent = memo(() => {
     { key: 'spaces', Component: Code },
     { key: 'projects', Component: Tickets },
     { key: 'dashboards', Component: Dashboards },
+    { key: 'routines', Component: ScheduledTasks },
     { key: 'settings', Component: SettingsPage },
     ...(import.meta.env.DEV ? [{ key: 'gallery' as const, Component: Gallery }] : []),
   ];

--- a/src/renderer/app/Sidebar.tsx
+++ b/src/renderer/app/Sidebar.tsx
@@ -59,6 +59,13 @@ const ALL_TABS: {
     iconActive: <DataBarVertical24Filled />,
     enterprise: true,
   },
+  {
+    value: 'routines',
+    label: 'Routines',
+    icon: <DataBarVertical24Regular />,
+    iconActive: <DataBarVertical24Filled />,
+    alwaysVisible: true,
+  },
   { value: 'gallery', label: 'Gallery', icon: <Beaker24Regular />, iconActive: <Beaker24Filled />, devOnly: true },
   {
     value: 'settings',

--- a/src/renderer/features/CommandPalette/commands.ts
+++ b/src/renderer/features/CommandPalette/commands.ts
@@ -51,7 +51,12 @@ export function buildCommands(ctx: PaletteContext): PaletteCommand[] {
       keywords: 'preferences models mcp git',
       run: () => ctx.navigate('settings'),
     },
-    { id: 'nav-routines', label: 'Go to Routines', keywords: 'scheduled tasks automation recurring', run: () => ctx.navigate('routines') },
+    {
+      id: 'nav-routines',
+      label: 'Go to Routines',
+      keywords: 'scheduled tasks automation recurring',
+      run: () => ctx.navigate('routines'),
+    },
     { id: 'add-inbox-item', label: 'Add inbox item', keywords: 'capture idea todo quick', run: ctx.addInboxItem },
     { id: 'create-project', label: 'Create project', keywords: 'new workspace initiative', run: ctx.createProject },
     { id: 'new-session', label: 'New session', keywords: 'create column agent', run: ctx.newSession },

--- a/src/renderer/features/CommandPalette/commands.ts
+++ b/src/renderer/features/CommandPalette/commands.ts
@@ -51,6 +51,7 @@ export function buildCommands(ctx: PaletteContext): PaletteCommand[] {
       keywords: 'preferences models mcp git',
       run: () => ctx.navigate('settings'),
     },
+    { id: 'nav-routines', label: 'Go to Routines', keywords: 'scheduled tasks automation recurring', run: () => ctx.navigate('routines') },
     { id: 'add-inbox-item', label: 'Add inbox item', keywords: 'capture idea todo quick', run: ctx.addInboxItem },
     { id: 'create-project', label: 'Create project', keywords: 'new workspace initiative', run: ctx.createProject },
     { id: 'new-session', label: 'New session', keywords: 'create column agent', run: ctx.newSession },

--- a/src/renderer/features/ScheduledTasks/ScheduledTasks.tsx
+++ b/src/renderer/features/ScheduledTasks/ScheduledTasks.tsx
@@ -1,0 +1,841 @@
+import {
+  Button,
+  Card,
+  Field,
+  Input,
+  makeStyles,
+  mergeClasses,
+  Select,
+  Switch,
+  Textarea,
+  tokens,
+} from '@fluentui/react-components';
+import { useStore } from '@nanostores/react';
+import type { ComponentProps } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
+
+import { getProfileMenuLabel } from '@/renderer/features/SandboxProfile/profile-list';
+import { SandboxPicker } from '@/renderer/features/SandboxProfile/SandboxPicker';
+import { emitter } from '@/renderer/services/ipc';
+import { $machines } from '@/renderer/services/machines';
+import { scheduledTaskApi } from '@/renderer/services/scheduled-tasks';
+import { persistedStoreApi } from '@/renderer/services/store';
+import type {
+  CodeTab,
+  Project,
+  ScheduledTask,
+  ScheduledTaskAllowedMcpTool,
+  ScheduledTaskInput,
+  ScheduledTaskPermissionMode,
+  ScheduledTaskRun,
+  ScheduledTaskSchedule,
+} from '@/shared/types';
+
+const useStyles = makeStyles({
+  root: {
+    height: '100%',
+    overflow: 'auto',
+    padding: '32px',
+    backgroundColor: tokens.colorNeutralBackground1,
+    color: tokens.colorNeutralForeground1,
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: '16px',
+    alignItems: 'flex-start',
+    marginBottom: '24px',
+  },
+  title: {
+    fontSize: '28px',
+    fontWeight: 700,
+    margin: 0,
+  },
+  subtitle: {
+    color: tokens.colorNeutralForeground3,
+    marginTop: '6px',
+    maxWidth: '720px',
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(280px, 420px) minmax(320px, 1fr)',
+    gap: '20px',
+    '@media (max-width: 900px)': {
+      gridTemplateColumns: '1fr',
+    },
+  },
+  form: {
+    display: 'grid',
+    gap: '14px',
+  },
+  cards: {
+    display: 'grid',
+    gap: '12px',
+  },
+  taskCard: {
+    padding: '16px',
+  },
+  taskTop: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: '12px',
+  },
+  taskName: {
+    fontWeight: 650,
+    fontSize: '16px',
+  },
+  muted: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: '12px',
+  },
+  helperText: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: '12px',
+    lineHeight: '18px',
+  },
+  sandboxRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+  },
+  row: {
+    display: 'flex',
+    gap: '8px',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    marginTop: '12px',
+  },
+  empty: {
+    color: tokens.colorNeutralForeground3,
+    padding: '28px',
+    textAlign: 'center',
+  },
+  runHistory: {
+    borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+    display: 'grid',
+    gap: '8px',
+    marginTop: '14px',
+    paddingTop: '12px',
+  },
+  runHeading: {
+    color: tokens.colorNeutralForeground2,
+    fontSize: '12px',
+    fontWeight: 650,
+  },
+  allowedTools: {
+    borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+    display: 'grid',
+    gap: '8px',
+    marginTop: '14px',
+    paddingTop: '12px',
+  },
+  allowedToolItem: {
+    alignItems: 'center',
+    display: 'flex',
+    gap: '8px',
+    justifyContent: 'space-between',
+  },
+  runItem: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+    display: 'grid',
+    gap: '4px',
+    padding: '8px',
+  },
+  approvalRunItem: {
+    backgroundColor: tokens.colorPaletteYellowBackground1,
+    border: `1px solid ${tokens.colorPaletteYellowBorder2}`,
+  },
+  runSummary: {
+    alignItems: 'center',
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '8px',
+  },
+  statusPill: {
+    backgroundColor: tokens.colorNeutralBackground3,
+    borderRadius: tokens.borderRadiusCircular,
+    color: tokens.colorNeutralForeground2,
+    fontSize: '11px',
+    fontWeight: 650,
+    padding: '2px 8px',
+  },
+  approvalStatusPill: {
+    backgroundColor: tokens.colorPaletteYellowBackground3,
+    color: tokens.colorNeutralForegroundInverted,
+  },
+  runMeta: {
+    alignItems: 'center',
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '8px',
+  },
+  mono: {
+    fontFamily: tokens.fontFamilyMonospace,
+  },
+});
+
+const DEFAULT_TIME = '09:00';
+
+type ScheduleKind = 'manual' | 'hourly' | 'daily' | 'weekdays' | 'weekly';
+
+type RoutineFormState = {
+  name: string;
+  instructions: string;
+  scheduleKind: ScheduleKind;
+  time: string;
+  dayOfWeek: string;
+  projectId: string;
+  profileName: string;
+  permissionMode: ScheduledTaskPermissionMode;
+  enabled: boolean;
+};
+
+const createEmptyFormState = (defaultProfileName: string | undefined): RoutineFormState => ({
+  name: '',
+  instructions: '',
+  scheduleKind: 'daily',
+  time: DEFAULT_TIME,
+  dayOfWeek: '1',
+  projectId: '',
+  profileName: defaultProfileName ?? 'host',
+  permissionMode: 'ask',
+  enabled: true,
+});
+
+export const ScheduledTasks = memo(() => {
+  const styles = useStyles();
+  const store = useStore(persistedStoreApi.$atom);
+  const machines = useStore($machines);
+  const [isEnterprise, setIsEnterprise] = useState(false);
+  const [createForm, setCreateForm] = useState<RoutineFormState>(() => createEmptyFormState(store.defaultProfileName));
+  const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<RoutineFormState | null>(null);
+  const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
+  const [savingTaskId, setSavingTaskId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  useEffect(() => {
+    emitter
+      .invoke('platform:is-enterprise')
+      .then(setIsEnterprise)
+      .catch(() => setIsEnterprise(false));
+  }, []);
+
+  const sorted = useMemo(
+    () =>
+      [...(store.scheduledTasks ?? [])].sort(
+        (a, b) => (a.nextRunAt ?? Number.MAX_SAFE_INTEGER) - (b.nextRunAt ?? Number.MAX_SAFE_INTEGER)
+      ),
+    [store.scheduledTasks]
+  );
+
+  const createTask = async () => {
+    setError(null);
+    try {
+      await scheduledTaskApi.create(toScheduledTaskInput(createForm));
+      setCreateForm((current) => ({
+        ...createEmptyFormState(store.defaultProfileName),
+        projectId: current.projectId,
+        profileName: current.profileName,
+      }));
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const startEdit = (task: ScheduledTask) => {
+    setEditError(null);
+    setEditingTaskId(task.id);
+    setEditForm(toFormState(task, store.defaultProfileName));
+  };
+
+  const cancelEdit = () => {
+    setEditingTaskId(null);
+    setEditForm(null);
+    setEditError(null);
+  };
+
+  const saveEdit = async (task: ScheduledTask) => {
+    if (!editForm) {
+      return;
+    }
+    setSavingTaskId(task.id);
+    setEditError(null);
+    try {
+      await scheduledTaskApi.update(task.id, toScheduledTaskUpdate(editForm));
+      cancelEdit();
+    } catch (err) {
+      setEditError((err as Error).message);
+    } finally {
+      setSavingTaskId(null);
+    }
+  };
+
+  const runNow = async (task: ScheduledTask) => {
+    setBusyTaskId(task.id);
+    try {
+      await scheduledTaskApi.runNow(task.id);
+    } finally {
+      setBusyTaskId(null);
+    }
+  };
+
+  const openSession = async (task: ScheduledTask, run: ScheduledTaskRun) => {
+    if (!run.sessionId) {
+      return;
+    }
+    const tabs = persistedStoreApi.getKey('codeTabs') ?? [];
+    const existing = tabs.find((tab) => tab.sessionId === run.sessionId);
+    if (existing) {
+      await persistedStoreApi.setKey('activeCodeTabId', existing.id);
+      await persistedStoreApi.setKey('layoutMode', 'spaces');
+      return;
+    }
+    let workspaceDir: string | undefined;
+    if (task.projectId) {
+      workspaceDir = store.workspaceDir;
+    } else if (store.workspaceDir) {
+      try {
+        workspaceDir = await emitter.invoke('util:session-workspace-dir', store.workspaceDir, run.sessionId);
+      } catch {}
+    }
+    const tab: CodeTab = {
+      id: `routine-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      projectId: task.projectId ?? null,
+      sessionId: run.sessionId,
+      profileName: task.profileName ?? store.defaultProfileName ?? 'host',
+      profileNameExplicit: Boolean(task.profileName),
+      createdAt: Date.now(),
+      ...(workspaceDir ? { workspaceDir } : {}),
+    };
+    await persistedStoreApi.setKey('codeTabs', [...tabs, tab]);
+    await persistedStoreApi.setKey('activeCodeTabId', tab.id);
+    await persistedStoreApi.setKey('layoutMode', 'spaces');
+  };
+
+  const allowTool = async (task: ScheduledTask, toolName: string) => {
+    await scheduledTaskApi.allowTool(task.id, toolName);
+  };
+
+  const revokeTool = async (task: ScheduledTask, toolName: string) => {
+    await scheduledTaskApi.revokeTool(task.id, toolName);
+  };
+
+  const allowMcpTool = async (task: ScheduledTask, tool: ScheduledTaskAllowedMcpTool) => {
+    await scheduledTaskApi.allowMcpTool(task.id, tool);
+  };
+
+  const revokeMcpTool = async (task: ScheduledTask, tool: ScheduledTaskAllowedMcpTool) => {
+    await scheduledTaskApi.revokeMcpTool(task.id, tool);
+  };
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <div>
+          <h1 className={styles.title}>Routines</h1>
+          <div className={styles.subtitle}>
+            Schedule local Omni sessions that run while Desktop is open. Use /loop for quick polling inside one session.
+          </div>
+        </div>
+      </div>
+      <div className={styles.grid}>
+        <Card>
+          <RoutineForm
+            styles={styles}
+            value={createForm}
+            projects={store.projects}
+            sandboxContext={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
+            machines={machines}
+            submitLabel="Create routine"
+            error={error}
+            onChange={setCreateForm}
+            onSubmit={() => void createTask()}
+          />
+        </Card>
+        <div className={styles.cards}>
+          {sorted.length === 0 ? <Card className={styles.empty}>No routines yet.</Card> : null}
+          {sorted.map((task) => {
+            const isEditing = editingTaskId === task.id && editForm;
+            return (
+              <Card key={task.id} className={styles.taskCard}>
+                <div className={styles.taskTop}>
+                  <div>
+                    <div className={styles.taskName}>{task.name}</div>
+                    <div className={styles.muted}>{formatSchedule(task)}</div>
+                    <div className={styles.muted}>{formatProject(task, store.projects)}</div>
+                    <div className={styles.muted}>
+                      {task.profileName ? getProfileMenuLabel(task.profileName, machines) : 'Default sandbox'}
+                    </div>
+                  </div>
+                  <Switch
+                    checked={task.enabled}
+                    label={task.enabled ? 'Active' : 'Paused'}
+                    onChange={(_, data) => void scheduledTaskApi.update(task.id, { enabled: data.checked })}
+                  />
+                </div>
+                <div className={styles.row}>
+                  <Button size="small" onClick={() => void runNow(task)} disabled={busyTaskId === task.id}>
+                    Run now
+                  </Button>
+                  <Button size="small" appearance="secondary" onClick={() => startEdit(task)}>
+                    Edit
+                  </Button>
+                  <Button size="small" appearance="secondary" onClick={() => void scheduledTaskApi.delete(task.id)}>
+                    Delete
+                  </Button>
+                  <span className={styles.muted}>{task.history[0] ? lastRunLabel(task.history[0]) : 'Never run'}</span>
+                </div>
+                {isEditing ? (
+                  <div className={styles.runHistory} aria-label={`Edit ${task.name}`}>
+                    <div className={styles.runHeading}>Edit routine</div>
+                    <RoutineForm
+                      styles={styles}
+                      value={editForm}
+                      projects={store.projects}
+                      sandboxContext={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
+                      machines={machines}
+                      submitLabel="Save changes"
+                      error={editError}
+                      showEnabled
+                      busy={savingTaskId === task.id}
+                      onChange={setEditForm}
+                      onSubmit={() => void saveEdit(task)}
+                      onCancel={cancelEdit}
+                    />
+                  </div>
+                ) : null}
+                <AllowedToolsPanel
+                  styles={styles}
+                  task={task}
+                  onRevokeTool={revokeTool}
+                  onRevokeMcpTool={revokeMcpTool}
+                />
+                <RunHistory
+                  styles={styles}
+                  task={task}
+                  onOpenSession={openSession}
+                  onAllowTool={allowTool}
+                  onAllowMcpTool={allowMcpTool}
+                />
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+ScheduledTasks.displayName = 'ScheduledTasks';
+
+type RoutineFormProps = {
+  styles: ReturnType<typeof useStyles>;
+  value: RoutineFormState;
+  projects: Project[];
+  sandboxContext: ComponentProps<typeof SandboxPicker>['context'];
+  machines: Parameters<typeof getProfileMenuLabel>[1];
+  submitLabel: string;
+  error?: string | null;
+  showEnabled?: boolean;
+  busy?: boolean;
+  onChange: (value: RoutineFormState) => void;
+  onSubmit: () => void;
+  onCancel?: () => void;
+};
+
+const RoutineForm = ({
+  styles,
+  value,
+  projects,
+  sandboxContext,
+  machines,
+  submitLabel,
+  error,
+  showEnabled = false,
+  busy = false,
+  onChange,
+  onSubmit,
+  onCancel,
+}: RoutineFormProps) => {
+  const selectedProject = projects.find((project) => project.id === value.projectId);
+  const setField = <K extends keyof RoutineFormState>(field: K, fieldValue: RoutineFormState[K]) => {
+    onChange({ ...value, [field]: fieldValue });
+  };
+
+  return (
+    <div className={styles.form}>
+      <Field label="Name">
+        <Input
+          value={value.name}
+          onChange={(_, data) => setField('name', data.value)}
+          placeholder="Morning code review"
+        />
+      </Field>
+      <Field label="Instructions">
+        <Textarea
+          value={value.instructions}
+          onChange={(_, data) => setField('instructions', data.value)}
+          placeholder="Review yesterday's changes and summarize any risks."
+          resize="vertical"
+        />
+      </Field>
+      <Field label="Project">
+        <Select value={value.projectId} onChange={(event) => setField('projectId', event.currentTarget.value)}>
+          <option value="">No project · new session workspace</option>
+          {projects.map((project) => (
+            <option key={project.id} value={project.id}>
+              {project.label}
+            </option>
+          ))}
+        </Select>
+      </Field>
+      {!selectedProject ? (
+        <div className={styles.helperText}>
+          No project selected. Omni creates a fresh session workspace when this routine runs.
+        </div>
+      ) : null}
+      <Field label="Sandbox profile">
+        <div className={styles.sandboxRow}>
+          <SandboxPicker
+            value={value.profileName}
+            onChange={(profileName) => setField('profileName', profileName)}
+            context={sandboxContext}
+          />
+          <span className={styles.muted}>{getProfileMenuLabel(value.profileName, machines)}</span>
+        </div>
+      </Field>
+      <Field label="Approvals">
+        <Select
+          value={value.permissionMode}
+          onChange={(event) => setField('permissionMode', event.currentTarget.value as ScheduledTaskPermissionMode)}
+        >
+          <option value="ask">Ask when required</option>
+        </Select>
+      </Field>
+      <div className={styles.helperText}>
+        Uses the agent's built-in safe tools. Function tools can be always allowed by tool name; MCP tools can be always
+        allowed only for a specific server and tool pair.
+      </div>
+      <Field label="Schedule">
+        <Select
+          value={value.scheduleKind}
+          onChange={(event) => setField('scheduleKind', event.currentTarget.value as ScheduleKind)}
+        >
+          <option value="manual">Manual</option>
+          <option value="hourly">Hourly</option>
+          <option value="daily">Daily</option>
+          <option value="weekdays">Weekdays</option>
+          <option value="weekly">Weekly</option>
+        </Select>
+      </Field>
+      {value.scheduleKind !== 'manual' && value.scheduleKind !== 'hourly' ? (
+        <Field label="Time">
+          <Input type="time" value={value.time} onChange={(_, data) => setField('time', data.value)} />
+        </Field>
+      ) : null}
+      {value.scheduleKind === 'weekly' ? (
+        <Field label="Day">
+          <Select value={value.dayOfWeek} onChange={(event) => setField('dayOfWeek', event.currentTarget.value)}>
+            <option value="1">Monday</option>
+            <option value="2">Tuesday</option>
+            <option value="3">Wednesday</option>
+            <option value="4">Thursday</option>
+            <option value="5">Friday</option>
+            <option value="6">Saturday</option>
+            <option value="0">Sunday</option>
+          </Select>
+        </Field>
+      ) : null}
+      {showEnabled ? (
+        <Switch
+          checked={value.enabled}
+          label={value.enabled ? 'Active' : 'Paused'}
+          onChange={(_, data) => setField('enabled', data.checked)}
+        />
+      ) : null}
+      {error ? <div className={styles.muted}>{error}</div> : null}
+      <div className={styles.row}>
+        <Button
+          appearance="primary"
+          onClick={onSubmit}
+          disabled={busy || !value.name.trim() || !value.instructions.trim()}
+        >
+          {submitLabel}
+        </Button>
+        {onCancel ? (
+          <Button appearance="secondary" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+type RunHistoryProps = {
+  styles: ReturnType<typeof useStyles>;
+  task: ScheduledTask;
+  onOpenSession: (task: ScheduledTask, run: ScheduledTaskRun) => Promise<void>;
+  onAllowTool: (task: ScheduledTask, toolName: string) => Promise<void>;
+  onAllowMcpTool: (task: ScheduledTask, tool: ScheduledTaskAllowedMcpTool) => Promise<void>;
+};
+
+const RunHistory = ({ styles, task, onOpenSession, onAllowTool, onAllowMcpTool }: RunHistoryProps) => (
+  <div className={styles.runHistory} aria-label={`${task.name} recent runs`}>
+    <div className={styles.runHeading}>Recent runs</div>
+    {(task.history ?? []).length === 0 ? <div className={styles.muted}>No runs yet.</div> : null}
+    {(task.history ?? []).slice(0, 5).map((run) => (
+      <div key={run.id} className={mergeClasses(styles.runItem, isWaitingForApproval(run) && styles.approvalRunItem)}>
+        <div className={styles.runSummary}>
+          <span className={mergeClasses(styles.statusPill, isWaitingForApproval(run) && styles.approvalStatusPill)}>
+            Status: {formatRunStatus(run.status)}
+          </span>
+          <span className={styles.muted}>{formatRunTime(run)}</span>
+        </div>
+        {isWaitingForApproval(run) ? (
+          <div className={styles.helperText}>
+            {run.pendingApprovalKind === 'mcp'
+              ? run.pendingApprovalServerLabel && run.pendingApprovalToolName
+                ? `Waiting on MCP tool “${run.pendingApprovalServerLabel} / ${run.pendingApprovalToolName}”. You can always allow this exact server and tool pair for future runs; approve the current request in the session.`
+                : 'Waiting on an MCP approval. Approve the current request in the session.'
+              : run.pendingApprovalToolName
+                ? `Waiting on function tool “${run.pendingApprovalToolName}”. You can always allow it for future runs; approve the current request in the session.`
+                : 'Waiting on a function tool approval. Approve the current request in the session.'}
+          </div>
+        ) : null}
+        {run.reason ? <div className={styles.muted}>Reason: {run.reason}</div> : null}
+        <div className={styles.runMeta}>
+          {run.sessionId ? (
+            <span className={styles.muted}>
+              Session: <code className={styles.mono}>{shortId(run.sessionId)}</code>
+            </span>
+          ) : null}
+          {run.runId ? (
+            <span className={styles.muted}>
+              Run: <code className={styles.mono}>{shortId(run.runId)}</code>
+            </span>
+          ) : null}
+          {run.sessionId ? (
+            <Button size="small" appearance="subtle" onClick={() => void onOpenSession(task, run)}>
+              Open session
+            </Button>
+          ) : null}
+          {isWaitingForApproval(run) && run.pendingApprovalKind !== 'mcp' && run.pendingApprovalToolName ? (
+            <Button
+              size="small"
+              appearance="subtle"
+              onClick={() => void onAllowTool(task, run.pendingApprovalToolName!)}
+            >
+              Always allow for this routine
+            </Button>
+          ) : null}
+          {isWaitingForApproval(run) &&
+          run.pendingApprovalKind === 'mcp' &&
+          run.pendingApprovalServerLabel &&
+          run.pendingApprovalToolName ? (
+            <Button
+              size="small"
+              appearance="subtle"
+              onClick={() =>
+                void onAllowMcpTool(task, {
+                  serverLabel: run.pendingApprovalServerLabel!,
+                  toolName: run.pendingApprovalToolName!,
+                })
+              }
+            >
+              Always allow this MCP tool for this routine
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+type AllowedToolsPanelProps = {
+  styles: ReturnType<typeof useStyles>;
+  task: ScheduledTask;
+  onRevokeTool: (task: ScheduledTask, toolName: string) => Promise<void>;
+  onRevokeMcpTool: (task: ScheduledTask, tool: ScheduledTaskAllowedMcpTool) => Promise<void>;
+};
+
+const AllowedToolsPanel = ({ styles, task, onRevokeTool, onRevokeMcpTool }: AllowedToolsPanelProps) => {
+  const allowedToolNames = task.allowedToolNames ?? [];
+  const allowedMcpTools = task.allowedMcpTools ?? [];
+  return (
+    <>
+      <div className={styles.allowedTools} aria-label={`${task.name} always allowed function tools`}>
+        <div className={styles.runHeading}>Always allowed function tools</div>
+        {allowedToolNames.length === 0 ? (
+          <div className={styles.muted}>No function tools are always allowed for this routine.</div>
+        ) : null}
+        {allowedToolNames.map((toolName) => (
+          <div key={toolName} className={styles.allowedToolItem}>
+            <code className={styles.mono}>{toolName}</code>
+            <Button size="small" appearance="subtle" onClick={() => void onRevokeTool(task, toolName)}>
+              Revoke
+            </Button>
+          </div>
+        ))}
+      </div>
+      <div className={styles.allowedTools} aria-label={`${task.name} always allowed MCP tools`}>
+        <div className={styles.runHeading}>Always allowed MCP tools</div>
+        <div className={styles.helperText}>MCP approvals are scoped to the exact server label and tool name.</div>
+        {allowedMcpTools.length === 0 ? (
+          <div className={styles.muted}>No MCP server and tool pairs are always allowed for this routine.</div>
+        ) : null}
+        {allowedMcpTools.map((tool) => (
+          <div key={`${tool.serverLabel}\u0000${tool.toolName}`} className={styles.allowedToolItem}>
+            <code className={styles.mono}>
+              {tool.serverLabel} / {tool.toolName}
+            </code>
+            <Button size="small" appearance="subtle" onClick={() => void onRevokeMcpTool(task, tool)}>
+              Revoke
+            </Button>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+function buildSchedule(kind: ScheduleKind, time: string, dayOfWeek: number): ScheduledTaskSchedule {
+  if (kind === 'manual') {
+    return { kind: 'manual' };
+  }
+  if (kind === 'hourly') {
+    return { kind: 'interval', everyMinutes: 60 };
+  }
+  if (kind === 'weekdays') {
+    return { kind: 'daily', time, weekdaysOnly: true };
+  }
+  if (kind === 'weekly') {
+    return { kind: 'weekly', dayOfWeek, time };
+  }
+  return { kind: 'daily', time };
+}
+
+function toScheduledTaskInput(form: RoutineFormState): ScheduledTaskInput {
+  return {
+    name: form.name,
+    instructions: form.instructions,
+    description: '',
+    schedule: buildSchedule(form.scheduleKind, form.time, Number(form.dayOfWeek)),
+    permissionMode: form.permissionMode,
+    enabled: form.enabled,
+    ...(form.projectId ? { projectId: form.projectId } : {}),
+    ...(form.profileName ? { profileName: form.profileName } : {}),
+  };
+}
+
+function toScheduledTaskUpdate(form: RoutineFormState): ScheduledTaskInput {
+  return {
+    name: form.name,
+    instructions: form.instructions,
+    description: '',
+    schedule: buildSchedule(form.scheduleKind, form.time, Number(form.dayOfWeek)),
+    permissionMode: form.permissionMode,
+    enabled: form.enabled,
+    projectId: form.projectId,
+    profileName: form.profileName,
+  };
+}
+
+function toFormState(task: ScheduledTask, defaultProfileName: string | undefined): RoutineFormState {
+  const schedule = task.schedule;
+  const fallback = createEmptyFormState(defaultProfileName);
+  if (schedule.kind === 'manual') {
+    return { ...fallback, ...baseFormState(task), scheduleKind: 'manual' };
+  }
+  if (schedule.kind === 'interval') {
+    return { ...fallback, ...baseFormState(task), scheduleKind: 'hourly' };
+  }
+  if (schedule.kind === 'weekly') {
+    return {
+      ...fallback,
+      ...baseFormState(task),
+      scheduleKind: 'weekly',
+      time: schedule.time,
+      dayOfWeek: String(schedule.dayOfWeek),
+    };
+  }
+  return {
+    ...fallback,
+    ...baseFormState(task),
+    scheduleKind: schedule.weekdaysOnly ? 'weekdays' : 'daily',
+    time: schedule.time,
+  };
+}
+
+function baseFormState(
+  task: ScheduledTask
+): Pick<RoutineFormState, 'name' | 'instructions' | 'projectId' | 'profileName' | 'permissionMode' | 'enabled'> {
+  return {
+    name: task.name,
+    instructions: task.instructions,
+    projectId: task.projectId ?? '',
+    profileName: task.profileName ?? 'host',
+    permissionMode: task.permissionMode ?? 'ask',
+    enabled: task.enabled,
+  };
+}
+
+function formatSchedule(task: ScheduledTask): string {
+  if (!task.enabled) {
+    return 'Paused';
+  }
+  const next = task.nextRunAt ? ` · next ${new Date(task.nextRunAt).toLocaleString()}` : '';
+  const schedule = task.schedule;
+  if (schedule.kind === 'manual') {
+    return 'Manual';
+  }
+  if (schedule.kind === 'interval') {
+    return `Every ${schedule.everyMinutes} minutes${next}`;
+  }
+  if (schedule.kind === 'daily') {
+    return `${schedule.weekdaysOnly ? 'Weekdays' : 'Daily'} at ${schedule.time}${next}`;
+  }
+  return `Weekly on ${formatDayOfWeek(schedule.dayOfWeek)} at ${schedule.time}${next}`;
+}
+
+function formatDayOfWeek(dayOfWeek: number): string {
+  return ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'][dayOfWeek] ?? 'Monday';
+}
+
+function formatProject(task: ScheduledTask, projects: Project[]): string {
+  if (!task.projectId) {
+    return 'No project';
+  }
+  return projects.find((project) => project.id === task.projectId)?.label ?? 'Unknown project';
+}
+
+function lastRunLabel(run: ScheduledTask['history'][number]): string {
+  return `Last ${formatRunStatus(run.status)} ${new Date(run.startedAt).toLocaleString()}`;
+}
+
+function formatRunStatus(status: ScheduledTaskRun['status']): string {
+  if (status === 'waiting_for_approval') {
+    return 'Waiting for approval';
+  }
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+function isWaitingForApproval(run: ScheduledTaskRun): boolean {
+  return run.status === 'waiting_for_approval';
+}
+
+function formatRunTime(run: ScheduledTaskRun): string {
+  const started = new Date(run.startedAt).toLocaleString();
+  if (!run.completedAt) {
+    return `Started ${started}`;
+  }
+  return `Started ${started} · Completed ${new Date(run.completedAt).toLocaleString()}`;
+}
+
+function shortId(id: string): string {
+  return id.length > 12 ? id.slice(0, 8) : id;
+}

--- a/src/renderer/features/ScheduledTasks/ScheduledTasks.tsx
+++ b/src/renderer/features/ScheduledTasks/ScheduledTasks.tsx
@@ -517,8 +517,8 @@ const RoutineForm = ({
         </Select>
       </Field>
       <div className={styles.helperText}>
-        Uses the agent's built-in safe tools. Function tools can be always allowed by tool name; MCP tools can be always
-        allowed only for a specific server and tool pair.
+        Uses the agent&apos;s built-in safe tools. Function tools can be always allowed by tool name; MCP tools can be
+        always allowed only for a specific server and tool pair.
       </div>
       <Field label="Schedule">
         <Select

--- a/src/renderer/services/app-history.ts
+++ b/src/renderer/services/app-history.ts
@@ -26,6 +26,7 @@ const TAB_TITLES: Record<LayoutMode, string> = {
   spaces: 'Spaces',
   projects: 'Projects',
   dashboards: 'Dashboards',
+  routines: 'Routines',
   settings: 'Settings',
   gallery: 'Gallery',
 };

--- a/src/renderer/services/scheduled-tasks.ts
+++ b/src/renderer/services/scheduled-tasks.ts
@@ -1,5 +1,10 @@
 import { emitter } from '@/renderer/services/ipc';
-import type { ScheduledTask, ScheduledTaskAllowedMcpTool, ScheduledTaskInput, ScheduledTaskUpdate } from '@/shared/types';
+import type {
+  ScheduledTask,
+  ScheduledTaskAllowedMcpTool,
+  ScheduledTaskInput,
+  ScheduledTaskUpdate,
+} from '@/shared/types';
 
 export const scheduledTaskApi = {
   list: (): Promise<ScheduledTask[]> => emitter.invoke('scheduled-task:list'),

--- a/src/renderer/services/scheduled-tasks.ts
+++ b/src/renderer/services/scheduled-tasks.ts
@@ -1,0 +1,19 @@
+import { emitter } from '@/renderer/services/ipc';
+import type { ScheduledTask, ScheduledTaskAllowedMcpTool, ScheduledTaskInput, ScheduledTaskUpdate } from '@/shared/types';
+
+export const scheduledTaskApi = {
+  list: (): Promise<ScheduledTask[]> => emitter.invoke('scheduled-task:list'),
+  create: (input: ScheduledTaskInput): Promise<ScheduledTask> => emitter.invoke('scheduled-task:create', input),
+  update: (taskId: string, patch: ScheduledTaskUpdate): Promise<ScheduledTask> =>
+    emitter.invoke('scheduled-task:update', taskId, patch),
+  delete: (taskId: string): Promise<void> => emitter.invoke('scheduled-task:delete', taskId),
+  runNow: (taskId: string): Promise<ScheduledTask> => emitter.invoke('scheduled-task:run-now', taskId),
+  allowTool: (taskId: string, toolName: string): Promise<ScheduledTask> =>
+    emitter.invoke('scheduled-task:allow-tool', taskId, toolName),
+  revokeTool: (taskId: string, toolName: string): Promise<ScheduledTask> =>
+    emitter.invoke('scheduled-task:revoke-tool', taskId, toolName),
+  allowMcpTool: (taskId: string, tool: ScheduledTaskAllowedMcpTool): Promise<ScheduledTask> =>
+    emitter.invoke('scheduled-task:allow-mcp-tool', taskId, tool),
+  revokeMcpTool: (taskId: string, tool: ScheduledTaskAllowedMcpTool): Promise<ScheduledTask> =>
+    emitter.invoke('scheduled-task:revoke-mcp-tool', taskId, tool),
+};

--- a/src/renderer/services/store.ts
+++ b/src/renderer/services/store.ts
@@ -50,6 +50,7 @@ const getDefaults = (): StoreData => ({
   wipLimit: 3,
   weeklyReviewDay: 5,
   lastWeeklyReviewAt: null,
+  scheduledTasks: [],
   enabledExtensions: {},
   skillSources: {},
   installedBundles: {},

--- a/src/server/managers.ts
+++ b/src/server/managers.ts
@@ -50,6 +50,7 @@ import { backfillProjectConfigs } from '@/main/project-config-backfill';
 import { closeProjectDb, getDb, openProjectDb } from '@/main/project-db';
 import { registerProjectHandlers } from '@/main/project-handlers';
 import { ProjectManager } from '@/main/project-manager';
+import { registerScheduledTaskHandlers, ScheduledTaskManager } from '@/main/scheduled-task-manager';
 import { registerSnapshotHandlers } from '@/main/snapshot-manager';
 import { registerSupervisorHandlers } from '@/main/supervisor-handlers';
 import { getOmniConfigDir } from '@/main/util';
@@ -407,6 +408,7 @@ export const wireGlobalHandlers = async (arg: {
   type TenantInstance = {
     projectManager: ProjectManager;
     processManager: ProcessManager;
+    scheduledTaskManager: ScheduledTaskManager;
     settings: SettingsStore;
     extension: ExtensionManager;
     browser: BrowserContext;
@@ -565,6 +567,18 @@ export const wireGlobalHandlers = async (arg: {
     };
     applyPlatformClient();
     settings.onDidAnyChange(() => applyPlatformClient());
+    const scheduledTaskManager = new ScheduledTaskManager({
+      store: settings as any,
+      processManager,
+      sendToWindow: (channel, ...args) => {
+        if (channel === 'store:changed') {
+          tenantSend('store:changed', getStoreSnapshot(teamId, principalId));
+          return;
+        }
+        tenantSend(channel, ...args);
+      },
+    });
+    scheduledTaskManager.start();
     // Computer-as-sandbox: the per-principal set of `local:<machineId>` picker
     // entries is derived from the machine registry in `broadcastMachines` (a
     // sync cache read by `getStoreSnapshot`). The single `HostBridgePreparer`
@@ -610,7 +624,7 @@ export const wireGlobalHandlers = async (arg: {
     // (enabledExtensions / browser profiles/tabs/history/bookmarks are per-user).
     const extension = new ExtensionManager({ store: settings as any, sendToWindow: tenantSend });
     const browser = buildBrowserContext(settings as any, tenantSend);
-    ref = { projectManager, processManager, settings, extension, browser, configDir };
+    ref = { projectManager, processManager, scheduledTaskManager, settings, extension, browser, configDir };
     tenants.set(tenantKey(teamId, principalId), ref);
     return ref;
   };
@@ -874,6 +888,7 @@ export const wireGlobalHandlers = async (arg: {
   );
   registerInboxHandlers(ipc, (e) => tenantPM(e).inbox);
   registerProcessHandlers(ipc, (e) => ctxTenant(e).processManager);
+  registerScheduledTaskHandlers(ipc, (e) => ctxTenant(e).scheduledTaskManager);
   registerExtensionHandlers(ipc, (e) => ctxTenant(e).extension);
   registerBrowserHandlers(ipc, (e) => ctxTenant(e).browser);
 
@@ -1628,6 +1643,7 @@ export const wireGlobalHandlers = async (arg: {
       await stopListener();
     }
     const tenantCleanups = [...tenants.values()].flatMap((t) => [
+      Promise.resolve(t.scheduledTaskManager.stop()),
       t.projectManager.exit(),
       t.processManager.cleanup(),
       t.extension.cleanup(),

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -46,6 +46,7 @@ export const DEFAULTS: StoreData = {
   wipLimit: 3,
   weeklyReviewDay: 5,
   lastWeeklyReviewAt: null,
+  scheduledTasks: [],
   enabledExtensions: {},
   skillSources: {},
   installedBundles: {},

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -49,7 +49,7 @@ export type WindowProps = {
 /**
  * Data stored in the electron store.
  */
-export type LayoutMode = 'chat' | 'spaces' | 'projects' | 'dashboards' | 'settings' | 'gallery';
+export type LayoutMode = 'chat' | 'spaces' | 'projects' | 'dashboards' | 'routines' | 'settings' | 'gallery';
 export type OmniTheme =
   | 'omni'
   | 'teams-light'
@@ -203,6 +203,7 @@ export type StoreData = {
   weeklyReviewDay: number;
   /** Timestamp (ms) of last completed weekly review. Null if never done. */
   lastWeeklyReviewAt: number | null;
+  scheduledTasks: ScheduledTask[];
   schemaVersion: number;
   // Chat session identity lives on the reserved ``codeTabs`` entry
   // (``CHAT_TAB_ID``) since v26; the legacy ``chatSessionId`` /
@@ -346,6 +347,70 @@ export type PagesMigrationState = {
   /** True once the user dismissed the notice or ran cleanup. */
   acknowledged: boolean;
 };
+
+export type ScheduledTaskSchedule =
+  | { kind: 'manual' }
+  | { kind: 'interval'; everyMinutes: number }
+  | { kind: 'daily'; time: string; weekdaysOnly?: boolean }
+  | { kind: 'weekly'; dayOfWeek: number; time: string };
+
+export type ScheduledTaskRunStatus = 'running' | 'waiting_for_approval' | 'completed' | 'skipped' | 'failed';
+
+export type ScheduledTaskPermissionMode = 'ask';
+
+export type ScheduledTaskRun = {
+  id: string;
+  scheduledFor: number;
+  startedAt: number;
+  completedAt?: number;
+  status: ScheduledTaskRunStatus;
+  runId?: string;
+  sessionId?: string;
+  processId?: string;
+  pendingApprovalToolName?: string;
+  pendingApprovalServerLabel?: string;
+  pendingApprovalKind?: 'function' | 'mcp';
+  reason?: string;
+};
+
+export type ScheduledTaskAllowedMcpTool = {
+  serverLabel: string;
+  toolName: string;
+};
+
+export type ScheduledTask = {
+  id: string;
+  name: string;
+  description: string;
+  instructions: string;
+  schedule: ScheduledTaskSchedule;
+  permissionMode: ScheduledTaskPermissionMode;
+  enabled: boolean;
+  projectId?: ProjectId;
+  profileName?: string;
+  createdAt: number;
+  updatedAt: number;
+  nextRunAt: number | null;
+  lastRunAt?: number;
+  runningSessionId?: string;
+  runningProcessId?: string;
+  allowedToolNames: string[];
+  allowedMcpTools: ScheduledTaskAllowedMcpTool[];
+  history: ScheduledTaskRun[];
+};
+
+export type ScheduledTaskInput = {
+  name: string;
+  description?: string;
+  instructions: string;
+  schedule: ScheduledTaskSchedule;
+  permissionMode?: ScheduledTaskPermissionMode;
+  enabled?: boolean;
+  projectId?: ProjectId;
+  profileName?: string;
+};
+
+export type ScheduledTaskUpdate = Partial<ScheduledTaskInput> & { enabled?: boolean };
 
 // #region Browser types
 
@@ -512,7 +577,7 @@ export const schema: Schema<StoreData> = {
     // 'code' and 'os' are pre-v20 names for 'spaces'; 'more' is the retired
     // mobile overflow page. Kept so existing stores load before the renderer's
     // migrateLayoutMode pass converts them.
-    enum: ['chat', 'spaces', 'os', 'code', 'projects', 'dashboards', 'settings', 'more', 'gallery'],
+    enum: ['chat', 'spaces', 'os', 'code', 'projects', 'dashboards', 'routines', 'settings', 'more', 'gallery'],
     default: 'chat',
   },
   theme: {
@@ -562,6 +627,56 @@ export const schema: Schema<StoreData> = {
   lastWeeklyReviewAt: {
     type: ['number', 'null'],
     default: null,
+  },
+  scheduledTasks: {
+    type: 'array',
+    default: [],
+    items: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        description: { type: 'string' },
+        instructions: { type: 'string' },
+        schedule: { type: 'object' },
+        permissionMode: { type: 'string', enum: ['ask'], default: 'ask' },
+        enabled: { type: 'boolean' },
+        projectId: { type: 'string' },
+        profileName: { type: 'string' },
+        createdAt: { type: 'number' },
+        updatedAt: { type: 'number' },
+        nextRunAt: { type: ['number', 'null'] },
+        lastRunAt: { type: 'number' },
+        runningSessionId: { type: 'string' },
+        runningProcessId: { type: 'string' },
+        allowedToolNames: { type: 'array', default: [], items: { type: 'string' } },
+        allowedMcpTools: {
+          type: 'array',
+          default: [],
+          items: {
+            type: 'object',
+            properties: {
+              serverLabel: { type: 'string' },
+              toolName: { type: 'string' },
+            },
+            required: ['serverLabel', 'toolName'],
+          },
+        },
+        history: { type: 'array', default: [], items: { type: 'object' } },
+      },
+      required: [
+        'id',
+        'name',
+        'description',
+        'instructions',
+        'schedule',
+        'enabled',
+        'createdAt',
+        'updatedAt',
+        'nextRunAt',
+        'history',
+      ],
+    },
   },
   schemaVersion: {
     type: 'number',
@@ -1807,6 +1922,21 @@ type StoreIpcEvents = Namespaced<
   }
 >;
 
+type ScheduledTaskIpcEvents = Namespaced<
+  'scheduled-task',
+  {
+    list: () => ScheduledTask[];
+    create: (input: ScheduledTaskInput) => ScheduledTask;
+    update: (taskId: string, patch: ScheduledTaskUpdate) => ScheduledTask;
+    delete: (taskId: string) => void;
+    'run-now': (taskId: string) => ScheduledTask;
+    'allow-tool': (taskId: string, toolName: string) => ScheduledTask;
+    'revoke-tool': (taskId: string, toolName: string) => ScheduledTask;
+    'allow-mcp-tool': (taskId: string, tool: ScheduledTaskAllowedMcpTool) => ScheduledTask;
+    'revoke-mcp-tool': (taskId: string, tool: ScheduledTaskAllowedMcpTool) => ScheduledTask;
+  }
+>;
+
 /**
  * Main Process API. Main process handles these events, renderer process invokes them.
  */
@@ -2562,7 +2692,11 @@ export type RunOverrides = {
   /** Prepended to the column's existing additional_instructions. */
   additionalInstructions?: string;
   /** Approval policy override; replaces the column's default. */
-  safeToolOverrides?: { safe_tool_names?: string[]; safe_tool_patterns?: string[] };
+  safeToolOverrides?: {
+    safe_tool_names?: string[];
+    safe_tool_patterns?: string[];
+    safe_mcp_tools?: { server_label: string; tool_name: string }[];
+  };
 };
 
 export type SupervisorBridgeRequest =
@@ -3110,6 +3244,7 @@ export type IpcEvents = MainProcessIpcEvents &
   UtilIpcEvents &
   TerminalIpcEvents &
   StoreIpcEvents &
+  ScheduledTaskIpcEvents &
   ConfigIpcEvents &
   CodexIpcEvents &
   CloudIpcEvents &

--- a/tests/e2e/specs/app-shell.spec.ts
+++ b/tests/e2e/specs/app-shell.spec.ts
@@ -6,6 +6,7 @@ test.describe('app shell', () => {
       await expect(appPage.getByRole('tablist', { name: 'Main navigation' })).toBeVisible();
       await expect(appPage.getByRole('tab', { name: 'Chat' })).toBeVisible();
       await expect(appPage.getByRole('tab', { name: 'Projects' })).toBeVisible();
+      await expect(appPage.getByRole('tab', { name: 'Routines' })).toBeVisible();
       await expect(appPage.getByRole('tab', { name: 'Settings' })).toBeVisible();
     });
 
@@ -17,6 +18,12 @@ test.describe('app shell', () => {
     await test.step('switch to Settings', async () => {
       await appPage.getByRole('tab', { name: 'Settings' }).click();
       await expect(appPage.getByRole('tab', { name: 'Settings' })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    await test.step('switch to Routines', async () => {
+      await appPage.getByRole('tab', { name: 'Routines' }).click();
+      await expect(appPage.getByRole('tab', { name: 'Routines' })).toHaveAttribute('aria-selected', 'true');
+      await expect(appPage.getByRole('heading', { name: 'Routines' })).toBeVisible();
     });
   });
 });

--- a/tests/e2e/specs/routines.spec.ts
+++ b/tests/e2e/specs/routines.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from 'tests/e2e/fixtures/test';
+import { openRoutines } from 'tests/e2e/support/app';
+
+test.use({ seedState: 'planning' });
+
+test.describe('routines', () => {
+  test('creates, edits, pauses, runs, opens, and deletes a desktop scheduled task', async ({ app }) => {
+    await openRoutines(app.page);
+
+    await test.step('create routine', async () => {
+      await app.page.getByRole('textbox', { name: 'Name' }).fill('E2E morning review');
+      await app.page.getByRole('textbox', { name: 'Instructions' }).fill('Summarize the workspace status.');
+      await expect(app.page.getByRole('combobox', { name: 'Project' })).toBeVisible();
+      await expect(app.page.getByRole('combobox', { name: 'Approvals' })).toHaveValue('ask');
+      await expect(app.page.getByText(/Function tools can be always allowed by tool name/)).toBeVisible();
+      await expect(
+        app.page.getByText(/MCP tools can be always allowed only for a specific server and tool pair/)
+      ).toBeVisible();
+      await expect(app.page.getByText(/auto[- ]approve all/i)).toHaveCount(0);
+      await app.page.getByRole('combobox', { name: 'Project' }).selectOption({ label: 'Seeded Project' });
+      await expect(app.page.getByRole('button', { name: /This computer/ })).toBeVisible();
+      await app.page.getByRole('button', { name: 'Create routine' }).click();
+      await expect(app.page.getByText('E2E morning review')).toBeVisible();
+      await expect(app.page.getByText(/Daily at 09:00/)).toBeVisible();
+      await expect(app.page.getByLabel('E2E morning review always allowed function tools')).toBeVisible();
+      await expect(app.page.getByText('Always allowed function tools')).toBeVisible();
+      await expect(app.page.getByText('No function tools are always allowed for this routine.')).toBeVisible();
+      await expect(app.page.getByLabel('E2E morning review always allowed MCP tools')).toBeVisible();
+      await expect(app.page.getByText('Always allowed MCP tools')).toBeVisible();
+      await expect(
+        app.page.getByText('MCP approvals are scoped to the exact server label and tool name.')
+      ).toBeVisible();
+      await expect(
+        app.page.getByText('No MCP server and tool pairs are always allowed for this routine.')
+      ).toBeVisible();
+      await expect(app.page.locator('div').filter({ hasText: /^Seeded Project$/ })).toBeVisible();
+      await expect(app.page.getByText('This computer (no sandbox)').first()).toBeVisible();
+    });
+
+    await test.step('edit routine', async () => {
+      await app.page.getByRole('button', { name: 'Edit' }).click();
+      const editPanel = app.page.getByLabel('Edit E2E morning review');
+      await expect(editPanel).toBeVisible();
+      await expect(editPanel.getByRole('combobox', { name: 'Approvals' })).toHaveValue('ask');
+      await expect(editPanel.getByText(/Function tools can be always allowed by tool name/)).toBeVisible();
+      await expect(
+        editPanel.getByText(/MCP tools can be always allowed only for a specific server and tool pair/)
+      ).toBeVisible();
+      await expect(editPanel.getByText(/auto[- ]approve all/i)).toHaveCount(0);
+      await editPanel.getByRole('textbox', { name: 'Name' }).fill('E2E edited review');
+      await editPanel.getByRole('combobox', { name: 'Schedule' }).selectOption('weekly');
+      await editPanel.getByLabel('Time').fill('10:30');
+      await editPanel.getByRole('combobox', { name: 'Day' }).selectOption('2');
+      await editPanel.getByRole('button', { name: 'Save changes' }).click();
+      await expect(app.page.getByText('E2E edited review')).toBeVisible();
+      await expect(app.page.getByText(/Weekly on Tuesday at 10:30/)).toBeVisible();
+      await expect(editPanel).toHaveCount(0);
+    });
+
+    await test.step('pause and resume routine', async () => {
+      const routineCard = app.page.getByRole('group').filter({ hasText: 'E2E edited review' });
+      await routineCard.getByRole('switch', { name: 'Active' }).click();
+      await expect(routineCard.getByRole('switch', { name: 'Paused' })).toBeVisible();
+      await routineCard.getByRole('switch', { name: 'Paused' }).click();
+      await expect(routineCard.getByRole('switch', { name: 'Active' })).toBeVisible();
+    });
+
+    await test.step('run manually records launch attempt', async () => {
+      await app.page.getByRole('button', { name: 'Run now' }).click();
+      await expect(app.page.getByText(/Last (Running|Completed|Failed|Waiting for approval)/)).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(app.page.getByLabel('E2E edited review recent runs')).toBeVisible();
+      await expect(app.page.getByText(/Status: (Running|Completed|Failed|Waiting for approval)/)).toBeVisible();
+      await expect(app.page.getByText(/Session:/)).toBeVisible();
+      await expect(app.page.getByRole('button', { name: 'Open session' })).toBeVisible();
+    });
+
+    await test.step('open run session for review', async () => {
+      await app.page.getByRole('button', { name: 'Open session' }).click();
+      await expect(app.page.getByRole('tab', { name: 'Spaces' })).toHaveAttribute('aria-selected', 'true');
+      await openRoutines(app.page);
+    });
+
+    await test.step('delete routine', async () => {
+      await app.page.getByRole('button', { name: 'Delete' }).click();
+      await expect(app.page.getByText('No routines yet.')).toBeVisible();
+    });
+  });
+});

--- a/tests/e2e/support/app.ts
+++ b/tests/e2e/support/app.ts
@@ -28,6 +28,11 @@ export async function openSettings(page: Page): Promise<void> {
   await expect(page.getByRole('tab', { name: 'Settings' })).toHaveAttribute('aria-selected', 'true');
 }
 
+export async function openRoutines(page: Page): Promise<void> {
+  await page.getByRole('tab', { name: 'Routines' }).click();
+  await expect(page.getByRole('tab', { name: 'Routines' })).toHaveAttribute('aria-selected', 'true');
+}
+
 export async function createProject(page: Page, projectName: string): Promise<void> {
   await openProjects(page);
   await page.getByRole('button', { name: 'New project' }).first().click();


### PR DESCRIPTION
## Summary
- Add Desktop Routines for persisted scheduled Omni sessions alongside `/loop`
- Add project and sandbox profile selection, run lifecycle tracking, edit/delete/run-now controls, and recent run history with session review links
- Add per-routine function and MCP allowed-tool persistence with revoke UI, approval-needed status, lifecycle toasts, catch-up scheduling, and Playwright proof coverage

## Validation
- `npm run lint:tsc`
- `npm test -- --run src/lib/scheduled-task-schedule.test.ts src/lib/store-init.test.ts src/renderer/features/CommandPalette/commands.test.ts`
- `npx playwright test tests/e2e/specs/routines.spec.ts tests/e2e/specs/app-shell.spec.ts --project=server-local --project=electron-local`
- `VISUAL_PROOF=1 npx playwright test tests/e2e/specs/routines.spec.ts --project=server-local --project=electron-local`

## Proof
- `artifacts/playwright-proof-results/routines-routines-creates--0adfa-es-a-desktop-scheduled-task-server-local/test-finished-1.png`
- `artifacts/playwright-proof-results/routines-routines-creates--0adfa-es-a-desktop-scheduled-task-electron-local/test-finished-1.png`
