### PR TITLE
Expose OpenAI API mode in settings

### DIFF
--- a/src/renderer/features/SettingsModal/SettingsModalAiTab.tsx
+++ b/src/renderer/features/SettingsModal/SettingsModalAiTab.tsx
@@ -335,17 +335,18 @@ export const SettingsModalAiTab = memo(() => {
   );
 
   const updateProvider = useCallback(
-    (name: string, field: string, value: string) => {
+    (name: string, field: string, value: string | boolean | undefined) => {
       updateConfig((c) => {
         const prov = c.providers[name];
         if (!prov) {
           return c;
         }
+        const nextValue = value === '' ? undefined : value;
         return {
           ...c,
           providers: {
             ...c.providers,
-            [name]: { ...prov, [field]: value || undefined },
+            [name]: { ...prov, [field]: nextValue },
           },
         };
       });
@@ -713,7 +714,7 @@ const ProviderRow = memo(
     editingModel: { provider: string; modelId: string } | null;
     newModelId: string;
     onRemove: (name: string) => void;
-    onUpdateProvider: (name: string, field: string, value: string) => void;
+    onUpdateProvider: (name: string, field: string, value: string | boolean | undefined) => void;
     onAddModel: (providerName: string) => void;
     onRemoveModel: (providerName: string, modelId: string) => void;
     onUpdateModel: (providerName: string, modelId: string, field: string, value: unknown) => void;
@@ -730,6 +731,8 @@ const ProviderRow = memo(
     const showBaseUrl =
       provider.type === 'azure' || provider.type === 'openai-compatible' || provider.type === 'litellm';
     const showApiVersion = provider.type === 'azure';
+    const showApiMode =
+      provider.type === 'openai' || provider.type === 'openai-compatible' || provider.type === 'azure';
     // OAuth providers authenticate via the ChatGPT sign-in above, not a key.
     const showApiKey = !isOauth;
 
@@ -751,6 +754,12 @@ const ProviderRow = memo(
     );
     const onChangeApiVersion = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => onUpdateProvider(name, 'api_version', e.target.value),
+      [name, onUpdateProvider]
+    );
+    const onChangeApiMode = useCallback(
+      (e: ChangeEvent<HTMLSelectElement>) => {
+        onUpdateProvider(name, 'use_responses', e.target.value === 'responses' ? undefined : false);
+      },
       [name, onUpdateProvider]
     );
     const onClickAddModel = useCallback(() => onAddModel(name), [name, onAddModel]);
@@ -813,6 +822,17 @@ const ProviderRow = memo(
                   mono
                   className={styles.flex1}
                 />
+              </FormField>
+            )}
+            {showApiMode && (
+              <FormField label="OpenAI API mode">
+                <Select
+                  value={provider.use_responses === false ? 'chat_completions' : 'responses'}
+                  onChange={onChangeApiMode}
+                >
+                  <option value="responses">Responses API (recommended)</option>
+                  <option value="chat_completions">Chat Completions API</option>
+                </Select>
               </FormField>
             )}
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3551,6 +3551,8 @@ export type ProviderEntry = {
   api_key?: string;
   base_url?: string;
   api_version?: string;
+  use_responses?: boolean;
+  use_responses_websocket?: boolean;
   models: Record<string, ModelEntry>;
 };
 


### PR DESCRIPTION
## Summary
- Add an Advanced settings selector for OpenAI API mode on OpenAI, OpenAI-compatible, and Azure providers.
- Persist Chat Completions mode as `use_responses: false` while keeping Responses API as the default.
- Extend provider config typing for API mode fields without exposing a WebSocket toggle.

## Why
Users need a UI path for providers that support Chat Completions but not the Responses API. This complements the Omni Code runtime support while keeping the advanced settings surface focused.

## Validation
- `npm run lint:tsc`
- `npx prettier --check src/renderer/features/SettingsModal/SettingsModalAiTab.tsx src/shared/types.ts`
