### PR TITLE
Fix new session tab reuse for Routine columns

### DIFF
--- a/src/renderer/features/Code/CodeDeck.tsx
+++ b/src/renderer/features/Code/CodeDeck.tsx
@@ -2386,16 +2386,6 @@ export const CodeDeck = memo(() => {
     });
   }, []);
 
-  const addingFirstTab = useRef(false);
-  useEffect(() => {
-    if (tabs.length === 0 && !addingFirstTab.current) {
-      addingFirstTab.current = true;
-      codeApi.addTab().finally(() => {
-        addingFirstTab.current = false;
-      });
-    }
-  }, [tabs.length]);
-
   useEffect(() => {
     const firstTab = tabs[0];
     if (!activeTabId && firstTab) {

--- a/src/renderer/features/Code/state.test.ts
+++ b/src/renderer/features/Code/state.test.ts
@@ -208,6 +208,40 @@ describe('reserved chat record guards', () => {
     expect(store.codeTabs.some((t) => t.id === 'chat')).toBe(true);
   });
 
+  it('addTab creates a fresh tab instead of reusing an existing blank session', async () => {
+    resetStore({ codeTabs: [tab({ id: 'blank-tab', projectId: null, sessionId: 'blank-session' })] });
+    const { codeApi } = await import('./state');
+
+    const created = await codeApi.addTab();
+
+    expect(created.id).not.toBe('blank-tab');
+    expect(store.codeTabs).toHaveLength(2);
+    expect(store.activeCodeTabId).toBe(created.id);
+  });
+
+  it('addTab creates a fresh tab instead of reusing a routine session', async () => {
+    resetStore({
+      codeTabs: [
+        tab({
+          id: 'routine-tab',
+          projectId: null,
+          sessionId: 'routine-session',
+          routineId: 'routine-1',
+          routineName: 'Morning review',
+          routineSchedule: 'Manual',
+        }),
+      ],
+    });
+    const { codeApi } = await import('./state');
+
+    const created = await codeApi.addTab();
+
+    expect(created.id).not.toBe('routine-tab');
+    expect(store.codeTabs).toHaveLength(2);
+    expect(store.activeCodeTabId).toBe(created.id);
+    expect(store.codeTabs.find((item) => item.id === 'routine-tab')).toMatchObject({ routineId: 'routine-1' });
+  });
+
   it('removeTab is a no-op for the chat record', async () => {
     resetStore({ codeTabs: [chatTab(), tab({ id: 'tab-1' })] });
     const { codeApi } = await import('./state');

--- a/src/renderer/features/Code/state.ts
+++ b/src/renderer/features/Code/state.ts
@@ -69,17 +69,7 @@ export const codeApi = {
   },
 
   addTab: async (): Promise<CodeTab> => {
-    // Reuse an existing unconfigured tab instead of stacking up orphan
-    // "New Session" columns: a tab created here but abandoned before a
-    // project was picked is indistinguishable from a fresh one.
     const existingTabs = persistedStoreApi.getKey('codeTabs') ?? [];
-    // The reserved chat record is also projectless — never hand it out as a
-    // blank "New Session" tab.
-    const blank = existingTabs.find((t) => !isChatTab(t) && !t.projectId && !t.customAppId && !t.ticketId);
-    if (blank) {
-      await persistedStoreApi.setKey('activeCodeTabId', blank.id);
-      return blank;
-    }
     const tab: CodeTab = {
       id: nanoid(),
       projectId: null,


### PR DESCRIPTION
## Summary
- Make every explicit `New session` action create a fresh code tab.
- Remove automatic blank-tab recreation after the user closes all code tabs.
- Add regressions covering existing blank tabs and projectless Routine tabs.

## Rationale
Routine session columns can be projectless, so the previous blank-tab reuse path could focus/reuse a Routine column when the user clicked `+ New`. More broadly, explicit new-session actions should not silently reuse older tabs; users can intentionally open multiple tabs and close them when done.

## Tests
- `npx vitest run src/renderer/features/Code/state.test.ts`
- `npm run lint:tsc`
