### PR TITLE
Improve Routines workspace and live session UX

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -296,6 +296,7 @@ const [processManager, cleanupProcessManager] = createProcessManager({
 const scheduledTaskManager = new ScheduledTaskManager({
   store,
   processManager,
+  getProjects: () => repo.listProjects().map(rowToProject),
   sendToWindow: main.sendToWindow,
 });
 const scheduledTaskChannels = registerScheduledTaskHandlers(main.ipc, () => scheduledTaskManager);

--- a/src/main/scheduled-task-manager.test.ts
+++ b/src/main/scheduled-task-manager.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ScheduledTaskManager } from '@/main/scheduled-task-manager';
+import type { Project, ScheduledTask, StoreData } from '@/shared/types';
+
+const now = 1_700_000_000_000;
+
+function createTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: 'routine-1',
+    name: 'Routine',
+    description: '',
+    instructions: 'Do work',
+    schedule: { kind: 'manual' },
+    permissionMode: 'ask',
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+    nextRunAt: null,
+    allowedToolNames: [],
+    allowedMcpTools: [],
+    history: [],
+    ...overrides,
+  };
+}
+
+function createProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'project-1',
+    label: 'Project',
+    slug: 'project',
+    sources: [],
+    createdAt: now,
+    ...overrides,
+  };
+}
+
+function createStore(storeData: Partial<StoreData>) {
+  return {
+    get: <Key extends keyof StoreData>(key: Key): StoreData[Key] => storeData[key] as StoreData[Key],
+    set: <Key extends keyof StoreData>(key: Key, value: StoreData[Key]): void => {
+      storeData[key] = value;
+    },
+  } as any;
+}
+
+describe('ScheduledTaskManager workspace resolution', () => {
+  let tempDir: string | null = null;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it('launches project routines in the project local source directory', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'routine-project-'));
+    let capturedWorkspaceDir: string | undefined;
+    const storeData: Partial<StoreData> = {
+      workspaceDir: join(tempDir, 'omni-root'),
+      scheduledTasks: [createTask({ projectId: 'project-1' })],
+    };
+    const manager = new ScheduledTaskManager({
+      store: createStore(storeData),
+      processManager: {
+        start: async (_processId: string, opts: { workspaceDir: string }) => {
+          capturedWorkspaceDir = opts.workspaceDir;
+          throw new Error('stop after capture');
+        },
+        stop: vi.fn(),
+        getStatus: vi.fn(),
+      } as any,
+      getProjects: () => [
+        createProject({
+          sources: [{ kind: 'local', id: 'src-1', mountName: 'project', workspaceDir: join(tempDir!, 'project') }],
+        }),
+      ],
+      now: () => now,
+    });
+
+    manager.runNow('routine-1');
+
+    await vi.waitFor(() => expect(capturedWorkspaceDir).toBe(join(tempDir!, 'project')));
+  });
+
+  it('launches projectless routines in a per-session scratch workspace', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'routine-session-'));
+    let capturedWorkspaceDir: string | undefined;
+    const storeData: Partial<StoreData> = {
+      workspaceDir: join(tempDir, 'omni-root'),
+      scheduledTasks: [createTask()],
+    };
+    const manager = new ScheduledTaskManager({
+      store: createStore(storeData),
+      processManager: {
+        start: async (_processId: string, opts: { workspaceDir: string }) => {
+          capturedWorkspaceDir = opts.workspaceDir;
+          throw new Error('stop after capture');
+        },
+        stop: vi.fn(),
+        getStatus: vi.fn(),
+      } as any,
+      getProjects: () => [],
+      now: () => now,
+    });
+
+    manager.runNow('routine-1');
+
+    await vi.waitFor(() => {
+      expect(capturedWorkspaceDir).toContain(join(tempDir!, 'omni-root', 'Sessions'));
+    });
+  });
+});

--- a/src/main/scheduled-task-manager.ts
+++ b/src/main/scheduled-task-manager.ts
@@ -7,9 +7,11 @@ import { WebSocket as WsWebSocket } from 'ws';
 import { mostRecentMissedScheduledTaskRun, nextScheduledTaskRun } from '@/lib/scheduled-task-schedule';
 import type { ProcessManager } from '@/main/process-manager';
 import { ensureDirectory } from '@/main/util';
+import { getLocalWorkspaceDir } from '@/shared/project-source';
 import type { IIpcListener } from '@/shared/ipc-listener';
 import type {
   IpcRendererEvents,
+  Project,
   ScheduledTask,
   ScheduledTaskAllowedMcpTool,
   ScheduledTaskInput,
@@ -18,6 +20,7 @@ import type {
   ScheduledTaskUpdate,
   StoreData,
 } from '@/shared/types';
+import { firstSource } from '@/shared/types';
 
 const TICK_MS = 60_000;
 const HISTORY_LIMIT = 25;
@@ -60,6 +63,7 @@ type ApprovalRequest = {
 type ManagerDeps = {
   store: ScheduledTaskStore;
   processManager: ProcessManager;
+  getProjects: () => Project[];
   sendToWindow?: <T extends keyof IpcRendererEvents>(channel: T, ...args: IpcRendererEvents[T]) => void;
   now?: () => number;
 };
@@ -72,6 +76,7 @@ type NotifiableRunStatus = Extract<
 export class ScheduledTaskManager {
   private store: ScheduledTaskStore;
   private processManager: ProcessManager;
+  private getProjects: () => Project[];
   private sendToWindow?: ManagerDeps['sendToWindow'];
   private now: () => number;
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -82,6 +87,7 @@ export class ScheduledTaskManager {
   constructor(deps: ManagerDeps) {
     this.store = deps.store;
     this.processManager = deps.processManager;
+    this.getProjects = deps.getProjects;
     this.sendToWindow = deps.sendToWindow;
     this.now = deps.now ?? Date.now;
   }
@@ -511,11 +517,19 @@ export class ScheduledTaskManager {
 
   private async resolveWorkspaceDir(task: ScheduledTask, sessionId: string): Promise<string> {
     const baseDir = this.store.get('workspaceDir');
+    if (task.projectId) {
+      const project = this.getProjects().find((item) => item.id === task.projectId);
+      const projectWorkspaceDir = getLocalWorkspaceDir(firstSource(project));
+      if (projectWorkspaceDir) {
+        return projectWorkspaceDir;
+      }
+      if (!baseDir?.trim()) {
+        throw new Error('Workspace root is not configured');
+      }
+      return join(baseDir, 'Projects', project?.slug ?? task.projectId);
+    }
     if (!baseDir?.trim()) {
       throw new Error('Workspace root is not configured');
-    }
-    if (task.projectId) {
-      return baseDir;
     }
     const safeId = sessionId.replace(/[^a-zA-Z0-9_-]/g, '') || 'default';
     const dir = join(baseDir, 'Sessions', safeId);

--- a/src/main/scheduled-task-manager.ts
+++ b/src/main/scheduled-task-manager.ts
@@ -7,8 +7,8 @@ import { WebSocket as WsWebSocket } from 'ws';
 import { mostRecentMissedScheduledTaskRun, nextScheduledTaskRun } from '@/lib/scheduled-task-schedule';
 import type { ProcessManager } from '@/main/process-manager';
 import { ensureDirectory } from '@/main/util';
-import { getLocalWorkspaceDir } from '@/shared/project-source';
 import type { IIpcListener } from '@/shared/ipc-listener';
+import { getLocalWorkspaceDir } from '@/shared/project-source';
 import type {
   IpcRendererEvents,
   Project,

--- a/src/renderer/app/MainContent.tsx
+++ b/src/renderer/app/MainContent.tsx
@@ -8,7 +8,7 @@ import { Code } from '@/renderer/features/Code/Code';
 import { Dashboards } from '@/renderer/features/Dashboards/Dashboards';
 import { Gallery } from '@/renderer/features/Gallery/Gallery';
 import { OnboardingWizard } from '@/renderer/features/Onboarding/OnboardingWizard';
-import { ScheduledTasks } from '@/renderer/features/ScheduledTasks/ScheduledTasks';
+import { RoutineSessionWatcher, ScheduledTasks } from '@/renderer/features/ScheduledTasks/ScheduledTasks';
 import { SettingsPage } from '@/renderer/features/SettingsModal/SettingsPage';
 import { Tickets } from '@/renderer/features/Tickets/Tickets';
 import { persistedStoreApi } from '@/renderer/services/store';
@@ -112,6 +112,7 @@ export const MainContent = memo(() => {
       }
     >
       <Sidebar />
+      <RoutineSessionWatcher />
       <div className={styles.content}>
         {panels.map(
           ({ key, Component }) =>

--- a/src/renderer/features/Code/CodeDeck.tsx
+++ b/src/renderer/features/Code/CodeDeck.tsx
@@ -22,6 +22,7 @@ import {
   Apps20Regular,
   ArrowMaximize20Regular,
   ArrowMinimize20Regular,
+  ArrowSync20Regular,
   BranchFork20Regular,
   Chat20Regular,
   Globe20Regular,
@@ -208,6 +209,55 @@ const useStyles = makeStyles({
     paddingTop: '2px',
     paddingBottom: tokens.spacingVerticalXS,
     backgroundColor: 'transparent',
+  },
+  routineBanner: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    columnGap: tokens.spacingHorizontalS,
+    rowGap: '2px',
+    paddingLeft: tokens.spacingHorizontalM,
+    paddingRight: tokens.spacingHorizontalM,
+    paddingTop: '2px',
+    paddingBottom: tokens.spacingVerticalXS,
+    backgroundColor: 'color-mix(in srgb, #7c3aed 8%, transparent)',
+    borderTop: '1px solid color-mix(in srgb, #7c3aed 22%, transparent)',
+    borderBottom: '1px solid color-mix(in srgb, #7c3aed 14%, transparent)',
+  },
+  glassRoutineBanner: {
+    backgroundColor: 'color-mix(in srgb, #7c3aed 14%, transparent)',
+    borderTop: '1px solid color-mix(in srgb, #c4b5fd 28%, transparent)',
+    borderBottom: '1px solid color-mix(in srgb, #c4b5fd 18%, transparent)',
+  },
+  routinePill: {
+    alignItems: 'center',
+    backgroundColor: 'color-mix(in srgb, #7c3aed 18%, transparent)',
+    border: '1px solid color-mix(in srgb, #7c3aed 38%, transparent)',
+    borderRadius: tokens.borderRadiusCircular,
+    color: '#6d28d9',
+    display: 'inline-flex',
+    flexShrink: 0,
+    fontSize: tokens.fontSizeBase100,
+    fontWeight: tokens.fontWeightSemibold,
+    gap: '4px',
+    padding: '1px 8px',
+  },
+  routineTitle: {
+    color: tokens.colorNeutralForeground2,
+    flex: '1 1 160px',
+    fontSize: tokens.fontSizeBase200,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  routineSchedule: {
+    color: tokens.colorNeutralForeground3,
+    flexShrink: 0,
+    fontSize: tokens.fontSizeBase100,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
   ticketTitle: {
     flex: '1 1 100%',
@@ -938,6 +988,8 @@ const startedLabel = (tab: CodeTab): string | null => {
   return `Started ${started.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}, ${started.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`;
 };
 
+const shortRoutineSchedule = (schedule: string): string => schedule.replace(/ · next .+$/, '');
+
 /**
  * Glanceable "now doing X" under a column header: sandbox boot phase while
  * launching, then the live run state (tool line / waiting-for-approval)
@@ -1142,6 +1194,8 @@ const CodeSessionHeader = memo(
     subLabel,
     statusTabId,
     ticketTitle,
+    routineName,
+    routineSchedule,
     ticketColumnBadge,
     ticketMetaBadge,
     ticketActions,
@@ -1160,6 +1214,8 @@ const CodeSessionHeader = memo(
     /** When set, a live ColumnStatusLine for this tab renders under the header. */
     statusTabId?: CodeTabId;
     ticketTitle?: string | null;
+    routineName?: string | null;
+    routineSchedule?: string | null;
     ticketColumnBadge?: React.ReactNode;
     ticketMetaBadge?: React.ReactNode;
     ticketActions?: React.ReactNode;
@@ -1255,6 +1311,22 @@ const CodeSessionHeader = memo(
             {ticketActions && <div className={styles.ticketActions}>{ticketActions}</div>}
           </div>
         )}
+        {!ticketTitle && routineName && (
+          <div className={mergeClasses(styles.routineBanner, isGlass && styles.glassRoutineBanner)}>
+            <span className={styles.routinePill}>
+              <ArrowSync20Regular style={{ width: 12, height: 12 }} />
+              Routine
+            </span>
+            <span className={styles.routineTitle} title={routineName}>
+              {routineName}
+            </span>
+            {routineSchedule && (
+              <span className={styles.routineSchedule} title={routineSchedule}>
+                {shortRoutineSchedule(routineSchedule)}
+              </span>
+            )}
+          </div>
+        )}
         {statusTabId && <ColumnStatusLine tabId={statusTabId} />}
       </>
     );
@@ -1267,6 +1339,8 @@ const DeckColumn = memo(
     tab,
     label,
     ticketTitle,
+    routineName,
+    routineSchedule,
     ticketColumnBadge,
     ticketMetaBadge,
     ticketActions,
@@ -1282,6 +1356,8 @@ const DeckColumn = memo(
     tab: CodeTab;
     label: string;
     ticketTitle?: string | null;
+    routineName?: string | null;
+    routineSchedule?: string | null;
     ticketColumnBadge?: React.ReactNode;
     ticketMetaBadge?: React.ReactNode;
     ticketActions?: React.ReactNode;
@@ -1332,9 +1408,11 @@ const DeckColumn = memo(
           <ColumnAura tabId={tab.id} />
           <CodeSessionHeader
             label={label}
-            subLabel={ticketTitle ? null : startedLabel(tab)}
+            subLabel={ticketTitle || routineName ? null : startedLabel(tab)}
             statusTabId={tab.id}
             ticketTitle={ticketTitle}
+            routineName={routineName}
+            routineSchedule={routineSchedule}
             ticketColumnBadge={ticketColumnBadge}
             ticketMetaBadge={ticketMetaBadge}
             ticketActions={ticketActions}
@@ -1962,6 +2040,8 @@ const CodeSessionPane = memo(
     tab,
     label,
     ticketTitle,
+    routineName,
+    routineSchedule,
     ticketColumnBadge,
     ticketMetaBadge,
     ticketActions,
@@ -1974,6 +2054,8 @@ const CodeSessionPane = memo(
     tab: CodeTab;
     label: string;
     ticketTitle?: string | null;
+    routineName?: string | null;
+    routineSchedule?: string | null;
     ticketColumnBadge?: React.ReactNode;
     ticketMetaBadge?: React.ReactNode;
     ticketActions?: React.ReactNode;
@@ -2007,9 +2089,11 @@ const CodeSessionPane = memo(
         <ColumnAura tabId={tab.id} />
         <CodeSessionHeader
           label={label}
-          subLabel={ticketTitle ? null : startedLabel(tab)}
+          subLabel={ticketTitle || routineName ? null : startedLabel(tab)}
           statusTabId={tab.id}
           ticketTitle={ticketTitle}
+          routineName={routineName}
+          routineSchedule={routineSchedule}
           ticketColumnBadge={ticketColumnBadge}
           ticketMetaBadge={ticketMetaBadge}
           ticketActions={ticketActions}
@@ -2423,6 +2507,8 @@ export const CodeDeck = memo(() => {
   );
 
   const resolveTicketTitle = useCallback((tab: CodeTab) => tab.ticketTitle ?? null, []);
+  const resolveRoutineName = useCallback((tab: CodeTab) => tab.routineName ?? null, []);
+  const resolveRoutineSchedule = useCallback((tab: CodeTab) => tab.routineSchedule ?? null, []);
 
   const handleLayoutMode = useCallback((mode: CodeLayoutMode) => {
     codeApi.setLayoutMode(mode);
@@ -2761,6 +2847,8 @@ export const CodeDeck = memo(() => {
                               tab={tab}
                               label={resolveLabel(tab)}
                               ticketTitle={resolveTicketTitle(tab)}
+                              routineName={resolveRoutineName(tab)}
+                              routineSchedule={resolveRoutineSchedule(tab)}
                               ticketColumnBadge={renderTicketColumnBadge(tab)}
                               ticketMetaBadge={renderTicketMetaBadge(tab)}
                               ticketActions={renderTicketBannerActions(tab)}
@@ -2831,7 +2919,7 @@ export const CodeDeck = memo(() => {
                         key={tab.id}
                         tab={tab}
                         label={resolveLabel(tab)}
-                        subLabel={resolveTicketTitle(tab)}
+                        subLabel={resolveTicketTitle(tab) ?? resolveRoutineName(tab)}
                         isActive={tab.id === activeTab?.id}
                         onSelect={handleSelect}
                         onClose={handleClose}
@@ -2916,6 +3004,8 @@ export const CodeDeck = memo(() => {
                         tab={tab}
                         label={resolveLabel(tab)}
                         ticketTitle={resolveTicketTitle(tab)}
+                        routineName={resolveRoutineName(tab)}
+                        routineSchedule={resolveRoutineSchedule(tab)}
                         ticketColumnBadge={renderTicketColumnBadge(tab)}
                         ticketMetaBadge={renderTicketMetaBadge(tab)}
                         ticketActions={renderTicketBannerActions(tab)}

--- a/src/renderer/features/ScheduledTasks/ScheduledTasks.tsx
+++ b/src/renderer/features/ScheduledTasks/ScheduledTasks.tsx
@@ -393,7 +393,10 @@ export const ScheduledTasks = memo(() => {
             {sorted.map((task) => (
               <button
                 key={task.id}
-                className={mergeClasses(styles.listItem, !creating && selectedTask?.id === task.id && styles.selectedListItem)}
+                className={mergeClasses(
+                  styles.listItem,
+                  !creating && selectedTask?.id === task.id && styles.selectedListItem
+                )}
                 type="button"
                 onClick={() => {
                   cancelEdit();
@@ -541,7 +544,11 @@ const RoutineDetail = ({
           {task.profileName ? getProfileMenuLabel(task.profileName, machines) : 'Default sandbox'}
         </div>
       </div>
-      <Switch checked={task.enabled} label={task.enabled ? 'Active' : 'Paused'} onChange={(_, data) => void onToggle(task, data.checked)} />
+      <Switch
+        checked={task.enabled}
+        label={task.enabled ? 'Active' : 'Paused'}
+        onChange={(_, data) => void onToggle(task, data.checked)}
+      />
     </div>
     <div className={styles.row}>
       <Button size="small" onClick={() => void onRunNow(task)} disabled={busy}>
@@ -574,7 +581,13 @@ const RoutineDetail = ({
       </div>
     ) : null}
     <AllowedToolsPanel styles={styles} task={task} onRevokeTool={onRevokeTool} onRevokeMcpTool={onRevokeMcpTool} />
-    <RunHistory styles={styles} task={task} onOpenSession={onOpenSession} onAllowTool={onAllowTool} onAllowMcpTool={onAllowMcpTool} />
+    <RunHistory
+      styles={styles}
+      task={task}
+      onOpenSession={onOpenSession}
+      onAllowTool={onAllowTool}
+      onAllowMcpTool={onAllowMcpTool}
+    />
   </div>
 );
 
@@ -1021,7 +1034,7 @@ async function resolveRoutineWorkspaceDir(
       return source.workspaceDir;
     }
     if (store.workspaceDir && project) {
-      return `${store.workspaceDir.replace(/[\/]+$/, '')}/Projects/${project.slug}`;
+      return `${store.workspaceDir.replace(/[/\\]+$/, '')}/Projects/${project.slug}`;
     }
     return undefined;
   }

--- a/src/renderer/features/ScheduledTasks/ScheduledTasks.tsx
+++ b/src/renderer/features/ScheduledTasks/ScheduledTasks.tsx
@@ -30,6 +30,7 @@ import type {
   ScheduledTaskRun,
   ScheduledTaskSchedule,
 } from '@/shared/types';
+import { firstSource } from '@/shared/types';
 
 const useStyles = makeStyles({
   root: {
@@ -58,7 +59,7 @@ const useStyles = makeStyles({
   },
   grid: {
     display: 'grid',
-    gridTemplateColumns: 'minmax(280px, 420px) minmax(320px, 1fr)',
+    gridTemplateColumns: 'minmax(260px, 360px) minmax(420px, 1fr)',
     gap: '20px',
     '@media (max-width: 900px)': {
       gridTemplateColumns: '1fr',
@@ -71,6 +72,38 @@ const useStyles = makeStyles({
   cards: {
     display: 'grid',
     gap: '12px',
+  },
+  listCard: {
+    padding: '12px',
+  },
+  listHeader: {
+    alignItems: 'center',
+    display: 'flex',
+    justifyContent: 'space-between',
+    marginBottom: '10px',
+  },
+  listItem: {
+    alignItems: 'flex-start',
+    backgroundColor: tokens.colorNeutralBackground1,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+    color: tokens.colorNeutralForeground1,
+    cursor: 'pointer',
+    display: 'grid',
+    gap: '4px',
+    padding: '12px',
+    textAlign: 'left',
+    width: '100%',
+    ':hover': {
+      backgroundColor: tokens.colorNeutralBackground1Hover,
+    },
+  },
+  selectedListItem: {
+    backgroundColor: tokens.colorBrandBackground2,
+    border: `1px solid ${tokens.colorBrandStroke1}`,
+  },
+  detailCard: {
+    padding: '18px',
   },
   taskCard: {
     padding: '16px',
@@ -135,6 +168,13 @@ const useStyles = makeStyles({
     display: 'flex',
     gap: '8px',
     justifyContent: 'space-between',
+  },
+  section: {
+    borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+    display: 'grid',
+    gap: '12px',
+    marginTop: '16px',
+    paddingTop: '14px',
   },
   runItem: {
     border: `1px solid ${tokens.colorNeutralStroke2}`,
@@ -210,6 +250,8 @@ export const ScheduledTasks = memo(() => {
   const machines = useStore($machines);
   const [isEnterprise, setIsEnterprise] = useState(false);
   const [createForm, setCreateForm] = useState<RoutineFormState>(() => createEmptyFormState(store.defaultProfileName));
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(true);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<RoutineFormState | null>(null);
   const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
@@ -231,6 +273,17 @@ export const ScheduledTasks = memo(() => {
       ),
     [store.scheduledTasks]
   );
+  const selectedTask = useMemo(
+    () => sorted.find((task) => task.id === selectedTaskId) ?? sorted[0] ?? null,
+    [selectedTaskId, sorted]
+  );
+
+  useEffect(() => {
+    if (creating || selectedTaskId || !selectedTask) {
+      return;
+    }
+    setSelectedTaskId(selectedTask.id);
+  }, [creating, selectedTask, selectedTaskId]);
 
   const createTask = async () => {
     setError(null);
@@ -241,6 +294,7 @@ export const ScheduledTasks = memo(() => {
         projectId: current.projectId,
         profileName: current.profileName,
       }));
+      setCreating(false);
     } catch (err) {
       setError((err as Error).message);
     }
@@ -248,6 +302,8 @@ export const ScheduledTasks = memo(() => {
 
   const startEdit = (task: ScheduledTask) => {
     setEditError(null);
+    setCreating(false);
+    setSelectedTaskId(task.id);
     setEditingTaskId(task.id);
     setEditForm(toFormState(task, store.defaultProfileName));
   };
@@ -287,32 +343,7 @@ export const ScheduledTasks = memo(() => {
     if (!run.sessionId) {
       return;
     }
-    const tabs = persistedStoreApi.getKey('codeTabs') ?? [];
-    const existing = tabs.find((tab) => tab.sessionId === run.sessionId);
-    if (existing) {
-      await persistedStoreApi.setKey('activeCodeTabId', existing.id);
-      await persistedStoreApi.setKey('layoutMode', 'spaces');
-      return;
-    }
-    let workspaceDir: string | undefined;
-    if (task.projectId) {
-      workspaceDir = store.workspaceDir;
-    } else if (store.workspaceDir) {
-      try {
-        workspaceDir = await emitter.invoke('util:session-workspace-dir', store.workspaceDir, run.sessionId);
-      } catch {}
-    }
-    const tab: CodeTab = {
-      id: `routine-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      projectId: task.projectId ?? null,
-      sessionId: run.sessionId,
-      profileName: task.profileName ?? store.defaultProfileName ?? 'host',
-      profileNameExplicit: Boolean(task.profileName),
-      createdAt: Date.now(),
-      ...(workspaceDir ? { workspaceDir } : {}),
-    };
-    await persistedStoreApi.setKey('codeTabs', [...tabs, tab]);
-    await persistedStoreApi.setKey('activeCodeTabId', tab.id);
+    await ensureRoutineSessionTab(task, run.sessionId, store, true);
     await persistedStoreApi.setKey('layoutMode', 'spaces');
   };
 
@@ -343,94 +374,209 @@ export const ScheduledTasks = memo(() => {
         </div>
       </div>
       <div className={styles.grid}>
-        <Card>
-          <RoutineForm
-            styles={styles}
-            value={createForm}
-            projects={store.projects}
-            sandboxContext={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
-            machines={machines}
-            submitLabel="Create routine"
-            error={error}
-            onChange={setCreateForm}
-            onSubmit={() => void createTask()}
-          />
+        <Card className={styles.listCard}>
+          <div className={styles.listHeader}>
+            <div className={styles.runHeading}>Routine index</div>
+            <Button
+              size="small"
+              appearance={creating ? 'primary' : 'secondary'}
+              onClick={() => {
+                cancelEdit();
+                setCreating(true);
+              }}
+            >
+              New
+            </Button>
+          </div>
+          <div className={styles.cards}>
+            {sorted.length === 0 ? <div className={styles.empty}>No routines yet.</div> : null}
+            {sorted.map((task) => (
+              <button
+                key={task.id}
+                className={mergeClasses(styles.listItem, !creating && selectedTask?.id === task.id && styles.selectedListItem)}
+                type="button"
+                onClick={() => {
+                  cancelEdit();
+                  setCreating(false);
+                  setSelectedTaskId(task.id);
+                }}
+              >
+                <span className={styles.taskName}>{task.name}</span>
+                <span className={styles.muted}>{formatSchedule(task)}</span>
+                <span className={styles.muted}>{formatProject(task, store.projects)}</span>
+                <span className={styles.muted}>{task.history[0] ? lastRunLabel(task.history[0]) : 'Never run'}</span>
+              </button>
+            ))}
+          </div>
         </Card>
-        <div className={styles.cards}>
-          {sorted.length === 0 ? <Card className={styles.empty}>No routines yet.</Card> : null}
-          {sorted.map((task) => {
-            const isEditing = editingTaskId === task.id && editForm;
-            return (
-              <Card key={task.id} className={styles.taskCard}>
-                <div className={styles.taskTop}>
-                  <div>
-                    <div className={styles.taskName}>{task.name}</div>
-                    <div className={styles.muted}>{formatSchedule(task)}</div>
-                    <div className={styles.muted}>{formatProject(task, store.projects)}</div>
-                    <div className={styles.muted}>
-                      {task.profileName ? getProfileMenuLabel(task.profileName, machines) : 'Default sandbox'}
-                    </div>
-                  </div>
-                  <Switch
-                    checked={task.enabled}
-                    label={task.enabled ? 'Active' : 'Paused'}
-                    onChange={(_, data) => void scheduledTaskApi.update(task.id, { enabled: data.checked })}
-                  />
-                </div>
-                <div className={styles.row}>
-                  <Button size="small" onClick={() => void runNow(task)} disabled={busyTaskId === task.id}>
-                    Run now
-                  </Button>
-                  <Button size="small" appearance="secondary" onClick={() => startEdit(task)}>
-                    Edit
-                  </Button>
-                  <Button size="small" appearance="secondary" onClick={() => void scheduledTaskApi.delete(task.id)}>
-                    Delete
-                  </Button>
-                  <span className={styles.muted}>{task.history[0] ? lastRunLabel(task.history[0]) : 'Never run'}</span>
-                </div>
-                {isEditing ? (
-                  <div className={styles.runHistory} aria-label={`Edit ${task.name}`}>
-                    <div className={styles.runHeading}>Edit routine</div>
-                    <RoutineForm
-                      styles={styles}
-                      value={editForm}
-                      projects={store.projects}
-                      sandboxContext={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
-                      machines={machines}
-                      submitLabel="Save changes"
-                      error={editError}
-                      showEnabled
-                      busy={savingTaskId === task.id}
-                      onChange={setEditForm}
-                      onSubmit={() => void saveEdit(task)}
-                      onCancel={cancelEdit}
-                    />
-                  </div>
-                ) : null}
-                <AllowedToolsPanel
-                  styles={styles}
-                  task={task}
-                  onRevokeTool={revokeTool}
-                  onRevokeMcpTool={revokeMcpTool}
-                />
-                <RunHistory
-                  styles={styles}
-                  task={task}
-                  onOpenSession={openSession}
-                  onAllowTool={allowTool}
-                  onAllowMcpTool={allowMcpTool}
-                />
-              </Card>
-            );
-          })}
-        </div>
+        <Card className={styles.detailCard}>
+          {creating ? (
+            <>
+              <div className={styles.runHeading}>Create routine</div>
+              <RoutineForm
+                styles={styles}
+                value={createForm}
+                projects={store.projects}
+                sandboxContext={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
+                machines={machines}
+                submitLabel="Create routine"
+                error={error}
+                onChange={setCreateForm}
+                onSubmit={() => void createTask()}
+              />
+            </>
+          ) : selectedTask ? (
+            <RoutineDetail
+              styles={styles}
+              task={selectedTask}
+              projects={store.projects}
+              machines={machines}
+              isEditing={editingTaskId === selectedTask.id && Boolean(editForm)}
+              editForm={editForm}
+              editError={editError}
+              saving={savingTaskId === selectedTask.id}
+              busy={busyTaskId === selectedTask.id}
+              sandboxContext={{ isEnterprise, available: store.availableSandboxProfiles, machines }}
+              onRunNow={runNow}
+              onStartEdit={startEdit}
+              onDelete={async (task) => {
+                await scheduledTaskApi.delete(task.id);
+                setSelectedTaskId(null);
+                setCreating(sorted.length <= 1);
+              }}
+              onToggle={(task, enabled) => scheduledTaskApi.update(task.id, { enabled })}
+              onEditChange={setEditForm}
+              onSaveEdit={saveEdit}
+              onCancelEdit={cancelEdit}
+              onOpenSession={openSession}
+              onAllowTool={allowTool}
+              onAllowMcpTool={allowMcpTool}
+              onRevokeTool={revokeTool}
+              onRevokeMcpTool={revokeMcpTool}
+            />
+          ) : (
+            <div className={styles.empty}>Select or create a routine.</div>
+          )}
+        </Card>
       </div>
     </div>
   );
 });
 
 ScheduledTasks.displayName = 'ScheduledTasks';
+
+export const RoutineSessionWatcher = memo(() => {
+  const store = useStore(persistedStoreApi.$atom);
+
+  useEffect(() => {
+    for (const task of store.scheduledTasks ?? []) {
+      if (!task.runningSessionId) {
+        continue;
+      }
+      void ensureRoutineSessionTab(task, task.runningSessionId, store);
+    }
+  }, [store]);
+
+  return null;
+});
+
+RoutineSessionWatcher.displayName = 'RoutineSessionWatcher';
+
+type RoutineDetailProps = {
+  styles: ReturnType<typeof useStyles>;
+  task: ScheduledTask;
+  projects: Project[];
+  machines: Parameters<typeof getProfileMenuLabel>[1];
+  sandboxContext: ComponentProps<typeof SandboxPicker>['context'];
+  isEditing: boolean;
+  editForm: RoutineFormState | null;
+  editError: string | null;
+  saving: boolean;
+  busy: boolean;
+  onRunNow: (task: ScheduledTask) => Promise<void>;
+  onStartEdit: (task: ScheduledTask) => void;
+  onDelete: (task: ScheduledTask) => Promise<void>;
+  onToggle: (task: ScheduledTask, enabled: boolean) => Promise<ScheduledTask>;
+  onEditChange: (value: RoutineFormState) => void;
+  onSaveEdit: (task: ScheduledTask) => Promise<void>;
+  onCancelEdit: () => void;
+  onOpenSession: (task: ScheduledTask, run: ScheduledTaskRun) => Promise<void>;
+  onAllowTool: (task: ScheduledTask, toolName: string) => Promise<void>;
+  onAllowMcpTool: (task: ScheduledTask, tool: ScheduledTaskAllowedMcpTool) => Promise<void>;
+  onRevokeTool: (task: ScheduledTask, toolName: string) => Promise<void>;
+  onRevokeMcpTool: (task: ScheduledTask, tool: ScheduledTaskAllowedMcpTool) => Promise<void>;
+};
+
+const RoutineDetail = ({
+  styles,
+  task,
+  projects,
+  machines,
+  sandboxContext,
+  isEditing,
+  editForm,
+  editError,
+  saving,
+  busy,
+  onRunNow,
+  onStartEdit,
+  onDelete,
+  onToggle,
+  onEditChange,
+  onSaveEdit,
+  onCancelEdit,
+  onOpenSession,
+  onAllowTool,
+  onAllowMcpTool,
+  onRevokeTool,
+  onRevokeMcpTool,
+}: RoutineDetailProps) => (
+  <div>
+    <div className={styles.taskTop}>
+      <div>
+        <div className={styles.taskName}>{task.name}</div>
+        <div className={styles.muted}>{formatSchedule(task)}</div>
+        <div className={styles.muted}>{formatProject(task, projects)}</div>
+        <div className={styles.muted}>
+          {task.profileName ? getProfileMenuLabel(task.profileName, machines) : 'Default sandbox'}
+        </div>
+      </div>
+      <Switch checked={task.enabled} label={task.enabled ? 'Active' : 'Paused'} onChange={(_, data) => void onToggle(task, data.checked)} />
+    </div>
+    <div className={styles.row}>
+      <Button size="small" onClick={() => void onRunNow(task)} disabled={busy}>
+        Run now
+      </Button>
+      <Button size="small" appearance="secondary" onClick={() => onStartEdit(task)}>
+        Edit
+      </Button>
+      <Button size="small" appearance="secondary" onClick={() => void onDelete(task)}>
+        Delete
+      </Button>
+    </div>
+    {isEditing && editForm ? (
+      <div className={styles.section} aria-label={`Edit ${task.name}`}>
+        <div className={styles.runHeading}>Edit routine</div>
+        <RoutineForm
+          styles={styles}
+          value={editForm}
+          projects={projects}
+          sandboxContext={sandboxContext}
+          machines={machines}
+          submitLabel="Save changes"
+          error={editError}
+          showEnabled
+          busy={saving}
+          onChange={onEditChange}
+          onSubmit={() => void onSaveEdit(task)}
+          onCancel={onCancelEdit}
+        />
+      </div>
+    ) : null}
+    <AllowedToolsPanel styles={styles} task={task} onRevokeTool={onRevokeTool} onRevokeMcpTool={onRevokeMcpTool} />
+    <RunHistory styles={styles} task={task} onOpenSession={onOpenSession} onAllowTool={onAllowTool} onAllowMcpTool={onAllowMcpTool} />
+  </div>
+);
 
 type RoutineFormProps = {
   styles: ReturnType<typeof useStyles>;
@@ -811,6 +957,82 @@ function formatProject(task: ScheduledTask, projects: Project[]): string {
     return 'No project';
   }
   return projects.find((project) => project.id === task.projectId)?.label ?? 'Unknown project';
+}
+
+async function ensureRoutineSessionTab(
+  task: ScheduledTask,
+  sessionId: string,
+  store: ReturnType<typeof persistedStoreApi.get>,
+  activate = false
+): Promise<CodeTab> {
+  const tabs = persistedStoreApi.getKey('codeTabs') ?? [];
+  const existing = tabs.find((tab) => tab.sessionId === sessionId);
+  if (existing) {
+    const nextExisting = {
+      ...existing,
+      routineId: task.id,
+      routineName: task.name,
+      routineSchedule: formatSchedule(task),
+    };
+    if (
+      existing.routineId !== nextExisting.routineId ||
+      existing.routineName !== nextExisting.routineName ||
+      existing.routineSchedule !== nextExisting.routineSchedule
+    ) {
+      await persistedStoreApi.setKey(
+        'codeTabs',
+        tabs.map((tab) => (tab.id === existing.id ? nextExisting : tab))
+      );
+    }
+    if (activate) {
+      await persistedStoreApi.setKey('activeCodeTabId', existing.id);
+    }
+    return nextExisting;
+  }
+  const workspaceDir = await resolveRoutineWorkspaceDir(task, sessionId, store);
+  const tab: CodeTab = {
+    id: `routine-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    projectId: task.projectId ?? null,
+    sessionId,
+    routineId: task.id,
+    routineName: task.name,
+    routineSchedule: formatSchedule(task),
+    profileName: task.profileName ?? store.defaultProfileName ?? 'host',
+    profileNameExplicit: Boolean(task.profileName),
+    createdAt: Date.now(),
+    ...(workspaceDir ? { workspaceDir } : {}),
+  };
+  await persistedStoreApi.setKey('codeTabs', [...tabs, tab]);
+  if (activate) {
+    await persistedStoreApi.setKey('activeCodeTabId', tab.id);
+  }
+  return tab;
+}
+
+async function resolveRoutineWorkspaceDir(
+  task: ScheduledTask,
+  sessionId: string,
+  store: ReturnType<typeof persistedStoreApi.get>
+): Promise<string | undefined> {
+  if (task.projectId) {
+    const project = store.projects.find((item) => item.id === task.projectId);
+    const source = firstSource(project);
+    if (source?.kind === 'local') {
+      return source.workspaceDir;
+    }
+    if (store.workspaceDir && project) {
+      return `${store.workspaceDir.replace(/[\/]+$/, '')}/Projects/${project.slug}`;
+    }
+    return undefined;
+  }
+  if (!store.workspaceDir) {
+    return undefined;
+  }
+  try {
+    return await emitter.invoke('util:session-workspace-dir', store.workspaceDir, sessionId);
+  } catch {
+    return undefined;
+  }
 }
 
 function lastRunLabel(run: ScheduledTask['history'][number]): string {

--- a/src/server/managers.ts
+++ b/src/server/managers.ts
@@ -570,6 +570,7 @@ export const wireGlobalHandlers = async (arg: {
     const scheduledTaskManager = new ScheduledTaskManager({
       store: settings as any,
       processManager,
+      getProjects: () => getStoreSnapshot(teamId, principalId).projects,
       sendToWindow: (channel, ...args) => {
         if (channel === 'store:changed') {
           tenantSend('store:changed', getStoreSnapshot(teamId, principalId));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -693,6 +693,9 @@ export const schema: Schema<StoreData> = {
         ticketId: { type: 'string' },
         sessionId: { type: 'string' },
         ticketTitle: { type: 'string' },
+        routineId: { type: 'string' },
+        routineName: { type: 'string' },
+        routineSchedule: { type: 'string' },
         workspaceDir: { type: 'string' },
         profileName: { type: 'string' },
         containerId: { type: 'string' },
@@ -1316,6 +1319,9 @@ export type CodeTab = {
   ticketId?: TicketId;
   sessionId?: string;
   ticketTitle?: string;
+  routineId?: string;
+  routineName?: string;
+  routineSchedule?: string;
   workspaceDir?: string;
   /** When set, this tab renders as a global app column (webview) instead of an agent session. */
   customAppId?: string;

--- a/tests/e2e/specs/routines.spec.ts
+++ b/tests/e2e/specs/routines.spec.ts
@@ -8,6 +8,8 @@ test.describe('routines', () => {
     await openRoutines(app.page);
 
     await test.step('create routine', async () => {
+      await expect(app.page.getByText('Routine index')).toBeVisible();
+      await expect(app.page.getByText('Create routine').first()).toBeVisible();
       await app.page.getByRole('textbox', { name: 'Name' }).fill('E2E morning review');
       await app.page.getByRole('textbox', { name: 'Instructions' }).fill('Summarize the workspace status.');
       await expect(app.page.getByRole('combobox', { name: 'Project' })).toBeVisible();
@@ -20,8 +22,8 @@ test.describe('routines', () => {
       await app.page.getByRole('combobox', { name: 'Project' }).selectOption({ label: 'Seeded Project' });
       await expect(app.page.getByRole('button', { name: /This computer/ })).toBeVisible();
       await app.page.getByRole('button', { name: 'Create routine' }).click();
-      await expect(app.page.getByText('E2E morning review')).toBeVisible();
-      await expect(app.page.getByText(/Daily at 09:00/)).toBeVisible();
+      await expect(app.page.getByText('E2E morning review').first()).toBeVisible();
+      await expect(app.page.getByText(/Daily at 09:00/).first()).toBeVisible();
       await expect(app.page.getByLabel('E2E morning review always allowed function tools')).toBeVisible();
       await expect(app.page.getByText('Always allowed function tools')).toBeVisible();
       await expect(app.page.getByText('No function tools are always allowed for this routine.')).toBeVisible();
@@ -52,17 +54,16 @@ test.describe('routines', () => {
       await editPanel.getByLabel('Time').fill('10:30');
       await editPanel.getByRole('combobox', { name: 'Day' }).selectOption('2');
       await editPanel.getByRole('button', { name: 'Save changes' }).click();
-      await expect(app.page.getByText('E2E edited review')).toBeVisible();
-      await expect(app.page.getByText(/Weekly on Tuesday at 10:30/)).toBeVisible();
+      await expect(app.page.getByText('E2E edited review').first()).toBeVisible();
+      await expect(app.page.getByText(/Weekly on Tuesday at 10:30/).first()).toBeVisible();
       await expect(editPanel).toHaveCount(0);
     });
 
     await test.step('pause and resume routine', async () => {
-      const routineCard = app.page.getByRole('group').filter({ hasText: 'E2E edited review' });
-      await routineCard.getByRole('switch', { name: 'Active' }).click();
-      await expect(routineCard.getByRole('switch', { name: 'Paused' })).toBeVisible();
-      await routineCard.getByRole('switch', { name: 'Paused' }).click();
-      await expect(routineCard.getByRole('switch', { name: 'Active' })).toBeVisible();
+      await app.page.getByRole('switch', { name: 'Active' }).click();
+      await expect(app.page.getByRole('switch', { name: 'Paused' })).toBeVisible();
+      await app.page.getByRole('switch', { name: 'Paused' }).click();
+      await expect(app.page.getByRole('switch', { name: 'Active' })).toBeVisible();
     });
 
     await test.step('run manually records launch attempt', async () => {
@@ -79,6 +80,9 @@ test.describe('routines', () => {
     await test.step('open run session for review', async () => {
       await app.page.getByRole('button', { name: 'Open session' }).click();
       await expect(app.page.getByRole('tab', { name: 'Spaces' })).toHaveAttribute('aria-selected', 'true');
+      await expect(app.page.getByText('Routine', { exact: true })).toBeVisible();
+      await expect(app.page.getByText('E2E edited review').first()).toBeVisible();
+      await expect(app.page.getByText('Weekly on Tuesday at 10:30').first()).toBeVisible();
       await openRoutines(app.page);
     });
 


### PR DESCRIPTION
## Summary
- Refactor the Routines page into an index/detail workflow with cleaner create/edit/run controls.
- Resolve Routine workspaces consistently: project routines use project sources, projectless routines use per-session scratch dirs.
- Surface running Routine sessions as visible Code deck columns with Routine metadata and a distinct Routine banner.
- Add coverage for Routine workspace resolution and update Routine E2E proof coverage for the new UI and column banner.

## Validation
- `npm run lint:tsc`
- `npx vitest run src/main/scheduled-task-manager.test.ts src/lib/scheduled-task-schedule.test.ts`
- `npm run build:server`
- `npx playwright test tests/e2e/specs/routines.spec.ts --project=server-local`
- `VISUAL_PROOF=1 npx playwright test tests/e2e/specs/routines.spec.ts --project=server-local`

## Visual Proof
- Report: `artifacts/playwright-proof-report/index.html`
- Screenshot: `artifacts/playwright-proof-results/routines-routines-creates--0adfa-es-a-desktop-scheduled-task-server-local/test-finished-1.png`
- Video: `artifacts/playwright-proof-results/routines-routines-creates--0adfa-es-a-desktop-scheduled-task-server-local/attachments/server-local-video-1-b331f5dc40b5d5ee0c103e812e5f09af04e5b0bd.webm`
