### PR TITLE
Use prefixed official skill names in pipeline defaults

### DIFF
--- a/packages/projects-db/src/defaults.ts
+++ b/packages/projects-db/src/defaults.ts
@@ -54,8 +54,8 @@ export const DEFAULT_COLUMNS: ColumnDef[] = [
         'No source edits were made unless explicitly required to investigate a failing reproduction.',
       ],
       agentInstructions:
-        'Activate software-planning for feature, refactor, or spec work. Activate debug if this is a failure investigation and the root cause is not localized. Do not move to Implementation until the plan is decision-complete.',
-      recommendedSkills: ['software-planning', 'debug'],
+        'Activate software-planning for feature, refactor, or spec work. Activate software-debug if this is a failure investigation and the root cause is not localized. Do not move to Implementation until the plan is decision-complete.',
+      recommendedSkills: ['software-planning', 'software-debug'],
     },
   },
   {
@@ -77,7 +77,7 @@ export const DEFAULT_COLUMNS: ColumnDef[] = [
       ],
       agentInstructions:
         'Follow AGENTS.md in every source touched. Use worker agents only for independent subtasks with explicit file ownership and acceptance criteria. For bug fixes, prefer red-before-green testing when practical.',
-      recommendedSkills: ['debug', 'software-planning'],
+      recommendedSkills: ['software-debug', 'software-planning'],
     },
   },
   {
@@ -113,8 +113,8 @@ export const DEFAULT_COLUMNS: ColumnDef[] = [
         'Merge readiness is clear, or blockers are documented.',
       ],
       agentInstructions:
-        'Use push/PR-related skills only when explicitly asked or when the project workflow expects PR preparation. Do not merge unless the user or project policy explicitly allows it.',
-      recommendedSkills: ['push', 'pull', 'land'],
+        'Use git-push/PR-related skills only when explicitly asked or when the project workflow expects PR preparation. Do not merge unless the user or project policy explicitly allows it.',
+      recommendedSkills: ['git-push', 'git-pull', 'git-land'],
     },
   },
   {

--- a/src/lib/supervisor-prompt.test.ts
+++ b/src/lib/supervisor-prompt.test.ts
@@ -58,7 +58,7 @@ const WORKFLOW_PIPELINE = makePipeline([
       entryCriteria: ['Spec is approved by a human reviewer', 'Dependencies are unblocked'],
       definitionOfDone: ['Feature flag persists across restarts', 'Targeted Vitest coverage passes'],
       agentInstructions: 'Keep implementation minimal and preserve public APIs.',
-      recommendedSkills: ['bugfix', 'typescript'],
+      recommendedSkills: ['software-bugfix', 'typescript'],
       allowedTransitions: ['col-review'],
       autoDispatch: true,
     },
@@ -205,7 +205,7 @@ describe('buildAutopilotGoalText', () => {
     expect(goalText).toContain('Spec is approved by a human reviewer');
     expect(goalText).toContain('Feature flag persists across restarts');
     expect(goalText).toContain('Keep implementation minimal and preserve public APIs.');
-    expect(goalText).toContain('bugfix');
+    expect(goalText).toContain('software-bugfix');
     expect(goalText).toContain('col-review');
     expect(goalText).toMatch(/auto.?dispatch/i);
     expect(goalText).not.toContain('Reviewer has inspected the full PR diff');


### PR DESCRIPTION
## Summary
- Update default pipeline recommended skills to the new `software-*` and `git-*` official skill names.
- Update supervisor prompt tests to expect `software-bugfix`.

## Validation
- `npm test -- --run packages/projects-db/src/repo.test.ts src/lib/resolve-pipeline-defs.test.ts src/lib/supervisor-prompt.test.ts`
