### PR TITLE
Fix projectless Routine session launch

### DIFF
--- a/src/renderer/features/Code/CodeTabContent.tsx
+++ b/src/renderer/features/Code/CodeTabContent.tsx
@@ -292,6 +292,7 @@ export const CodeTabContent = memo(
     // Reserved chat record (CHAT_TAB_ID): projectless full-screen surface with
     // a per-conversation scratch workspace instead of a project workspace.
     const chatMode = isChatTab(tab);
+    const routineMode = Boolean(tab.routineId);
     const project = useMemo(
       () => store.projects.find((p) => p.id === tab.projectId) ?? null,
       [store.projects, tab.projectId]
@@ -513,8 +514,9 @@ export const CodeTabContent = memo(
       [baseSessionArgs, localVoice, personaInstructions]
     );
 
-    // No project selected — show project picker (chat is projectless by design)
-    if (!chatMode && !tab.projectId) {
+    // No project selected — show project picker. Chat and Routines can be
+    // projectless when they already carry a session workspace.
+    if (!chatMode && !routineMode && !tab.projectId) {
       return (
         <div className={mergeClasses(styles.fullSize, !isVisible && styles.hidden)}>
           <CodeEmptyState tabId={tab.id} embedded />
@@ -587,10 +589,10 @@ export const CodeTabContent = memo(
           <CodeErrorView tabId={tab.id} retry={retry} />
         ) : (
           /* idle / checking / installing / ready / starting / connecting —
-             at this point we already have tab.projectId (we passed the
-             early return above), so auto-launch will drive the machine to
-             ``running`` shortly. The in-composer sandbox picker handles
-             profile changes; no pre-launch picker needed here. */
+             at this point we already have a project or Routine session
+             workspace (we passed the early return above), so auto-launch will
+             drive the machine to ``running`` shortly. The in-composer sandbox
+             picker handles profile changes; no pre-launch picker needed here. */
           <div className={styles.flexCenter}>
             <motion.div
               className={styles.spinnerPill}

--- a/tests/e2e/specs/routines.spec.ts
+++ b/tests/e2e/specs/routines.spec.ts
@@ -83,6 +83,7 @@ test.describe('routines', () => {
       await expect(app.page.getByText('Routine', { exact: true })).toBeVisible();
       await expect(app.page.getByText('E2E edited review').first()).toBeVisible();
       await expect(app.page.getByText('Weekly on Tuesday at 10:30').first()).toBeVisible();
+      await expect(app.page.getByText('Select a project')).toHaveCount(0);
       await openRoutines(app.page);
     });
 


### PR DESCRIPTION
## Summary
- Fix projectless Routine Code tabs so they bypass the blank project-selection screen and launch from their session workspace.
- Add E2E coverage that fails if a Routine run opens Spaces and shows the project picker instead of the Routine session.

## Validation
- `npm run lint`
- `npx vitest run src/main/scheduled-task-manager.test.ts src/lib/scheduled-task-schedule.test.ts`
- `npm run build:server`
- `npx playwright test tests/e2e/specs/routines.spec.ts --project=server-local`
