### PR TITLE
fix(autopilot): forward goal approval overrides

### DIFF
--- a/src/renderer/omniagents-ui/App.tsx
+++ b/src/renderer/omniagents-ui/App.tsx
@@ -1328,6 +1328,9 @@ export function App({
         if (typeof tickInterval === 'number') {
           goalArgs.tick_interval = tickInterval;
         }
+        if (runOverrides?.safeToolOverrides) {
+          goalArgs.safe_tool_overrides = runOverrides.safeToolOverrides;
+        }
         await client.serverCall('goal', goalArgs, sid);
       },
       goalStop: async () => {


### PR DESCRIPTION
## Summary
- Forward Autopilot `safeToolOverrides` as `safe_tool_overrides` in the `/goal` server-call args.
- Leave existing `session.ensure` variable persistence unchanged for workspace and additional instruction metadata.

## Rationale
The launcher already builds the catch-all Autopilot bypass policy, but `/goal` must receive it as a top-level server-function argument so the server-side goal path can forward it to the run-starting API.

## Tests
- `npx vitest run src/lib/supervisor-orchestrator.test.ts src/renderer/services/supervisor-bridge.test.ts`
